### PR TITLE
Generate summary-driven RV plots and include literature RVs

### DIFF
--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -45,6 +45,8 @@ class RVPoint:
     rv_err: float
     rms: float
     file: str
+    telescope: str = "APF"
+    is_literature: bool = False
 
 
 def _parse_gaia_metadata(path: Path) -> Optional[Dict[str, Any]]:
@@ -388,6 +390,17 @@ def prefetch_gaia_nss_bulk(source_ids: List[str], cache_path: Path, chunk_size: 
     print(f"INFO:root:Gaia cache warmup done: {len(uniq)} ids scanned, {fetched} fetched, {time.time()-t0:.2f}s")
 
 
+def _pipeline_telescope_from_filename(name: str) -> str:
+    s = name.lower()
+    if "kpf" in s:
+        return "KPF"
+    if "ghost" in s:
+        return "GHOST"
+    if "maroon" in s:
+        return "MAROON-X"
+    return "APF"
+
+
 def parse_summary(path: Path) -> List[RVPoint]:
     text = path.read_text(encoding="utf-8", errors="replace")
     if "[PIPELINE RESULTS]" in text:
@@ -415,10 +428,42 @@ def parse_summary(path: Path) -> List[RVPoint]:
                     rv=float(parts[2]),
                     rv_err=max(float(parts[3]), 1e-4),
                     rms=max(abs(float(parts[4])), 1e-4),
+                    telescope=_pipeline_telescope_from_filename(parts[0]),
+                    is_literature=False,
                 )
             )
         except ValueError:
             continue
+    # Include literature RVs from [EXTERNAL RV DATA] when present.
+    try:
+        from darkhunter_rv.gaia_utils import parse_external_rvs_from_star_summary
+
+        ext_rows = parse_external_rvs_from_star_summary(path)
+    except Exception:
+        ext_rows = []
+    for r in ext_rows:
+        try:
+            mjd = float(r.get("mjd", float("nan")))
+            rv = float(r.get("rv", float("nan")))
+            rv_err = float(r.get("rv_err", float("nan")))
+            tel = str(r.get("telescope", "LITERATURE") or "LITERATURE")
+        except Exception:
+            continue
+        if not np.isfinite(mjd) or not np.isfinite(rv):
+            continue
+        if not np.isfinite(rv_err) or rv_err <= 0:
+            rv_err = 1.0
+        points.append(
+            RVPoint(
+                file=f"external:{tel}",
+                mjd=mjd,
+                rv=rv,
+                rv_err=max(rv_err, 1e-4),
+                rms=max(rv_err, 1e-4),
+                telescope=tel,
+                is_literature=True,
+            )
+        )
     points.sort(key=lambda p: p.mjd)
     return points
 
@@ -860,7 +905,49 @@ def build_plot(
         except Exception:
             pass
     ax.axvline(now_mjd, color="0.35", ls="--", lw=1.2, alpha=0.9)
-    ax.errorbar(t, y, yerr=yerr_rms, fmt="o", ms=5, lw=1, capsize=2)
+    # Plot symbols/colors:
+    # - Our data (black): APF=o, KPF=s, GHOST=p, MAROON-X=x
+    # - Literature (dark grey): diamond
+    plotted_any = False
+    tel_marker = {"APF": "o", "KPF": "s", "GHOST": "p", "MAROON-X": "x"}
+    for tel, marker in tel_marker.items():
+        idx = [i for i, p in enumerate(points) if (not p.is_literature and str(p.telescope).upper() == tel)]
+        if not idx:
+            continue
+        ax.errorbar(
+            t[idx],
+            y[idx],
+            yerr=yerr_rms[idx],
+            fmt=marker,
+            ms=5,
+            lw=1,
+            capsize=2,
+            color="black",
+            ecolor="black",
+            mec="black",
+            mfc=("black" if marker != "x" else "none"),
+            label=tel,
+        )
+        plotted_any = True
+    idx_lit = [i for i, p in enumerate(points) if p.is_literature]
+    if idx_lit:
+        ax.errorbar(
+            t[idx_lit],
+            y[idx_lit],
+            yerr=yerr_rms[idx_lit],
+            fmt="D",
+            ms=4.8,
+            lw=1,
+            capsize=2,
+            color="0.35",
+            ecolor="0.35",
+            mec="0.35",
+            mfc="0.35",
+            label="Literature",
+        )
+        plotted_any = True
+    if not plotted_any:
+        ax.errorbar(t, y, yerr=yerr_rms, fmt="o", ms=5, lw=1, capsize=2, color="black")
     ax.plot(t_dense, y_dense, "-", lw=2)
     ax.set_xlabel("MJD")
     ax.set_ylabel("RV (km/s)")
@@ -872,6 +959,8 @@ def build_plot(
     ax.yaxis.set_minor_locator(AutoMinorLocator())
     ax.tick_params(axis="both", which="major", direction="in", length=7, width=1.1, top=True, right=True)
     ax.tick_params(axis="both", which="minor", direction="in", length=3.5, width=0.9, top=True, right=True)
+    if plotted_any:
+        ax.legend(loc="best", fontsize=8.5)
 
     p_day = int(round(report["P_days"]))
     next_min_mjd = float(report["next_rv_min_mjd"])

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Website integration batch:
 # 1) Keplerian fits
-# 2) Regenerate APF plots
+# 2) Generate APF RV plots from summaries (no pipeline rerun)
 # 3) Stage files into website contract:
 #    stars/Gaia_DR3_<id>/Gaia/{<id>_summary.txt,Plots/*,RV_Fit/*}
 # 4) Update tables/data.csv M2 column from fit JSON
@@ -17,7 +17,6 @@ set -euo pipefail
 
 REPO="${REPO:-/data2/darkhunter/dark-hunter_rv}"
 OUT="${OUT:-$REPO/output}"
-SPEC_ROOT="${SPEC_ROOT:-/data2/gaia_stars/apf_reductions}"
 WEB_ROOT="${WEB_ROOT:-/data2/gaia_stars/dark-hunter_rv-kirsty}"
 PY="${PY:-/home/marley/anaconda2/envs/gaia-env/bin/python}"
 REPORTS_DIR="${REPORTS_DIR:-$REPO/rv_fit_reports}"
@@ -67,7 +66,6 @@ echo "=== $(date -Is) batch start (pid $$) ==="
 echo "repo=$REPO out=$OUT web_root=$WEB_ROOT reports=$REPORTS_DIR dry_run=$DRY_RUN star_id=${STAR_ID:-ALL}"
 
 require_path "$OUT" dir
-require_path "$SPEC_ROOT" dir
 require_path "$WEB_ROOT" dir
 require_path "$WEBSITE_TABLES_DIR" dir
 require_path "$DATA_CSV" file
@@ -125,36 +123,17 @@ if [[ -n "$STAR_ID" ]]; then
 fi
 run_cmd "$PY" "${fit_args[@]}"
 
-echo "=== Pipeline plots (per-star output subdir) ==="
-n_specs=0
-for summ in "${SUMMARY_FILES[@]}"; do
-  gid=$(basename "$summ" _summary.txt | sed 's/^Gaia_DR3_//')
-  plot_dir="$OUT/Gaia_DR3_${gid}"
-  run_cmd mkdir -p "$plot_dir"
-  export DARKHUNTER_PLOT_DIR="$plot_dir"
-  while IFS= read -r bn; do
-    [[ -n "$bn" ]] || continue
-    spec=$(find "$SPEC_ROOT" -type f -name "$bn" -print -quit 2>/dev/null || true)
-    if [[ -z "$spec" ]]; then
-      echo "[WARN] spectrum not found: $bn (Gaia_DR3_${gid})"
-      if [[ "$DRY_RUN" != "1" ]]; then
-        echo "${gid},missing_spectrum,${bn}" >> "$MISSING_ASSETS_CSV"
-      fi
-      continue
-    fi
-    n_specs=$((n_specs + 1))
-    run_cmd "$PY" -m darkhunter_rv.pipeline "$spec" \
-      --instrument APF \
-      --update \
-      --plots \
-      --plots-focus \
-      --plots-only
-  done < <(
-    awk '/^\[PIPELINE RESULTS\]/{show=1; next}
-         show && $0 !~ /^#/ && NF >= 5 { print $1 }' "$summ"
-  )
-done
-echo "plot_pass: summaries=${#SUMMARY_FILES[@]} pipeline_invocations=$n_specs"
+echo "=== Summary-based RV plots (no pipeline rerun) ==="
+plot_args=(
+  scripts/plot_rv_from_summaries.py
+  --summary-dir "$OUT"
+  --plots-root "$OUT"
+  --reports-dir "$REPORTS_DIR"
+)
+if [[ -n "$STAR_ID" ]]; then
+  plot_args+=(--star-id "$STAR_ID")
+fi
+run_cmd "$PY" "${plot_args[@]}"
 
 echo "=== Stage website files into stars/Gaia_DR3_<id>/Gaia/... ==="
 staged_stars=0

--- a/scripts/plot_rv_from_summaries.py
+++ b/scripts/plot_rv_from_summaries.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Generate APF RV-vs-MJD plots directly from summary files (no pipeline rerun)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def parse_gaia_id(path: Path) -> str | None:
+    m = re.search(r"Gaia_DR3_(\d{8,19})", f"{path.parent.name}/{path.stem}")
+    if m:
+        return m.group(1)
+    m2 = re.match(r"(\d{8,19})_summary$", path.stem)
+    return m2.group(1) if m2 else None
+
+
+def parse_points(summary_path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    text = summary_path.read_text(encoding="utf-8", errors="replace")
+    lines = text.split("[PIPELINE RESULTS]", 1)[-1].splitlines() if "[PIPELINE RESULTS]" in text else text.splitlines()
+    t, y, e = [], [], []
+    for raw in lines:
+        s = raw.strip()
+        if not s or s.startswith("#") or (s.startswith("[") and s.endswith("]")):
+            continue
+        parts = s.split()
+        if len(parts) < 5:
+            continue
+        if len(parts) >= 6 and parts[-1] in ("True", "False"):
+            parts = parts[:-1]
+        if len(parts) < 5:
+            continue
+        try:
+            mjd = float(parts[1])
+            rv = float(parts[2])
+            err = float(parts[3])
+            rms = float(parts[4])
+        except ValueError:
+            continue
+        if not np.isfinite(mjd) or not np.isfinite(rv):
+            continue
+        t.append(mjd)
+        y.append(rv)
+        if np.isfinite(rms) and rms > 0:
+            e.append(rms)
+        elif np.isfinite(err) and err > 0:
+            e.append(err)
+        else:
+            e.append(0.25)
+    return np.array(t, dtype=float), np.array(y, dtype=float), np.array(e, dtype=float)
+
+
+def build_plot(summary_path: Path, out_png: Path, fit_json: Path | None = None) -> bool:
+    t, y, e = parse_points(summary_path)
+    if t.size < 2:
+        return False
+    order = np.argsort(t)
+    t, y, e = t[order], y[order], e[order]
+
+    fig, ax = plt.subplots(figsize=(10, 4.8))
+    ax.errorbar(t, y, yerr=e, fmt="o", ms=4.5, capsize=2, lw=1, label="APF epochs")
+    ax.set_xlabel("MJD")
+    ax.set_ylabel("RV (km/s)")
+    gaia_id = parse_gaia_id(summary_path) or summary_path.stem.replace("_summary", "")
+    ax.set_title(f"Gaia DR3 {gaia_id} RV vs MJD")
+    ax.grid(alpha=0.25)
+
+    # Optional model overlay from keplerian fit JSON.
+    if fit_json is not None and fit_json.is_file():
+        try:
+            rep = json.loads(fit_json.read_text(encoding="utf-8"))
+            p = rep.get("params_raw")
+            t_ref = float(rep.get("t_ref_mjd"))
+            if isinstance(p, list) and len(p) == 6:
+                arr = np.array(p, dtype=float)
+                td = np.linspace(float(np.min(t) - 0.02 * (np.ptp(t) + 1)), float(np.max(t) + 0.02 * (np.ptp(t) + 1)), 1200)
+                logp, k, h, kk, m0, gamma = arr
+                period = np.exp(logp)
+                ecc = np.clip(np.hypot(h, kk), 1e-8, 0.95)
+                omega = float(np.arctan2(kk, h))
+                n = 2.0 * np.pi / period
+                mean_anom = n * (td - t_ref) + m0
+                E = np.array(mean_anom, dtype=float)
+                for _ in range(30):
+                    f = E - ecc * np.sin(E) - mean_anom
+                    fp = 1.0 - ecc * np.cos(E)
+                    E -= f / np.clip(fp, 1e-10, None)
+                cosf = (np.cos(E) - ecc) / (1.0 - ecc * np.cos(E))
+                sinf = (np.sqrt(1.0 - ecc * ecc) * np.sin(E)) / (1.0 - ecc * np.cos(E))
+                true_anom = np.arctan2(sinf, cosf)
+                model = gamma + k * (np.cos(true_anom + omega) + ecc * np.cos(omega))
+                ax.plot(td, model, "-", lw=1.6, alpha=0.9, label="Keplerian fit")
+                ax.legend(loc="best", fontsize=9)
+        except Exception:
+            pass
+
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=160)
+    plt.close(fig)
+    return True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Build RV plots from Gaia summary files only.")
+    ap.add_argument("--summary-dir", required=True, help="Directory containing Gaia_DR3_*_summary.txt")
+    ap.add_argument("--plots-root", required=True, help="Output root for per-star plot subdirs")
+    ap.add_argument("--reports-dir", default=None, help="Optional dir with <id>_keplerian_fit.json to overlay model")
+    ap.add_argument("--star-id", default=None, help="Optional single Gaia source id")
+    args = ap.parse_args()
+
+    summary_dir = Path(args.summary_dir)
+    plots_root = Path(args.plots_root)
+    reports_dir = Path(args.reports_dir) if args.reports_dir else None
+
+    pattern = f"Gaia_DR3_{args.star_id}_summary.txt" if args.star_id else "Gaia_DR3_*_summary.txt"
+    files = sorted(summary_dir.glob(pattern))
+    if not files:
+        print("No summary files found.")
+        return 2
+
+    built = 0
+    skipped = 0
+    for summ in files:
+        sid = parse_gaia_id(summ)
+        if not sid:
+            skipped += 1
+            continue
+        out_png = plots_root / f"Gaia_DR3_{sid}" / f"Gaia_DR3_{sid}_rv_plot.png"
+        fit_json = (reports_dir / f"{sid}_keplerian_fit.json") if reports_dir else None
+        ok = build_plot(summ, out_png, fit_json=fit_json)
+        if ok:
+            built += 1
+        else:
+            skipped += 1
+    print(f"Built {built} summary-based RV plots (skipped {skipped}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fit_apf_rv_keplerian.py
+++ b/tests/test_fit_apf_rv_keplerian.py
@@ -163,6 +163,25 @@ def test_fit_keplerian_clips_initial_guess() -> None:
     assert np.all(np.isfinite(params))
 
 
+def test_parse_summary_includes_external_rvs(tmp_path: Path) -> None:
+    summ = tmp_path / "Gaia_DR3_123_summary.txt"
+    summ.write_text(
+        "[GAIA METADATA]\nSource_ID: 123\nRA: 1.0\nDec: 2.0\n"
+        "\n[EXTERNAL RV DATA]\n"
+        "LAMOST_LRS 59000.0 -20.0 1.2 z_meas\n"
+        "\n[PIPELINE RESULTS]\n"
+        "Gaia_DR3_123_epoch_1.txt 60000.0 -10.0 0.2 0.3 False\n"
+        "Gaia_DR3_123_epoch_2_kpf.txt 60001.0 -9.0 0.2 0.3 False\n"
+    )
+    pts = fitmod.parse_summary(summ)
+    assert len(pts) == 3
+    lit = [p for p in pts if p.is_literature]
+    ours = [p for p in pts if not p.is_literature]
+    assert len(lit) == 1
+    assert lit[0].telescope == "LAMOST_LRS"
+    assert sorted(p.telescope for p in ours) == ["APF", "KPF"]
+
+
 def test_load_nss_priors_includes_inclination(tmp_path: Path) -> None:
     summ = tmp_path / "Gaia_DR3_1_summary.txt"
     summ.write_text(


### PR DESCRIPTION
## Summary
- add `scripts/plot_rv_from_summaries.py` to generate RV-vs-MJD plots directly from summary files (no pipeline rerun)
- update `fit_apf_rv_keplerian.py` to include `[EXTERNAL RV DATA]` literature RV points in fits and plots
- apply requested marker/color styling in RV fit plots:
  - APF black circles
  - KPF black squares
  - GHOST black pentagons
  - MAROON-X black X markers
  - literature dark-grey diamonds
- switch `scripts/batch_fits_plots_sync.sh` plot phase to use summary-based plotting

## Test plan
- [x] `python3 scripts/plot_rv_from_summaries.py --help`
- [x] `bash -n scripts/batch_fits_plots_sync.sh`
- [x] `PYTHONPATH=. python3 -m pytest tests/test_fit_apf_rv_keplerian.py -q`

Made with [Cursor](https://cursor.com)