### PR TITLE
Deploy RV explorer to /var/www/html/darkhunter/rv

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repo contains a **robust, echelle-aware RV measurement pipeline** targeting
 | [docs/rv_methods_evaluation.md](docs/rv_methods_evaluation.md) | Method validity, adopted-RV cascade, validation reports |
 | [docs/contributing.md](docs/contributing.md) | Doc map, pre-PR checklist, **git commands to open a PR** |
 | [docs/validation_playbook.md](docs/validation_playbook.md) | Validation campaigns |
+| [docs/website.md](docs/website.md) | Public RV explorer deploy (`/var/www/html/darkhunter/rv`) |
 
 ### Quick start
 

--- a/docs/website.md
+++ b/docs/website.md
@@ -1,0 +1,81 @@
+# Dark Hunter RV website (`/var/www/html/darkhunter/rv`)
+
+The public explorer lives in a **subdirectory** of the Apache base path so `/var/www/html/darkhunter/` stays free of `index.html` and mixed deploy scripts.
+
+## Directory layout
+
+```
+/var/www/html/darkhunter/          # base (no site index required)
+  README.html                      # optional pointer to rv/
+  rv/                              # WEB_ROOT — document root for the app
+    index.html
+    script.js
+    style.css
+    tables/
+      data.csv
+      keck_targets.csv
+      simbad_gaia_ids.csv   # optional
+    stars/
+      Gaia_DR3_<id>/
+        Gaia/
+          <id>_summary.txt
+          Plots/*.png
+          RV_Fit/<id>_keplerian_fit.png
+    output/                 # mirror of pipeline output (rsync)
+    rv_fit_reports/         # fit JSON/PNG archive (rsync)
+```
+
+Canonical URL shape (after Apache maps `/darkhunter/rv/`):
+
+`https://ziggy.ucolick.org/darkhunter/rv/?rows=all&page=1`
+
+## One-time setup on ziggy
+
+```bash
+cd /data2/darkhunter/dark-hunter_rv
+git pull
+
+# 1) Static HTML/JS/CSS into /var/www/html/darkhunter/rv
+bash scripts/setup_website.sh
+
+# 2) Copy catalog tables from legacy site (once)
+LEGACY_WEB_ROOT=/var/www/html/ktaggart/rv_website_v1 \
+  bash scripts/bootstrap_website_tables.sh
+
+# 3) Optional: tiny pointer at base (not a full site)
+echo '<!DOCTYPE html><html><body><p><a href="rv/">Dark Hunter RV explorer</a></p></body></html>' \
+  | sudo tee /var/www/html/darkhunter/README.html
+```
+
+Ensure Apache serves `/var/www/html/darkhunter/rv/` (existing `Alias` or symlink under `html/`).
+
+## Populate / refresh star assets
+
+Plots + staging write directly under `WEB_ROOT` (no separate Kirsty mirror).
+
+```bash
+cd /data2/darkhunter/dark-hunter_rv
+
+# Full refresh (fits + plots + table M2 columns + rsync archives)
+WEB_ROOT=/var/www/html/darkhunter/rv MIN_POINTS=5 bash scripts/populate_website.sh
+
+# Skip refitting; reuse existing rv_fit_reports/*.json
+WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 FIT_FORCE=0 MIN_POINTS=5 \
+  bash scripts/populate_website.sh
+```
+
+Detached:
+
+```bash
+screen -dmS darkhunter_web bash -lc '
+cd /data2/darkhunter/dark-hunter_rv
+WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 FIT_FORCE=0 MIN_POINTS=5 \
+  bash scripts/populate_website.sh >> batch_fits_plots_sync.log 2>&1
+'
+```
+
+## Repo source of truth
+
+Static assets: `website/rv/` in this repository.
+
+Batch integration: `scripts/batch_fits_plots_sync.sh` (default `WEB_ROOT=/var/www/html/darkhunter/rv`).

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -10,18 +10,22 @@
 #
 # Usage:
 #   bash scripts/batch_fits_plots_sync.sh
+#   WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 MIN_POINTS=5 bash scripts/batch_fits_plots_sync.sh
 #   DRY_RUN=1 bash scripts/batch_fits_plots_sync.sh
 #   STAR_ID=1702370142434513152 bash scripts/batch_fits_plots_sync.sh   # canary
+#
+# One-time site setup (static HTML/JS/CSS): bash scripts/setup_website.sh
 
 set -euo pipefail
 
 REPO="${REPO:-/data2/darkhunter/dark-hunter_rv}"
 OUT="${OUT:-$REPO/output}"
-WEB_ROOT="${WEB_ROOT:-/data2/gaia_stars/dark-hunter_rv-kirsty}"
+WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
 PY="${PY:-/home/marley/anaconda2/envs/gaia-env/bin/python}"
 REPORTS_DIR="${REPORTS_DIR:-$REPO/rv_fit_reports}"
 LOG="${LOG:-$REPO/batch_fits_plots_sync.log}"
 MIN_POINTS="${MIN_POINTS:-7}"
+RUN_FITS="${RUN_FITS:-1}"
 FIT_FORCE="${FIT_FORCE:-1}"
 QUERY_GAIA_ONLINE="${QUERY_GAIA_ONLINE:-0}"
 DRY_RUN="${DRY_RUN:-0}"
@@ -97,31 +101,35 @@ for summ in "${SUMMARY_FILES[@]}"; do
 done
 echo "summaries=${#SUMMARY_FILES[@]} with_epochs>=${MIN_POINTS}: $n_ge_min"
 
-echo "=== Keplerian fits ==="
-fit_args=(
-  fit_apf_rv_keplerian.py
-  --all
-  --output-dir "$OUT"
-  --use-gaia-nss
-  --min-points "$MIN_POINTS"
-  --reports-dir "$REPORTS_DIR"
-)
-if [[ "$FIT_FORCE" == "1" ]]; then
-  fit_args+=(--force)
-fi
-if [[ "$QUERY_GAIA_ONLINE" == "1" ]]; then
-  fit_args+=(--query-gaia-online)
-fi
-if [[ -n "$STAR_ID" ]]; then
-  fit_args=(fit_apf_rv_keplerian.py --summary "$OUT/Gaia_DR3_${STAR_ID}_summary.txt" --output-dir "$OUT" --use-gaia-nss --min-points "$MIN_POINTS" --reports-dir "$REPORTS_DIR")
+if [[ "$RUN_FITS" == "1" ]]; then
+  echo "=== Keplerian fits ==="
+  fit_args=(
+    fit_apf_rv_keplerian.py
+    --all
+    --output-dir "$OUT"
+    --use-gaia-nss
+    --min-points "$MIN_POINTS"
+    --reports-dir "$REPORTS_DIR"
+  )
   if [[ "$FIT_FORCE" == "1" ]]; then
     fit_args+=(--force)
   fi
   if [[ "$QUERY_GAIA_ONLINE" == "1" ]]; then
     fit_args+=(--query-gaia-online)
   fi
+  if [[ -n "$STAR_ID" ]]; then
+    fit_args=(fit_apf_rv_keplerian.py --summary "$OUT/Gaia_DR3_${STAR_ID}_summary.txt" --output-dir "$OUT" --use-gaia-nss --min-points "$MIN_POINTS" --reports-dir "$REPORTS_DIR")
+    if [[ "$FIT_FORCE" == "1" ]]; then
+      fit_args+=(--force)
+    fi
+    if [[ "$QUERY_GAIA_ONLINE" == "1" ]]; then
+      fit_args+=(--query-gaia-online)
+    fi
+  fi
+  run_cmd "$PY" "${fit_args[@]}"
+else
+  echo "=== Keplerian fits (skipped: RUN_FITS=0) ==="
 fi
-run_cmd "$PY" "${fit_args[@]}"
 
 echo "=== Summary-based RV plots (no pipeline rerun) ==="
 plot_args=(

--- a/scripts/bootstrap_website_tables.sh
+++ b/scripts/bootstrap_website_tables.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copy tables/*.csv from the legacy website into the new site tree.
+#
+# Usage:
+#   bash scripts/bootstrap_website_tables.sh
+#   LEGACY_WEB_ROOT=/var/www/html/ktaggart/rv_website_v1 bash scripts/bootstrap_website_tables.sh
+
+set -euo pipefail
+
+WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
+LEGACY_WEB_ROOT="${LEGACY_WEB_ROOT:-/var/www/html/ktaggart/rv_website_v1}"
+TABLES_DIR="$WEB_ROOT/tables"
+LEGACY_TABLES="$LEGACY_WEB_ROOT/tables"
+
+run_cmd() {
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    echo "[DRY_RUN] $*"
+  else
+    "$@"
+  fi
+}
+
+run_cmd mkdir -p "$TABLES_DIR"
+
+if [[ ! -d "$LEGACY_TABLES" ]]; then
+  echo "[ERROR] legacy tables dir not found: $LEGACY_TABLES" >&2
+  echo "Set LEGACY_WEB_ROOT to the old rv_website_v1 directory." >&2
+  exit 2
+fi
+
+echo "copying $LEGACY_TABLES -> $TABLES_DIR"
+run_cmd rsync -a "$LEGACY_TABLES/" "$TABLES_DIR/"
+
+if [[ ! -f "$TABLES_DIR/data.csv" ]]; then
+  echo "[ERROR] data.csv still missing after bootstrap" >&2
+  exit 2
+fi
+
+echo "OK: $(wc -l < "$TABLES_DIR/data.csv") lines in data.csv"
+
+# Add new mass columns to header if absent (batch table updater expects them).
+REPO="${REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
+PY="${PY:-python3}"
+if [[ -x /home/marley/anaconda2/envs/gaia-env/bin/python ]]; then
+  PY=/home/marley/anaconda2/envs/gaia-env/bin/python
+fi
+
+export DATA_CSV="$TABLES_DIR/data.csv"
+run_cmd "$PY" - <<'PY'
+import csv
+import os
+from pathlib import Path
+
+path = Path(os.environ["DATA_CSV"])
+rows = list(csv.reader(path.open(newline="", encoding="utf-8")))
+if not rows:
+    raise SystemExit("empty data.csv")
+hdr = rows[0]
+for col in ("M2sin i (Msun)", "(M2sin i)/(sin i) (Msun)"):
+    if col not in hdr:
+        hdr.append(col)
+        for r in rows[1:]:
+            while len(r) < len(hdr):
+                r.append("")
+        print(f"added column: {col}")
+with path.open("w", newline="", encoding="utf-8") as fh:
+    csv.writer(fh).writerows(rows)
+print("data.csv columns:", len(hdr))
+PY

--- a/scripts/populate_website.sh
+++ b/scripts/populate_website.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Populate website star tree + update tables/data.csv from pipeline output.
+#
+# Usage:
+#   bash scripts/populate_website.sh
+#   RUN_FITS=0 MIN_POINTS=5 bash scripts/populate_website.sh
+#   STAR_ID=1702370142434513152 bash scripts/populate_website.sh
+
+set -euo pipefail
+
+REPO="${REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
+export WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
+
+if [[ ! -f "$WEB_ROOT/tables/data.csv" ]]; then
+  echo "[ERROR] $WEB_ROOT/tables/data.csv missing. Run scripts/bootstrap_website_tables.sh first." >&2
+  exit 2
+fi
+
+cd "$REPO"
+exec bash scripts/batch_fits_plots_sync.sh

--- a/scripts/setup_website.sh
+++ b/scripts/setup_website.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Install static website files into /var/www/html/darkhunter/rv (no star data).
+#
+# Usage:
+#   bash scripts/setup_website.sh
+#   WEB_BASE=/var/www/html/darkhunter WEB_ROOT=/var/www/html/darkhunter/rv bash scripts/setup_website.sh
+#
+# After setup, seed tables/ (once):
+#   bash scripts/bootstrap_website_tables.sh
+#
+# Populate stars/ + refresh M2 columns:
+#   bash scripts/populate_website.sh
+
+set -euo pipefail
+
+REPO="${REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
+WEB_BASE="${WEB_BASE:-/var/www/html/darkhunter}"
+WEB_ROOT="${WEB_ROOT:-$WEB_BASE/rv}"
+SRC="$REPO/website/rv"
+
+if [[ ! -d "$SRC" ]]; then
+  echo "[ERROR] missing template dir: $SRC" >&2
+  exit 2
+fi
+
+echo "web_base=$WEB_BASE"
+echo "web_root=$WEB_ROOT (site document root)"
+echo "source=$SRC"
+
+run_cmd() {
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    echo "[DRY_RUN] $*"
+  else
+    "$@"
+  fi
+}
+
+run_cmd mkdir -p "$WEB_BASE" "$WEB_ROOT/tables" "$WEB_ROOT/stars"
+
+# Static assets only; never delete existing tables/ or stars/.
+run_cmd rsync -a \
+  --exclude 'tables/' \
+  --exclude 'stars/' \
+  "$SRC/" "$WEB_ROOT/"
+
+if [[ ! -f "$WEB_ROOT/tables/data.csv" ]]; then
+  cat <<EOF
+[WARN] $WEB_ROOT/tables/data.csv is missing.
+       Run: bash scripts/bootstrap_website_tables.sh
+       (copies tables from the legacy site, or set LEGACY_WEB_ROOT).
+EOF
+fi
+
+cat <<EOF
+
+Installed static site to: $WEB_ROOT
+Open (after Apache maps this path): .../darkhunter/rv/index.html
+
+Optional base-dir note (no index.html at $WEB_BASE):
+  echo 'RV explorer: <a href="rv/">rv/</a>' > $WEB_BASE/README.html
+
+EOF

--- a/website/rv/index.html
+++ b/website/rv/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dark Hunters Gaia Binary Explorer</title>
+    <link rel="shortcut icon" href="#">
+    <link rel="stylesheet" href="style.css">
+
+</head>
+<body>
+
+<header class="site-header">
+    <h1>Dark Hunters Gaia Binary Explorer</h1>
+</header>
+<div id="input-box">
+    <table class="input-container" id="search-holder">
+        <tr>
+            <td>Star Search:</td>
+            <td class="input-cell">
+                <input type="text" placeholder="Gaia ID" id="STARinput">
+            </td>
+            <td class="input-cell">
+                <button onclick="starSearch(0,'STARinput')">Submit</button>
+            </td>
+        </tr>
+    </table>
+</div>
+<div id="table-controls">
+    <div id="controls-left">
+        <div id="pagination-row">
+            <label for="page-size">Rows:</label>
+            <select id="page-size">
+                <option value="50">50</option>
+                <option value="100">100</option>
+                <option value="all">All</option>
+            </select>
+            <button id="page-first" type="button">First</button>
+            <button id="page-prev" type="button">Prev</button>
+            <button id="page-next" type="button">Next</button>
+            <button id="page-last" type="button">Last</button>
+            <span id="page-status">Page 1/1</span>
+        </div>
+        <div id="action-row">
+            <button id="copy-view-link" type="button">Copy view link</button>
+            <button id="download-selected" type="button">Download selected CSV</button>
+            <button id="sort-apf-count" type="button">Sort by APF points ↓</button>
+            <button id="sort-kpf-count" type="button">Sort by KPF points ↓</button>
+            <button id="sort-apf-recent" type="button">Sort by recent APF ↓</button>
+            <button id="sort-kpf-recent" type="button">Sort by recent KPF ↓</button>
+        </div>
+        <div id="query-toggles-row">
+            <div class="toggle-row">
+                <label class="toggle-tile"><input type="checkbox" id="toggle-rv"><span class="toggle-title">RV curve</span><span id="count-rv" class="toggle-count">(0)</span></label>
+                <label class="toggle-tile"><input type="checkbox" id="toggle-apf-data"><span class="toggle-title">APF data</span><span id="count-apf-data" class="toggle-count">(0)</span></label>
+                <label class="toggle-tile"><input type="checkbox" id="toggle-keck"><span class="toggle-title">KPF data</span><span id="count-keck" class="toggle-count">(0)</span></label>
+                <label class="toggle-tile"><input type="checkbox" id="toggle-recent-apf"><span class="toggle-title">Recent APF data (&lt;30d)</span><span id="count-recent-apf" class="toggle-count">(0)</span></label>
+                <label class="toggle-tile"><input type="checkbox" id="toggle-recent-apf-week"><span class="toggle-title">Recent APF data (&lt;7d)</span><span id="count-recent-apf-week" class="toggle-count">(0)</span></label>
+                <label class="toggle-tile"><input type="checkbox" id="toggle-recent-keck"><span class="toggle-title">Recent KPF data (&lt;30d)</span><span id="count-recent-keck" class="toggle-count">(0)</span></label>
+                <label class="toggle-tile"><input type="checkbox" id="toggle-recent-keck-week"><span class="toggle-title">Recent KPF data (&lt;7d)</span><span id="count-recent-keck-week" class="toggle-count">(0)</span></label>
+            </div>
+            <div class="toggle-row">
+                <label class="toggle-tile"><input type="checkbox" id="toggle-flux"><span class="toggle-title">H-beta</span><span id="count-flux" class="toggle-count">(0)</span></label>
+                <label class="toggle-tile"><span class="toggle-title">Broad lines</span><select id="toggle-param-1"><option value="">Any</option><option value="Y">Y</option><option value="N">N</option></select><span id="count-param-1" class="toggle-count">(Y:0 N:0)</span></label>
+                <label class="toggle-tile"><span class="toggle-title">Complete orbit now</span><select id="toggle-param-2"><option value="">Any</option><option value="Y">Y</option><option value="N">N</option></select><span id="count-param-2" class="toggle-count">(Y:0 N:0)</span></label>
+                <label class="toggle-tile"><span class="toggle-title">Complete orbit by DR4</span><select id="toggle-param-5"><option value="">Any</option><option value="Y">Y</option><option value="N">N</option></select><span id="count-param-5" class="toggle-count">(Y:0 N:0)</span></label>
+                <label class="toggle-tile"><span class="toggle-title">Jerk star</span><select id="toggle-param-3"><option value="">Any</option><option value="Y">Y</option><option value="N">N</option></select><span id="count-param-3" class="toggle-count">(Y:0 N:0)</span></label>
+                <label class="toggle-tile"><span class="toggle-title">Clear variability</span><select id="toggle-param-4"><option value="">Any</option><option value="Y">Y</option><option value="N">N</option></select><span id="count-param-4" class="toggle-count">(Y:0 N:0)</span></label>
+                <label class="toggle-tile"><span class="toggle-title">Low S/N</span><select id="toggle-param-6"><option value="">Any</option><option value="Y">Y</option><option value="N">N</option></select><span id="count-param-6" class="toggle-count">(Y:0 N:0)</span></label>
+            </div>
+        </div>
+    </div>
+</div>
+<table id="csv-container"></table>
+<div id="last-updated">Last updated: loading...</div>
+<div id="page-credit">
+    <div><span class="credit-label">Team:</span> <span class="credit-value">Kirsty Taggart, Shep Brooke, Jeff Andrews, Ryan Foley</span></div>
+    <div><span class="credit-label">Website:</span> <span class="credit-value">by Kirsty Taggart and Shep Brooke</span></div>
+    <div>
+        <span class="credit-label">Paper:</span>
+        <a id="sample-paper-link" href="https://arxiv.org/abs/2207.00680" target="_blank" rel="noopener noreferrer">
+            ATF22 (Andrews, Taggart, Foley)
+        </a>
+    </div>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/4.1.2/papaparse.js"></script>
+<script src="script.js"></script>
+
+</body>
+</html>

--- a/website/rv/script.js
+++ b/website/rv/script.js
@@ -1,0 +1,1841 @@
+let table = document.getElementById("csv-container");
+let input_container = document.getElementById("search-holder");
+let input_box = document.getElementById("input-box");
+let last_updated = document.getElementById("last-updated");
+let page_status = document.getElementById("page-status");
+let lastUpdatedDate = null;
+const headers_array = ["RA", "DEC", "PARALLAX", "PMRA", "PMDEC", "PERIOD", "ECCENTRICITY", "M1", "M2"];
+const mediaColumns = new Set([10, 12, 13]); // RV PLOT, FLUX PLOT, SOURCE IMAGE
+const RECENT_APF_DAYS = 30;
+const RECENT_KECK_DAYS = 30;
+const RECENT_WEEK_DAYS = 7;
+const INCLUDE_KECK_ONLY_ROWS = false;
+const KECK_GAIA_IDS = new Set();
+const KECK_TARGETS = new Map();
+const SIMBAD_GAIA_IDS = new Set();
+const COMPLETE_ORBIT_DR4_HEADER = "WILL HAVE COMPLETE ORBIT BY DR4";
+const COMPLETE_ORBIT_DR4_LEGACY_HEADER = "WILL HAVE COMPLETE ORBIT BY NOVEMBER";
+const YES_NO_PARAMS = [
+    { header: "BROAD LINES (HOT STAR/RAPID ROTATION)", label: "Broad lines", toggleId: "toggle-param-1", countId: "count-param-1", datasetKey: "param1", urlKey: "p1" },
+    { header: "COMPLETE ORBIT/MINIMA TO MAXIMA", label: "Complete orbit now", toggleId: "toggle-param-2", countId: "count-param-2", datasetKey: "param2", urlKey: "p2" },
+    { header: "JERK STAR", label: "Jerk star", toggleId: "toggle-param-3", countId: "count-param-3", datasetKey: "param3", urlKey: "p3" },
+    { header: "SHOWS CLEAR VARIABILITY", label: "Clear variability", toggleId: "toggle-param-4", countId: "count-param-4", datasetKey: "param4", urlKey: "p4" },
+    { header: COMPLETE_ORBIT_DR4_HEADER, legacyHeaders: [COMPLETE_ORBIT_DR4_LEGACY_HEADER], label: "Complete orbit by DR4", toggleId: "toggle-param-5", countId: "count-param-5", datasetKey: "param5", urlKey: "p5" },
+    { header: "LOW S/N", label: "Low S/N", toggleId: "toggle-param-6", countId: "count-param-6", datasetKey: "param6", urlKey: "p6" }
+];
+
+let sortColumn = null;
+let sortDirection = "asc";
+let pageSize = "all";
+let currentPage = 1;
+let suppressUrlSync = false;
+let lastMatchedRows = [];
+let apfCountSortDirection = "desc";
+let keckCountSortDirection = "desc";
+let apfRecentSortDirection = "asc";
+let keckRecentSortDirection = "asc";
+
+const headerDisplayMap = {
+    "GAIA NAME": "Gaia DR3",
+    "RA (deg)": "RA (deg)",
+    "DEC (deg)": "Dec (deg)",
+    "PARALLAX (mas)": "Parallax (mas)",
+    "PMRA (mas/yr)": "PMRA (mas/yr)",
+    "PMDEC (mas/yr)": "PMDec (mas/yr)",
+    "PERIOD (days)": "Period (days)",
+    "ECCENTRICITY": "Eccentricity",
+    "M1 (Msun)": "Luminous M1<br>(M<sub>⊙</sub>)",
+    "M2 (Msun)": "Dark M2<br>(M<sub>⊙</sub>)",
+    "M2sin i (Msun)": "M2 sin i<br>(M<sub>⊙</sub>)",
+    "(M2sin i)/(sin i) (Msun)": "M2 at i<br>(M<sub>⊙</sub>)",
+    "RV PLOT": "RV Curve",
+    "RV FIT": "RV Fit",
+    "FLUX PLOT": "H-beta",
+    "SOURCE IMAGE": "UV Image",
+    "DATA PRODUCTS": "Data Products",
+    "BROAD LINES (HOT STAR/RAPID ROTATION)": "Broad lines",
+    "COMPLETE ORBIT/MINIMA TO MAXIMA": "Complete orbit now",
+    "JERK STAR": "Jerk star",
+    "SHOWS CLEAR VARIABILITY": "Clear variability",
+    "WILL HAVE COMPLETE ORBIT BY NOVEMBER": "Complete orbit by DR4",
+    "WILL HAVE COMPLETE ORBIT BY DR4": "Complete orbit by DR4",
+    "LOW S/N": "Low S/N"
+};
+
+function parseUrlState() {
+    const params = new URLSearchParams(window.location.search);
+    const state = {
+        q: "",
+        rows: "all",
+        page: 1,
+        sort: null,
+        dir: "asc",
+        rv: false,
+        flux: false,
+        source: false,
+        apf: false,
+        keck: false,
+        rapf: false,
+        rkeck: false,
+        w7apf: false,
+        w7keck: false,
+        ranges: {
+            RA: ["", ""],
+            DEC: ["", ""],
+            PARALLAX: ["", ""],
+            PMRA: ["", ""],
+            PMDEC: ["", ""],
+            PERIOD: ["", ""],
+            ECCENTRICITY: ["", ""],
+            M1: ["", ""],
+            M2: ["", ""]
+        }
+    };
+    for (let i = 0; i < YES_NO_PARAMS.length; i++) {
+        state[YES_NO_PARAMS[i].datasetKey] = "";
+    }
+
+    state.q = params.get("q") || "";
+    state.rows = params.get("rows") || "all";
+    const parsedPage = parseInt(params.get("page") || "1", 10);
+    state.page = Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage;
+    state.sort = params.get("sort");
+    state.dir = params.get("dir") === "desc" ? "desc" : "asc";
+    state.rv = params.get("rv") === "1";
+    state.flux = params.get("flux") === "1";
+    state.source = params.get("source") === "1";
+    state.apf = params.get("apf") === "1";
+    state.keck = params.get("keck") === "1";
+    state.rapf = params.get("rapf") === "1";
+    state.rkeck = params.get("rkeck") === "1";
+    state.w7apf = params.get("w7apf") === "1";
+    state.w7keck = params.get("w7keck") === "1";
+
+    const rangeKeys = [
+        ["RA", "ra"], ["DEC", "dec"], ["PARALLAX", "parallax"],
+        ["PMRA", "pmra"], ["PMDEC", "pmdec"], ["PERIOD", "period"],
+        ["ECCENTRICITY", "ecc"], ["M1", "m1"], ["M2", "m2"]
+    ];
+    for (let i = 0; i < rangeKeys.length; i++) {
+        const label = rangeKeys[i][0];
+        const short = rangeKeys[i][1];
+        state.ranges[label] = [
+            params.get(`${short}_min`) || "",
+            params.get(`${short}_max`) || ""
+        ];
+    }
+
+    for (let i = 0; i < YES_NO_PARAMS.length; i++) {
+        const raw = String(params.get(YES_NO_PARAMS[i].urlKey) || "").trim().toUpperCase();
+        state[YES_NO_PARAMS[i].datasetKey] = (raw === "Y" || raw === "N") ? raw : "";
+    }
+
+    return state;
+}
+
+function normalizeYesNoValue(value) {
+    const v = String(value ?? "").trim().toUpperCase();
+    if (v === "Y" || v === "YES" || v === "1" || v === "TRUE" || v === "T") {
+        return "Y";
+    }
+    return "N";
+}
+
+function getParamFilterValue(param) {
+    const control = document.getElementById(param.toggleId);
+    if (!control) {
+        return "";
+    }
+    const raw = String(control.value ?? "").trim().toUpperCase();
+    if (raw === "Y" || raw === "N") {
+        return raw;
+    }
+    return "";
+}
+
+function ensureYesNoColumns(tableData) {
+    if (!Array.isArray(tableData) || tableData.length === 0 || !Array.isArray(tableData[0])) {
+        return tableData;
+    }
+
+    const headerRow = tableData[0];
+    for (let i = 0; i < YES_NO_PARAMS.length; i++) {
+        const param = YES_NO_PARAMS[i];
+        if (!headerRow.includes(param.header)) {
+            let legacyIdx = -1;
+            const legacyHeaders = Array.isArray(param.legacyHeaders) ? param.legacyHeaders : [];
+            for (let j = 0; j < legacyHeaders.length; j++) {
+                const idx = headerRow.indexOf(legacyHeaders[j]);
+                if (idx >= 0) {
+                    legacyIdx = idx;
+                    break;
+                }
+            }
+
+            if (legacyIdx >= 0) {
+                // Rename legacy column header in-place to avoid duplicate columns.
+                headerRow[legacyIdx] = param.header;
+            } else {
+                headerRow.push(param.header);
+                const newIdx = headerRow.length - 1;
+                for (let rowIdx = 1; rowIdx < tableData.length; rowIdx++) {
+                    const row = tableData[rowIdx];
+                    if (!Array.isArray(row)) {
+                        continue;
+                    }
+                    while (row.length <= newIdx) {
+                        row.push("N");
+                    }
+                }
+            }
+        }
+    }
+
+    for (let rowIdx = 1; rowIdx < tableData.length; rowIdx++) {
+        const row = tableData[rowIdx];
+        if (!Array.isArray(row)) {
+            continue;
+        }
+        const isEmpty = row.length === 0 || row.every(cell => String(cell ?? "").trim() === "");
+        if (isEmpty) {
+            continue;
+        }
+        while (row.length < headerRow.length) {
+            row.push("N");
+        }
+        for (let i = 0; i < YES_NO_PARAMS.length; i++) {
+            const colIdx = headerRow.indexOf(YES_NO_PARAMS[i].header);
+            row[colIdx] = normalizeYesNoValue(row[colIdx]);
+        }
+    }
+
+    return tableData;
+}
+
+const initialState = parseUrlState();
+if (window.location.search) {
+    history.replaceState(null, "", window.location.pathname);
+}
+
+function formatDateTimeUTC(d) {
+    const year = d.getUTCFullYear();
+    const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(d.getUTCDate()).padStart(2, "0");
+    const hours = String(d.getUTCHours()).padStart(2, "0");
+    const mins = String(d.getUTCMinutes()).padStart(2, "0");
+    const secs = String(d.getUTCSeconds()).padStart(2, "0");
+    return `${year}-${month}-${day} ${hours}:${mins}:${secs}`;
+}
+
+function renderLastUpdated() {
+    if (!last_updated) {
+        return;
+    }
+    if (!lastUpdatedDate) {
+        last_updated.innerHTML = "Last updated: unavailable";
+        return;
+    }
+    const ageHours = Math.max(0, (Date.now() - lastUpdatedDate.getTime()) / 3600000);
+    let freshnessClass = "fresh";
+    let freshnessLabel = "Up to date";
+    if (ageHours >= 72) {
+        freshnessClass = "old";
+        freshnessLabel = "Old";
+    } else if (ageHours >= 24) {
+        freshnessClass = "stale";
+        freshnessLabel = "Stale";
+    }
+    last_updated.innerHTML = `Last updated: ${formatDateTimeUTC(lastUpdatedDate)} UTC (${ageHours.toFixed(2)} hr ago) <span id=\"freshness-badge\" class=\"${freshnessClass}\">${freshnessLabel}</span>`;
+}
+
+function considerLastUpdated(lastModifiedHeader) {
+    if (!lastModifiedHeader) {
+        return;
+    }
+    const d = new Date(lastModifiedHeader);
+    if (Number.isNaN(d.getTime())) {
+        return;
+    }
+    if (!lastUpdatedDate || d.getTime() > lastUpdatedDate.getTime()) {
+        lastUpdatedDate = d;
+    }
+}
+
+async function refreshLastUpdatedFromWebsiteFiles() {
+    const files = [
+        "index.html",
+        "script.js",
+        "style.css",
+        "tables/data.csv",
+        "tables/keck_targets.csv"
+    ];
+    const tasks = files.map(file =>
+        fetch(file, { method: "HEAD", cache: "no-store" })
+            .then(resp => {
+                if (resp.ok) {
+                    considerLastUpdated(resp.headers.get("last-modified"));
+                }
+            })
+            .catch(() => {})
+    );
+    await Promise.allSettled(tasks);
+    if (!lastUpdatedDate) {
+        lastUpdatedDate = new Date();
+    }
+    renderLastUpdated();
+}
+
+function buildMediaCellHtml(text) {
+    if (typeof text !== "string") {
+        return text;
+    }
+
+    const trimmed = text.trim();
+    if (!trimmed || trimmed.toUpperCase() === "N/A") {
+        return text;
+    }
+
+    const srcMatch = trimmed.match(/src=['"]([^'"]+)['"]/i);
+    if (srcMatch && srcMatch[1]) {
+        return `<a href="${srcMatch[1]}" target="_blank" rel="noopener noreferrer">${trimmed}</a>`;
+    }
+
+    if (/^https?:\/\/\S+$/i.test(trimmed) && /\.(png|jpg|jpeg|gif|webp)(\?.*)?$/i.test(trimmed)) {
+        return `<a href="${trimmed}" target="_blank" rel="noopener noreferrer"><img src="${trimmed}" alt="plot"></a>`;
+    }
+
+    return text;
+}
+
+function hasNonNAContent(value) {
+    if (typeof value !== "string") {
+        return false;
+    }
+    const trimmed = value.trim();
+    return trimmed !== "" && trimmed.toUpperCase() !== "N/A";
+}
+
+function buildDataProductsHtml(dataProductsCell, fluxCell, uvImageCell) {
+    if (typeof dataProductsCell !== "string") {
+        return dataProductsCell;
+    }
+
+    const hrefMatch = dataProductsCell.match(/href=['"]([^'"]+)['"]/i);
+    if (!hrefMatch || !hrefMatch[1]) {
+        return dataProductsCell;
+    }
+
+    const base = hrefMatch[1].replace(/\/+$/, "");
+    const apfUrl = `${base}/Gaia/`;
+    const swiftUrl = `${base}/Swift/`;
+    const hasSwift = hasNonNAContent(fluxCell) || hasNonNAContent(uvImageCell);
+
+    let html = `<span class="product-links"><a href="${apfUrl}" target="_blank" rel="noopener noreferrer">APF</a>`;
+    if (hasSwift) {
+        html += ` <a href="${swiftUrl}" target="_blank" rel="noopener noreferrer">Swift</a>`;
+    }
+    html += `</span>`;
+    return html;
+}
+
+function escapeHtml(text) {
+    return String(text)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;");
+}
+
+function buildGaiaNameCellHtml(text) {
+    const raw = String(text || "");
+    const cleaned = raw.replace(/^Gaia\s+DR3\s+/i, "").trim();
+    const idMatch = cleaned.match(/(\d{8,})/);
+    const copyValue = idMatch ? idMatch[1] : cleaned;
+    if (!idMatch || !copyValue) {
+        return cleaned;
+    }
+    const safeText = escapeHtml(cleaned);
+    const safeCopy = escapeHtml(copyValue);
+    let display = `<span class=\"gaia-id-text\">${safeText}</span>`;
+    if (SIMBAD_GAIA_IDS.has(copyValue)) {
+        const simbadUrl = `https://simbad.u-strasbg.fr/simbad/sim-id?Ident=${encodeURIComponent(`Gaia DR3 ${copyValue}`)}`;
+        display = `<a class=\"gaia-id-text\" href=\"${simbadUrl}\" target=\"_blank\" rel=\"noopener noreferrer\">${safeText}</a>`;
+    }
+    return `<div class=\"gaia-id-wrap\">${display}<button class=\"copy-gaia-btn\" data-copy=\"${safeCopy}\" title=\"Copy Gaia ID\">Copy</button></div>`;
+}
+
+async function loadOptionalSimbadCatalog() {
+    const path = "tables/simbad_gaia_ids.csv";
+    try {
+        const resp = await fetch(path, { cache: "no-store" });
+        if (!resp.ok) {
+            return;
+        }
+        const txt = await resp.text();
+        const lines = txt.split(/\r?\n/);
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i].trim();
+            if (!line || line.startsWith("#")) {
+                continue;
+            }
+            const id = line.split(",")[0].trim().replace(/^['"]|['"]$/g, "");
+            if (/^\d{8,}$/.test(id)) {
+                SIMBAD_GAIA_IDS.add(id);
+            }
+        }
+    } catch {
+        // Optional file; no SIMBAD links if unavailable.
+    }
+}
+
+function buildHbetaCellHtml(gaiaId) {
+    if (!gaiaId) {
+        return "N/A";
+    }
+    const apfSrc = `stars/Gaia_DR3_${gaiaId}/Gaia/Plots/Gaia_DR3_${gaiaId}_28_hbeta.png`;
+    const kpfSrc = `stars/Gaia_DR3_${gaiaId}/Keck/Plots/Gaia_DR3_${gaiaId}_kpf_hbeta.png`;
+    const hasKeck = KECK_GAIA_IDS.has(gaiaId);
+    if (!hasKeck) {
+        return `<a href="${apfSrc}" target="_blank" rel="noopener noreferrer"><img src="${apfSrc}" alt="H-beta plot" onerror="this.closest('a').outerHTML='N/A';"></a>`;
+    }
+    return `<a href="${apfSrc}" target="_blank" rel="noopener noreferrer" data-apf="${apfSrc}" data-kpf="${kpfSrc}"><img src="${apfSrc}" alt="H-beta plot" onerror="(function(img){var a=img.closest('a');if(!a){return;}if(!a.dataset.fallbackTried){a.dataset.fallbackTried='1';var kpf=a.getAttribute('data-kpf');if(kpf){a.href=kpf;img.src=kpf;return;}}a.outerHTML='N/A';})(this);"></a>`;
+}
+
+function buildApfRvPlotCellHtml(gaiaId) {
+    if (!gaiaId) {
+        return "N/A";
+    }
+    const src = `stars/Gaia_DR3_${gaiaId}/Gaia/Plots/Gaia_DR3_${gaiaId}_rv_plot.png`;
+    return `<a href="${src}" target="_blank" rel="noopener noreferrer"><img src="${src}" alt="APF RV plot" onerror="this.closest('a').outerHTML='N/A';"></a>`;
+}
+
+function buildKeckRvCellHtml(gaiaId) {
+    if (!gaiaId) {
+        return "N/A";
+    }
+    const src = `stars/Gaia_DR3_${gaiaId}/Keck/Plots/${gaiaId}_kpf_rv_plot.png`;
+    return `<a href="${src}" target="_blank" rel="noopener noreferrer"><img src="${src}" alt="KPF RV plot" onerror="this.closest('a').outerHTML='N/A';"></a>`;
+}
+
+function buildRvFitCellHtml(gaiaId) {
+    if (!gaiaId) {
+        return "N/A";
+    }
+    const src = `stars/Gaia_DR3_${gaiaId}/Gaia/RV_Fit/${gaiaId}_keplerian_fit.png`;
+    return `<a href="${src}" target="_blank" rel="noopener noreferrer"><img src="${src}" alt="APF RV fit" onerror="this.closest('a').outerHTML='N/A';"></a>`;
+}
+
+function syncUrlState() {
+    if (suppressUrlSync) {
+        return;
+    }
+    const p = new URLSearchParams();
+    const starInput = document.getElementById("STARinput");
+    if (starInput && starInput.value.trim() !== "") {
+        p.set("q", starInput.value.trim());
+    }
+    p.set("rows", String(pageSize));
+    p.set("page", String(currentPage));
+    if (sortColumn !== null) {
+        p.set("sort", String(sortColumn));
+        p.set("dir", sortDirection);
+    }
+
+    const rv = document.getElementById("toggle-rv");
+    const flux = document.getElementById("toggle-flux");
+    const source = document.getElementById("toggle-source");
+    const apf = document.getElementById("toggle-apf-data");
+    const keck = document.getElementById("toggle-keck");
+    const recentApf = document.getElementById("toggle-recent-apf");
+    const recentKeck = document.getElementById("toggle-recent-keck");
+    const recentApfWeek = document.getElementById("toggle-recent-apf-week");
+    const recentKeckWeek = document.getElementById("toggle-recent-keck-week");
+    if (rv && rv.checked) p.set("rv", "1");
+    if (flux && flux.checked) p.set("flux", "1");
+    if (source && source.checked) p.set("source", "1");
+    if (apf && apf.checked) p.set("apf", "1");
+    if (keck && keck.checked) p.set("keck", "1");
+    if (recentApf && recentApf.checked) p.set("rapf", "1");
+    if (recentKeck && recentKeck.checked) p.set("rkeck", "1");
+    if (recentApfWeek && recentApfWeek.checked) p.set("w7apf", "1");
+    if (recentKeckWeek && recentKeckWeek.checked) p.set("w7keck", "1");
+    for (let i = 0; i < YES_NO_PARAMS.length; i++) {
+        const filterValue = getParamFilterValue(YES_NO_PARAMS[i]);
+        if (filterValue) {
+            p.set(YES_NO_PARAMS[i].urlKey, filterValue);
+        }
+    }
+
+    const rangeKeys = [
+        ["RA", "ra"], ["DEC", "dec"], ["PARALLAX", "parallax"],
+        ["PMRA", "pmra"], ["PMDEC", "pmdec"], ["PERIOD", "period"],
+        ["ECCENTRICITY", "ecc"], ["M1", "m1"], ["M2", "m2"]
+    ];
+    for (let i = 0; i < rangeKeys.length; i++) {
+        const label = rangeKeys[i][0];
+        const short = rangeKeys[i][1];
+        const start = document.getElementById(`${label}_start`);
+        const end = document.getElementById(`${label}_end`);
+        if (start && start.value.trim() !== "") p.set(`${short}_min`, start.value.trim());
+        if (end && end.value.trim() !== "") p.set(`${short}_max`, end.value.trim());
+    }
+
+    const qs = p.toString();
+    const newUrl = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+    history.replaceState(null, "", newUrl);
+}
+
+function parseCellNumber(cell) {
+    if (!cell) {
+        return NaN;
+    }
+    const n = parseFloat(cell.textContent.trim());
+    return Number.isNaN(n) ? NaN : n;
+}
+
+function normalizeGaiaId(text) {
+    const match = String(text || "").match(/(\d{8,})/);
+    return match && match[1] ? match[1] : "";
+}
+
+function cleanKeckValue(v) {
+    const s = String(v || "").trim();
+    if (!s || s.toUpperCase() === "N/A" || s === "--") {
+        return "--";
+    }
+    return s;
+}
+
+function loadOptionalKeckCatalog() {
+    return fetch("tables/keck_targets.csv", { cache: "no-store" })
+        .then(response => {
+            if (!response.ok) {
+                return "";
+            }
+            return response.text();
+        })
+        .then(csvText => {
+            if (!csvText) {
+                return;
+            }
+            const lines = csvText.split("\n");
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i].trim();
+                if (!line || line.startsWith("#")) {
+                    continue;
+                }
+                const firstCol = line.split(",")[0];
+                const gaiaId = normalizeGaiaId(firstCol);
+                if (gaiaId) {
+                    KECK_GAIA_IDS.add(gaiaId);
+                    const parts = line.split(",");
+                    const ra = cleanKeckValue(parts[1]);
+                    const dec = cleanKeckValue(parts[2]);
+                    const parallax = cleanKeckValue(parts[3]);
+                    const pmra = cleanKeckValue(parts[4]);
+                    const pmdec = cleanKeckValue(parts[5]);
+                    const period = cleanKeckValue(parts[6]);
+                    const ecc = cleanKeckValue(parts[7]);
+                    const m1 = cleanKeckValue(parts[8]);
+                    const m2 = cleanKeckValue(parts[9]);
+                    KECK_TARGETS.set(gaiaId, { ra, dec, parallax, pmra, pmdec, period, ecc, m1, m2 });
+                }
+            }
+        })
+        .catch(() => {});
+}
+
+function mergeKeckOnlyRows(tableData) {
+    if (!Array.isArray(tableData) || tableData.length === 0) {
+        return tableData;
+    }
+    const header = tableData[0];
+    const colCount = header.length;
+    const gaiaCol = 0;
+    const raCol = 1;
+    const decCol = 2;
+    const parallaxCol = 3;
+    const pmraCol = 4;
+    const pmdecCol = 5;
+    const periodCol = 6;
+    const eccCol = 7;
+    const m1Col = 8;
+    const m2Col = 9;
+    const dataProductsCol = 14;
+
+    const existingIds = new Set();
+    for (let i = 1; i < tableData.length; i++) {
+        const row = tableData[i];
+        if (!row) {
+            continue;
+        }
+        const gaiaId = normalizeGaiaId(row[gaiaCol]);
+        if (gaiaId) {
+            existingIds.add(gaiaId);
+        }
+    }
+
+    KECK_TARGETS.forEach((info, gaiaId) => {
+        if (existingIds.has(gaiaId)) {
+            return;
+        }
+        const row = new Array(colCount).fill("N/A");
+        row[gaiaCol] = `Gaia DR3 ${gaiaId}`;
+        row[raCol] = info.ra || "N/A";
+        row[decCol] = info.dec || "N/A";
+        row[parallaxCol] = info.parallax || "--";
+        row[pmraCol] = info.pmra || "--";
+        row[pmdecCol] = info.pmdec || "--";
+        row[periodCol] = info.period || "--";
+        row[eccCol] = info.ecc || "--";
+        row[m1Col] = info.m1 || "--";
+        row[m2Col] = info.m2 || "--";
+        row[dataProductsCol] = `<a href='stars/Gaia_DR3_${gaiaId}'> ${gaiaId} </a>`;
+        tableData.push(row);
+    });
+
+    return tableData;
+}
+
+function extractHrefFromAnchorHtml(text) {
+    if (typeof text !== "string") {
+        return "";
+    }
+    const hrefMatch = text.match(/href=['"]([^'"]+)['"]/i);
+    return (hrefMatch && hrefMatch[1]) ? hrefMatch[1].replace(/\/+$/, "") : "";
+}
+
+function toCsvCell(text) {
+    const s = String(text ?? "");
+    if (s.includes(",") || s.includes("\"") || s.includes("\n")) {
+        return `"${s.replaceAll("\"", "\"\"")}"`;
+    }
+    return s;
+}
+
+function hasMedia(cell) {
+    if (!cell) {
+        return false;
+    }
+    const html = cell.innerHTML.toLowerCase();
+    if (html.includes("<img") || html.includes("<a ")) {
+        return true;
+    }
+    const txt = cell.textContent.trim().toUpperCase();
+    return !!txt && txt !== "N/A";
+}
+
+function getDataRows() {
+    return Array.from(table.getElementsByTagName("tr")).slice(1);
+}
+
+function anyRangeQueryActive() {
+    for (let i = 0; i < headers_array.length; i++) {
+        const start = document.getElementById(`${headers_array[i]}_start`);
+        const end = document.getElementById(`${headers_array[i]}_end`);
+        if (!start || !end) {
+            continue;
+        }
+        if (start.value.trim() !== "" || end.value.trim() !== "") {
+            return true;
+        }
+    }
+    return false;
+}
+
+function anyToggleActive() {
+    const rv = document.getElementById("toggle-rv");
+    const flux = document.getElementById("toggle-flux");
+    const source = document.getElementById("toggle-source");
+    const apf = document.getElementById("toggle-apf-data");
+    const recent = document.getElementById("toggle-recent-apf");
+    const keck = document.getElementById("toggle-keck");
+    const recentKeck = document.getElementById("toggle-recent-keck");
+    const recentApfWeek = document.getElementById("toggle-recent-apf-week");
+    const recentKeckWeek = document.getElementById("toggle-recent-keck-week");
+    for (let i = 0; i < YES_NO_PARAMS.length; i++) {
+        if (getParamFilterValue(YES_NO_PARAMS[i])) {
+            return true;
+        }
+    }
+    return (rv && rv.checked) || (flux && flux.checked) || (source && source.checked) || (apf && apf.checked) || (recent && recent.checked) || (keck && keck.checked) || (recentKeck && recentKeck.checked) || (recentApfWeek && recentApfWeek.checked) || (recentKeckWeek && recentKeckWeek.checked);
+}
+
+function hasActiveQuery() {
+    const starInput = document.getElementById("STARinput");
+    return (starInput && starInput.value.trim() !== "") || anyRangeQueryActive() || anyToggleActive();
+}
+
+function rowMatchesBaseFilters(row) {
+    const cells = row.getElementsByTagName("td");
+
+    const starInput = document.getElementById("STARinput");
+    const starFilter = starInput ? starInput.value.trim().toUpperCase() : "";
+    if (starFilter) {
+        const txt = cells[0] ? cells[0].textContent.toUpperCase() : "";
+        if (!txt.includes(starFilter)) {
+            return false;
+        }
+    }
+
+    for (let i = 0; i < headers_array.length; i++) {
+        const start = document.getElementById(`${headers_array[i]}_start`);
+        const end = document.getElementById(`${headers_array[i]}_end`);
+        if (!start || !end) {
+            continue;
+        }
+
+        const val = parseCellNumber(cells[i + 1]);
+        const hasStart = start.value.trim() !== "";
+        const hasEnd = end.value.trim() !== "";
+
+        if ((hasStart || hasEnd) && Number.isNaN(val)) {
+            return false;
+        }
+
+        if (hasStart && val < parseFloat(start.value)) {
+            return false;
+        }
+        if (hasEnd && val > parseFloat(end.value)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function rowMatchesFilters(row) {
+    if (!rowMatchesBaseFilters(row)) {
+        return false;
+    }
+    const cells = row.getElementsByTagName("td");
+    const rvToggle = document.getElementById("toggle-rv");
+    const fluxToggle = document.getElementById("toggle-flux");
+    const sourceToggle = document.getElementById("toggle-source");
+    const apfToggle = document.getElementById("toggle-apf-data");
+    const recentApfToggle = document.getElementById("toggle-recent-apf");
+    const keckToggle = document.getElementById("toggle-keck");
+    const recentKeckToggle = document.getElementById("toggle-recent-keck");
+    const recentApfWeekToggle = document.getElementById("toggle-recent-apf-week");
+    const recentKeckWeekToggle = document.getElementById("toggle-recent-keck-week");
+
+    if (rvToggle && rvToggle.checked && !hasMedia(cells[10])) {
+        return false;
+    }
+    if (fluxToggle && fluxToggle.checked && !hasMedia(cells[12])) {
+        return false;
+    }
+    if (sourceToggle && sourceToggle.checked && !hasMedia(cells[13])) {
+        return false;
+    }
+    if (apfToggle && apfToggle.checked && row.dataset.hasApf !== "1") {
+        return false;
+    }
+    if (recentApfToggle && recentApfToggle.checked && row.dataset.apfRecent !== "1") {
+        return false;
+    }
+    if (recentApfWeekToggle && recentApfWeekToggle.checked && row.dataset.apfRecentWeek !== "1") {
+        return false;
+    }
+    if (keckToggle && keckToggle.checked && row.dataset.hasKeck !== "1") {
+        return false;
+    }
+    if (recentKeckToggle && recentKeckToggle.checked && row.dataset.keckRecent !== "1") {
+        return false;
+    }
+    if (recentKeckWeekToggle && recentKeckWeekToggle.checked && row.dataset.keckRecentWeek !== "1") {
+        return false;
+    }
+    for (let i = 0; i < YES_NO_PARAMS.length; i++) {
+        const selected = getParamFilterValue(YES_NO_PARAMS[i]);
+        if (selected && row.dataset[YES_NO_PARAMS[i].datasetKey] !== selected) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function colorRows(rows) {
+    let visibleCount = 0;
+    for (let i = 1; i < rows.length; i++) {
+        if (rows[i].style.display === "none") {
+            continue;
+        }
+        visibleCount += 1;
+        rows[i].style.backgroundColor = (visibleCount % 2 === 0) ? "#e6edf5" : "#ffffff";
+    }
+}
+
+function updatePageStatus(totalPages, selected) {
+    if (page_status) {
+        page_status.innerHTML = `Page ${currentPage}/${totalPages} (${selected} selected)`;
+    }
+}
+
+function updateToggleCounts(baseRows) {
+    const rvCount = document.getElementById("count-rv");
+    const fluxCount = document.getElementById("count-flux");
+    const sourceCount = document.getElementById("count-source");
+    const apfCount = document.getElementById("count-apf-data");
+    const recentCount = document.getElementById("count-recent-apf");
+    const keckCount = document.getElementById("count-keck");
+    const recentKeckCount = document.getElementById("count-recent-keck");
+    const recentApfWeekCount = document.getElementById("count-recent-apf-week");
+    const recentKeckWeekCount = document.getElementById("count-recent-keck-week");
+    const yesNoCounts = YES_NO_PARAMS.map(param => document.getElementById(param.countId));
+    let rv = 0;
+    let flux = 0;
+    let source = 0;
+    let apf = 0;
+    let recent = 0;
+    let keck = 0;
+    let recentKeck = 0;
+    let recentApfWeek = 0;
+    let recentKeckWeek = 0;
+    const yesNoTotals = YES_NO_PARAMS.map(() => ({ Y: 0, N: 0 }));
+    for (let i = 0; i < baseRows.length; i++) {
+        const cells = baseRows[i].getElementsByTagName("td");
+        if (hasMedia(cells[10])) rv += 1;
+        if (hasMedia(cells[12])) flux += 1;
+        if (hasMedia(cells[13])) source += 1;
+        if (baseRows[i].dataset.hasApf === "1") apf += 1;
+        if (baseRows[i].dataset.apfRecent === "1") recent += 1;
+        if (baseRows[i].dataset.apfRecentWeek === "1") recentApfWeek += 1;
+        if (baseRows[i].dataset.hasKeck === "1") keck += 1;
+        if (baseRows[i].dataset.keckRecent === "1") recentKeck += 1;
+        if (baseRows[i].dataset.keckRecentWeek === "1") recentKeckWeek += 1;
+        for (let j = 0; j < YES_NO_PARAMS.length; j++) {
+            const v = normalizeYesNoValue(baseRows[i].dataset[YES_NO_PARAMS[j].datasetKey]);
+            yesNoTotals[j][v] += 1;
+        }
+    }
+    if (rvCount) rvCount.textContent = `(${rv})`;
+    if (fluxCount) fluxCount.textContent = `(${flux})`;
+    if (sourceCount) sourceCount.textContent = `(${source})`;
+    if (apfCount) apfCount.textContent = `(${apf})`;
+    if (recentCount) recentCount.textContent = `(${recent})`;
+    if (keckCount) keckCount.textContent = `(${keck})`;
+    if (recentKeckCount) recentKeckCount.textContent = `(${recentKeck})`;
+    if (recentApfWeekCount) recentApfWeekCount.textContent = `(${recentApfWeek})`;
+    if (recentKeckWeekCount) recentKeckWeekCount.textContent = `(${recentKeckWeek})`;
+    for (let i = 0; i < yesNoCounts.length; i++) {
+        if (yesNoCounts[i]) {
+            yesNoCounts[i].textContent = `(Y:${yesNoTotals[i].Y} N:${yesNoTotals[i].N})`;
+        }
+    }
+}
+
+function renderDataProductsCell(row) {
+    const base = row.dataset.starBase || "";
+    if (!base) {
+        return "N/A";
+    }
+    const apfUrl = `${base}/Gaia/`;
+    const swiftUrl = `${base}/Swift/`;
+    const keckUrl = `${base}/Keck/`;
+    const hasApf = row.dataset.hasApf !== "0";
+    const hasSwift = row.dataset.hasSwift === "1";
+    const hasKeck = row.dataset.hasKeck === "1";
+    const apfRecent = row.dataset.apfRecent || "unknown";
+    const apfChecked = row.dataset.apfChecked === "1";
+    const apfAgeDays = parseFloat(row.dataset.apfAgeDays || "");
+    const keckRecent = row.dataset.keckRecent || "unknown";
+    const keckChecked = row.dataset.keckChecked === "1";
+    const keckAgeDays = parseFloat(row.dataset.keckAgeDays || "");
+    let apfStateClass = "apf-unknown";
+    let apfStateText = "";
+    if (apfChecked && Number.isFinite(apfAgeDays)) {
+        if (apfRecent === "1") {
+            apfStateClass = "apf-recent";
+        } else if (apfRecent === "0") {
+            apfStateClass = "apf-old";
+        }
+        apfStateText = `last epoch ${Math.round(apfAgeDays)} d ago`;
+    }
+    let keckStateClass = "apf-unknown";
+    let keckStateText = "";
+    if (keckChecked && Number.isFinite(keckAgeDays)) {
+        if (keckRecent === "1") {
+            keckStateClass = "apf-recent";
+        } else if (keckRecent === "0") {
+            keckStateClass = "apf-old";
+        }
+        keckStateText = `last epoch ${Math.round(keckAgeDays)} d ago`;
+    }
+
+    let html = `<div class="product-links">`;
+    if (hasApf) {
+        html += `<div class="product-line"><a href="${apfUrl}" target="_blank" rel="noopener noreferrer">APF</a><span class="apf-state ${apfStateClass}">${apfStateText}</span></div>`;
+    }
+    if (hasKeck) {
+        html += `<div class="product-line"><a href="${keckUrl}" target="_blank" rel="noopener noreferrer">KPF</a><span class="apf-state ${keckStateClass}">${keckStateText}</span></div>`;
+    }
+    if (hasSwift) {
+        html += `<div class="product-line"><a href="${swiftUrl}" target="_blank" rel="noopener noreferrer">Swift</a></div>`;
+    }
+    html += `</div>`;
+    return html;
+}
+
+function mjdNow() {
+    return Date.now() / 86400000 + 40587;
+}
+
+function isPlausibleMjd(mjd, nowMjd) {
+    return Number.isFinite(mjd) && mjd > 40000 && mjd <= (nowMjd + 1);
+}
+
+function extractLatestMjd(summaryText) {
+    const lines = String(summaryText || "").split("\n");
+    let latest = null;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i].trim();
+        if (!line || line.startsWith("#")) {
+            continue;
+        }
+        const parts = line.split(/\s+/);
+        if (parts.length < 5) {
+            continue;
+        }
+        const mjd = parseFloat(parts[1]);
+        if (!Number.isNaN(mjd) && (latest === null || mjd > latest)) {
+            latest = mjd;
+        }
+    }
+    return latest;
+}
+
+function extractEpochCount(summaryText) {
+    const lines = String(summaryText || "").split("\n");
+    const uniqueEpochs = new Set();
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i].trim();
+        if (!line || line.startsWith("#")) {
+            continue;
+        }
+        const parts = line.split(/\s+/);
+        if (parts.length >= 5) {
+            // Count unique APF epochs only once even if the summary contains
+            // duplicate rows with different path prefixes.
+            const inputPath = parts[0] || "";
+            const baseName = inputPath.split("/").pop() || inputPath;
+            const mjd = parts[1] || "";
+            uniqueEpochs.add(`${baseName}|${mjd}`);
+        }
+    }
+    return uniqueEpochs.size;
+}
+
+async function updateApfRecencyFlags() {
+    const rows = getDataRows();
+    const nowMjd = mjdNow();
+    const tasks = rows.map(async (row) => {
+        const gaiaId = row.dataset.gaiaId;
+        if (!gaiaId || row.dataset.hasApf === "0") {
+            return;
+        }
+        const summaryUrl = `stars/Gaia_DR3_${gaiaId}/Gaia/${gaiaId}_summary.txt`;
+        try {
+            const resp = await fetch(summaryUrl, { cache: "no-store" });
+            if (!resp.ok) {
+                row.dataset.apfRecent = "unknown";
+                row.dataset.apfRecentWeek = "unknown";
+                row.dataset.apfAgeDays = "";
+                row.dataset.apfChecked = "1";
+                return;
+            }
+            const txt = await resp.text();
+            const latestMjd = extractLatestMjd(txt);
+            const epochCount = extractEpochCount(txt);
+            row.dataset.apfCount = String(epochCount);
+            if (latestMjd === null || !isPlausibleMjd(latestMjd, nowMjd)) {
+                row.dataset.apfRecent = "unknown";
+                row.dataset.apfRecentWeek = "unknown";
+                row.dataset.apfAgeDays = "";
+                row.dataset.apfChecked = "1";
+                return;
+            }
+            const ageDays = nowMjd - latestMjd;
+            row.dataset.apfRecent = (ageDays >= 0 && ageDays <= RECENT_APF_DAYS) ? "1" : "0";
+            row.dataset.apfRecentWeek = (ageDays >= 0 && ageDays <= RECENT_WEEK_DAYS) ? "1" : "0";
+            row.dataset.apfLatestMjd = String(latestMjd);
+            row.dataset.apfAgeDays = String(ageDays);
+            row.dataset.apfChecked = "1";
+        } catch {
+            row.dataset.apfRecent = "unknown";
+            row.dataset.apfRecentWeek = "unknown";
+            row.dataset.apfAgeDays = "";
+            row.dataset.apfChecked = "1";
+            row.dataset.apfCount = row.dataset.apfCount || "0";
+        }
+    });
+    await Promise.allSettled(tasks);
+
+    for (let i = 0; i < rows.length; i++) {
+        const cell = rows[i].getElementsByTagName("td")[14];
+        if (cell) {
+            cell.innerHTML = renderDataProductsCell(rows[i]);
+        }
+    }
+    applyFiltersAndPagination();
+}
+
+function sortRowsByApfCount() {
+    const rows = getDataRows();
+    if (rows.length === 0) {
+        return;
+    }
+
+    sortColumn = null;
+
+    rows.sort((a, b) => {
+        const av = parseInt(a.dataset.apfCount || "0", 10);
+        const bv = parseInt(b.dataset.apfCount || "0", 10);
+        const an = Number.isNaN(av) ? 0 : av;
+        const bn = Number.isNaN(bv) ? 0 : bv;
+        const cmp = an - bn;
+        return apfCountSortDirection === "asc" ? cmp : -cmp;
+    });
+
+    for (let i = 0; i < rows.length; i++) {
+        table.appendChild(rows[i]);
+    }
+
+    const btn = document.getElementById("sort-apf-count");
+    if (btn) {
+        btn.textContent = apfCountSortDirection === "desc" ? "Sort by APF points ↑" : "Sort by APF points ↓";
+    }
+    apfCountSortDirection = apfCountSortDirection === "desc" ? "asc" : "desc";
+
+    applyFiltersAndPagination();
+}
+
+function sortRowsByKeckCount() {
+    const rows = getDataRows();
+    if (rows.length === 0) {
+        return;
+    }
+
+    sortColumn = null;
+
+    rows.sort((a, b) => {
+        const av = parseInt(a.dataset.keckCount || "0", 10);
+        const bv = parseInt(b.dataset.keckCount || "0", 10);
+        const an = Number.isNaN(av) ? 0 : av;
+        const bn = Number.isNaN(bv) ? 0 : bv;
+        const cmp = an - bn;
+        return keckCountSortDirection === "asc" ? cmp : -cmp;
+    });
+
+    for (let i = 0; i < rows.length; i++) {
+        table.appendChild(rows[i]);
+    }
+
+    const btn = document.getElementById("sort-kpf-count");
+    if (btn) {
+        btn.textContent = keckCountSortDirection === "desc" ? "Sort by KPF points ↑" : "Sort by KPF points ↓";
+    }
+    keckCountSortDirection = keckCountSortDirection === "desc" ? "asc" : "desc";
+
+    applyFiltersAndPagination();
+}
+
+function parseAgeForSort(value) {
+    const v = parseFloat(value || "");
+    return Number.isFinite(v) ? v : Number.POSITIVE_INFINITY;
+}
+
+function sortRowsByApfRecent() {
+    const rows = getDataRows();
+    if (rows.length === 0) {
+        return;
+    }
+
+    sortColumn = null;
+
+    rows.sort((a, b) => {
+        const av = parseAgeForSort(a.dataset.apfAgeDays);
+        const bv = parseAgeForSort(b.dataset.apfAgeDays);
+        const cmp = av - bv;
+        return apfRecentSortDirection === "asc" ? cmp : -cmp;
+    });
+
+    for (let i = 0; i < rows.length; i++) {
+        table.appendChild(rows[i]);
+    }
+
+    const btn = document.getElementById("sort-apf-recent");
+    if (btn) {
+        btn.textContent = apfRecentSortDirection === "asc" ? "Sort by recent APF ↑" : "Sort by recent APF ↓";
+    }
+    apfRecentSortDirection = apfRecentSortDirection === "asc" ? "desc" : "asc";
+
+    applyFiltersAndPagination();
+}
+
+function sortRowsByKeckRecent() {
+    const rows = getDataRows();
+    if (rows.length === 0) {
+        return;
+    }
+
+    sortColumn = null;
+
+    rows.sort((a, b) => {
+        const av = parseAgeForSort(a.dataset.keckAgeDays);
+        const bv = parseAgeForSort(b.dataset.keckAgeDays);
+        const cmp = av - bv;
+        return keckRecentSortDirection === "asc" ? cmp : -cmp;
+    });
+
+    for (let i = 0; i < rows.length; i++) {
+        table.appendChild(rows[i]);
+    }
+
+    const btn = document.getElementById("sort-kpf-recent");
+    if (btn) {
+        btn.textContent = keckRecentSortDirection === "asc" ? "Sort by recent KPF ↑" : "Sort by recent KPF ↓";
+    }
+    keckRecentSortDirection = keckRecentSortDirection === "asc" ? "desc" : "asc";
+
+    applyFiltersAndPagination();
+}
+
+async function updateKeckRecencyFlags() {
+    const rows = getDataRows();
+    const nowMjd = mjdNow();
+    const tasks = rows.map(async (row) => {
+        const gaiaId = row.dataset.gaiaId;
+        if (!gaiaId || row.dataset.hasKeck !== "1") {
+            return;
+        }
+        const candidates = [
+            `stars/Gaia_DR3_${gaiaId}/Keck/${gaiaId}_summary.txt`,
+            `stars/Gaia_DR3_${gaiaId}/Keck/Gaia_DR3_${gaiaId}_summary.txt`
+        ];
+        let latestMjd = null;
+        let chosenSummaryText = "";
+        for (let i = 0; i < candidates.length; i++) {
+            try {
+                const resp = await fetch(candidates[i], { cache: "no-store" });
+                if (!resp.ok) {
+                    continue;
+                }
+                const txt = await resp.text();
+                latestMjd = extractLatestMjd(txt);
+                if (latestMjd !== null) {
+                    chosenSummaryText = txt;
+                    break;
+                }
+            } catch {
+                // try next candidate
+            }
+        }
+        if (latestMjd === null || !isPlausibleMjd(latestMjd, nowMjd)) {
+            row.dataset.keckRecent = "unknown";
+            row.dataset.keckRecentWeek = "unknown";
+            row.dataset.keckAgeDays = "";
+            row.dataset.keckChecked = "1";
+            row.dataset.keckCount = row.dataset.keckCount || "0";
+            return;
+        }
+        row.dataset.keckCount = String(extractEpochCount(chosenSummaryText));
+        const ageDays = nowMjd - latestMjd;
+        row.dataset.keckRecent = (ageDays >= 0 && ageDays <= RECENT_KECK_DAYS) ? "1" : "0";
+        row.dataset.keckRecentWeek = (ageDays >= 0 && ageDays <= RECENT_WEEK_DAYS) ? "1" : "0";
+        row.dataset.keckAgeDays = String(ageDays);
+        row.dataset.keckChecked = "1";
+    });
+    await Promise.allSettled(tasks);
+
+    for (let i = 0; i < rows.length; i++) {
+        const cell = rows[i].getElementsByTagName("td")[14];
+        if (cell) {
+            cell.innerHTML = renderDataProductsCell(rows[i]);
+        }
+    }
+    applyFiltersAndPagination();
+}
+
+function applyFiltersAndPagination() {
+    const rows = getDataRows();
+    const baseMatched = [];
+    const matched = [];
+
+    for (let i = 0; i < rows.length; i++) {
+        if (rowMatchesBaseFilters(rows[i])) {
+            baseMatched.push(rows[i]);
+        }
+        if (rowMatchesFilters(rows[i])) {
+            matched.push(rows[i]);
+        }
+    }
+    lastMatchedRows = matched.slice();
+    updateToggleCounts(baseMatched);
+
+    const perPage = pageSize === "all" ? matched.length : parseInt(pageSize, 10);
+    const totalPages = Math.max(1, pageSize === "all" ? 1 : Math.ceil(matched.length / perPage));
+    if (currentPage > totalPages) {
+        currentPage = totalPages;
+    }
+
+    for (let i = 0; i < rows.length; i++) {
+        rows[i].style.display = "none";
+    }
+
+    if (pageSize === "all") {
+        for (let i = 0; i < matched.length; i++) {
+            matched[i].style.display = "";
+        }
+    } else {
+        const startIdx = (currentPage - 1) * perPage;
+        const endIdx = startIdx + perPage;
+        for (let i = startIdx; i < endIdx && i < matched.length; i++) {
+            matched[i].style.display = "";
+        }
+    }
+
+    colorRows(table.rows);
+    updatePageStatus(totalPages, matched.length);
+    syncUrlState();
+}
+
+function updateSortIndicators() {
+    const headers = table.getElementsByTagName("th");
+    for (let i = 0; i < headers.length; i++) {
+        const base = headers[i].dataset.baseLabel || headers[i].textContent.replace(/\s*[▲▼]$/, "");
+        headers[i].dataset.baseLabel = base;
+        headers[i].innerHTML = base;
+        if (i === sortColumn) {
+            headers[i].innerHTML = `${base} ${sortDirection === "asc" ? "▲" : "▼"}`;
+        }
+    }
+}
+
+function prettifyHeaderText(rawText) {
+    if (typeof rawText !== "string") {
+        return rawText;
+    }
+    return headerDisplayMap[rawText] || rawText;
+}
+
+function sortTable(n) {
+    if (sortColumn === n) {
+        sortDirection = sortDirection === "asc" ? "desc" : "asc";
+    } else {
+        sortColumn = n;
+        sortDirection = "asc";
+    }
+
+    sortRowsByCurrent();
+    applyFiltersAndPagination();
+}
+
+function sortRowsByCurrent() {
+    const rows = getDataRows();
+    if (rows.length === 0 || sortColumn === null) {
+        return;
+    }
+
+    rows.sort((a, b) => {
+        const ax = a.getElementsByTagName("td")[sortColumn];
+        const bx = b.getElementsByTagName("td")[sortColumn];
+        const av = ax ? ax.textContent.trim() : "";
+        const bv = bx ? bx.textContent.trim() : "";
+        const an = parseFloat(av);
+        const bn = parseFloat(bv);
+
+        let cmp = 0;
+        if (!Number.isNaN(an) && !Number.isNaN(bn)) {
+            cmp = an - bn;
+        } else {
+            cmp = av.localeCompare(bv);
+        }
+
+        return sortDirection === "asc" ? cmp : -cmp;
+    });
+
+    for (let i = 0; i < rows.length; i++) {
+        table.appendChild(rows[i]);
+    }
+
+    updateSortIndicators();
+}
+
+function arrayToTable(tableData) {
+    table.innerHTML = "";
+    let stripes = 0;
+    const yesNoColumnsByIndex = new Map();
+    if (Array.isArray(tableData) && Array.isArray(tableData[0])) {
+        const headerRow = tableData[0];
+        for (let i = 0; i < YES_NO_PARAMS.length; i++) {
+            const colIdx = headerRow.indexOf(YES_NO_PARAMS[i].header);
+            if (colIdx >= 0) {
+                yesNoColumnsByIndex.set(colIdx, YES_NO_PARAMS[i]);
+            }
+        }
+    }
+
+    for (let i = 0; i < tableData.length; i++) {
+        const rowData = tableData[i];
+        if (!rowData || Object.keys(rowData).length === 0) {
+            continue;
+        }
+
+        const row = document.createElement("tr");
+        row.style.backgroundColor = stripes === 0 ? "#e6edf5" : "#ffffff";
+        stripes = stripes === 0 ? 1 : 0;
+
+        for (const key in rowData) {
+            let cell;
+            if (i === 0) {
+                cell = document.createElement("th");
+                const col = parseInt(key, 10);
+                cell.onclick = function () {
+                    sortTable(col);
+                };
+                cell.style.cursor = "pointer";
+            } else {
+                cell = document.createElement("td");
+            }
+
+            let text = rowData[key];
+            const colIdx = parseInt(key, 10);
+            if (i === 0) {
+                text = prettifyHeaderText(text);
+                cell.dataset.baseLabel = text;
+            }
+            if (i > 0 && colIdx === 0) {
+                const gaiaId = normalizeGaiaId(text);
+                if (gaiaId) {
+                    row.dataset.gaiaId = gaiaId;
+                }
+                text = buildGaiaNameCellHtml(text);
+            }
+            if (i > 0 && yesNoColumnsByIndex.has(colIdx)) {
+                const param = yesNoColumnsByIndex.get(colIdx);
+                const normalized = normalizeYesNoValue(text);
+                text = normalized;
+                row.dataset[param.datasetKey] = normalized;
+            }
+            if (i > 0 && colIdx !== 0 && !mediaColumns.has(colIdx) && !Number.isNaN(Number(text))) {
+                text = Number(text).toFixed(5);
+            }
+            if (i > 0 && mediaColumns.has(colIdx)) {
+                text = buildMediaCellHtml(text);
+            }
+            if (i > 0 && colIdx === 10) {
+                const gaiaId = row.dataset.gaiaId || normalizeGaiaId(rowData["0"]);
+                const hasApfRvPlot = hasNonNAContent(rowData["10"]);
+                if (!hasApfRvPlot) {
+                    text = buildApfRvPlotCellHtml(gaiaId);
+                }
+                if (!hasNonNAContent(text) && KECK_GAIA_IDS.has(gaiaId)) {
+                    text = buildKeckRvCellHtml(gaiaId);
+                }
+            }
+            if (i > 0 && colIdx === 12) {
+                const gaiaId = row.dataset.gaiaId || normalizeGaiaId(rowData["0"]);
+                text = buildHbetaCellHtml(gaiaId);
+            }
+            if (i > 0 && colIdx === 11) {
+                const gaiaId = row.dataset.gaiaId || normalizeGaiaId(rowData["0"]);
+                text = buildRvFitCellHtml(gaiaId);
+            }
+            if (i > 0 && colIdx === 14) {
+                const base = extractHrefFromAnchorHtml(text);
+                const gaiaId = row.dataset.gaiaId || "";
+                row.dataset.starBase = gaiaId ? `stars/Gaia_DR3_${gaiaId}` : base;
+                row.dataset.hasApf = (hasNonNAContent(rowData["10"]) || hasNonNAContent(rowData["11"])) ? "1" : "0";
+                row.dataset.hasSwift = (hasNonNAContent(rowData["12"]) || hasNonNAContent(rowData["13"])) ? "1" : "0";
+                row.dataset.hasKeck = KECK_GAIA_IDS.has(row.dataset.gaiaId || "") ? "1" : "0";
+                row.dataset.apfRecent = "unknown";
+                row.dataset.apfRecentWeek = "unknown";
+                row.dataset.apfAgeDays = "";
+                row.dataset.apfChecked = "0";
+                row.dataset.apfCount = "0";
+                row.dataset.keckRecent = "unknown";
+                row.dataset.keckRecentWeek = "unknown";
+                row.dataset.keckAgeDays = "";
+                row.dataset.keckChecked = "0";
+                row.dataset.keckCount = "0";
+                text = renderDataProductsCell(row);
+            }
+
+            cell.innerHTML = text;
+            row.appendChild(cell);
+        }
+
+        if (i > 0 && row.textContent.trim() === "") {
+            continue;
+        }
+        if (i > 0) {
+            for (let j = 0; j < YES_NO_PARAMS.length; j++) {
+                if (!row.dataset[YES_NO_PARAMS[j].datasetKey]) {
+                    row.dataset[YES_NO_PARAMS[j].datasetKey] = "N";
+                }
+            }
+        }
+
+        table.appendChild(row);
+    }
+
+    if (sortColumn !== null) {
+        sortRowsByCurrent();
+    }
+    applyFiltersAndPagination();
+    updateApfRecencyFlags();
+    updateKeckRecencyFlags();
+}
+
+function loadCSV(file) {
+    Papa.parse(file, {
+        complete: function (results) {
+            const normalizedData = ensureYesNoColumns(results.data);
+            const tableData = INCLUDE_KECK_ONLY_ROWS ? mergeKeckOnlyRows(normalizedData) : normalizedData;
+            arrayToTable(tableData);
+        },
+        error: function (error) {
+            table.innerHTML = "Failed to load table.";
+            console.log(error.message);
+        }
+    });
+}
+
+function starSearch() {
+    currentPage = 1;
+    applyFiltersAndPagination();
+}
+
+function searchFunction() {
+    currentPage = 1;
+    applyFiltersAndPagination();
+}
+
+function reset() {
+    const inputs = input_container.querySelectorAll("input");
+    for (let i = 0; i < inputs.length; i++) {
+        inputs[i].value = "";
+    }
+
+    const rv = document.getElementById("toggle-rv");
+    const flux = document.getElementById("toggle-flux");
+    const source = document.getElementById("toggle-source");
+    const apf = document.getElementById("toggle-apf-data");
+    const keck = document.getElementById("toggle-keck");
+    const recentApf = document.getElementById("toggle-recent-apf");
+    const recentKeck = document.getElementById("toggle-recent-keck");
+    const recentApfWeek = document.getElementById("toggle-recent-apf-week");
+    const recentKeckWeek = document.getElementById("toggle-recent-keck-week");
+    if (rv) rv.checked = false;
+    if (flux) flux.checked = false;
+    if (source) source.checked = false;
+    if (apf) apf.checked = false;
+    if (keck) keck.checked = false;
+    if (recentApf) recentApf.checked = false;
+    if (recentKeck) recentKeck.checked = false;
+    if (recentApfWeek) recentApfWeek.checked = false;
+    if (recentKeckWeek) recentKeckWeek.checked = false;
+    for (let i = 0; i < YES_NO_PARAMS.length; i++) {
+        const control = document.getElementById(YES_NO_PARAMS[i].toggleId);
+        if (control) {
+            control.value = "";
+        }
+    }
+
+    currentPage = 1;
+    applyFiltersAndPagination();
+}
+
+async function copyViewLink(btn) {
+    try {
+        await navigator.clipboard.writeText(window.location.href);
+        if (btn) {
+            const bg = btn.style.backgroundColor;
+            btn.style.backgroundColor = "#fff4b3";
+            setTimeout(() => { btn.style.backgroundColor = bg; }, 900);
+        }
+    } catch {
+        // no-op
+    }
+}
+
+function downloadSelectedCsv() {
+    const headers = Array.from(table.getElementsByTagName("th")).map(h => h.textContent.replace(/\s*[▲▼]$/, "").trim());
+    const lines = [];
+    lines.push(headers.map(toCsvCell).join(","));
+    for (let i = 0; i < lastMatchedRows.length; i++) {
+        const row = lastMatchedRows[i];
+        const tds = row.getElementsByTagName("td");
+        const vals = [];
+        for (let j = 0; j < tds.length; j++) {
+            let txt = tds[j].textContent.trim();
+            if (j === 0) {
+                txt = txt.replace(/\s*Copy$/, "").trim();
+            }
+            vals.push(toCsvCell(txt));
+        }
+        lines.push(vals.join(","));
+    }
+    const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "gaia_selected_rows.csv";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+}
+
+function writeInputs() {
+    let start_row = document.createElement("tr");
+    start_row.className = "input-row";
+    let end_row = document.createElement("tr");
+    end_row.className = "input-row";
+
+    let start = document.createElement("td");
+    start.className = "start-cell";
+    start.innerHTML = "Start:";
+    start_row.appendChild(start);
+
+    let end = document.createElement("td");
+    end.className = "start-cell";
+    end.innerHTML = "End:";
+    end_row.appendChild(end);
+
+    for (let header in headers_array) {
+        let start_cell = document.createElement("td");
+        start_cell.className = "input-cell";
+        let end_cell = document.createElement("td");
+        end_cell.className = "input-cell";
+
+        let input_start = document.createElement("input");
+        let input_end = document.createElement("input");
+
+        input_start.id = `${headers_array[header]}_start`;
+        input_end.id = `${headers_array[header]}_end`;
+
+        input_start.placeholder = `Start of ${headers_array[header]}`;
+        input_end.placeholder = `End of ${headers_array[header]}`;
+
+        start_cell.appendChild(input_start);
+        end_cell.appendChild(input_end);
+
+        start_row.appendChild(start_cell);
+        end_row.appendChild(end_cell);
+
+        input_start.addEventListener("keydown", function (event) {
+            if (event.key === "Enter") {
+                searchFunction();
+            }
+        });
+        input_start.addEventListener("input", function () {
+            currentPage = 1;
+            applyFiltersAndPagination();
+        });
+        input_end.addEventListener("keydown", function (event) {
+            if (event.key === "Enter") {
+                searchFunction();
+            }
+        });
+        input_end.addEventListener("input", function () {
+            currentPage = 1;
+            applyFiltersAndPagination();
+        });
+    }
+
+    input_container.appendChild(start_row);
+    input_container.appendChild(end_row);
+
+    let submit_text = document.createElement("div");
+    submit_text.innerHTML = "Submit query:";
+    submit_text.style.display = "inline-block";
+    input_box.appendChild(submit_text);
+
+    let submit_button = document.createElement("button");
+    submit_button.id = "submit-button";
+    submit_button.innerHTML = "Submit";
+    submit_button.addEventListener("click", function () { searchFunction(); });
+    input_box.appendChild(submit_button);
+
+    let reset_text = document.createElement("div");
+    reset_text.innerHTML = "Reset all fields:";
+    reset_text.style.display = "inline-block";
+    input_box.appendChild(reset_text);
+
+    let reset_button = document.createElement("button");
+    reset_button.id = "reset-button";
+    reset_button.innerHTML = "Reset";
+    reset_button.addEventListener("click", function () { reset(); });
+    input_box.appendChild(reset_button);
+
+    const starInput = document.getElementById("STARinput");
+    const toggleRv = document.getElementById("toggle-rv");
+    const toggleFlux = document.getElementById("toggle-flux");
+    const toggleSource = document.getElementById("toggle-source");
+    const toggleApfData = document.getElementById("toggle-apf-data");
+    const toggleKeck = document.getElementById("toggle-keck");
+    const toggleRecentApf = document.getElementById("toggle-recent-apf");
+    const toggleRecentKeck = document.getElementById("toggle-recent-keck");
+    const toggleRecentApfWeek = document.getElementById("toggle-recent-apf-week");
+    const toggleRecentKeckWeek = document.getElementById("toggle-recent-keck-week");
+    const yesNoToggleControls = YES_NO_PARAMS.map(param => document.getElementById(param.toggleId));
+    const pageSizeSelect = document.getElementById("page-size");
+    const firstBtn = document.getElementById("page-first");
+    const prevBtn = document.getElementById("page-prev");
+    const nextBtn = document.getElementById("page-next");
+    const lastBtn = document.getElementById("page-last");
+    const copyViewLinkBtn = document.getElementById("copy-view-link");
+    const downloadSelectedBtn = document.getElementById("download-selected");
+    const sortApfCountBtn = document.getElementById("sort-apf-count");
+    const sortKeckCountBtn = document.getElementById("sort-kpf-count");
+    const sortApfRecentBtn = document.getElementById("sort-apf-recent");
+    const sortKeckRecentBtn = document.getElementById("sort-kpf-recent");
+
+    suppressUrlSync = true;
+    if (starInput) {
+        starInput.value = initialState.q;
+    }
+    if (toggleRv) toggleRv.checked = initialState.rv;
+    if (toggleFlux) toggleFlux.checked = initialState.flux;
+    if (toggleSource) toggleSource.checked = initialState.source;
+    if (toggleApfData) toggleApfData.checked = initialState.apf;
+    if (toggleKeck) toggleKeck.checked = initialState.keck;
+    if (toggleRecentApf) toggleRecentApf.checked = initialState.rapf;
+    if (toggleRecentKeck) toggleRecentKeck.checked = initialState.rkeck;
+    if (toggleRecentApfWeek) toggleRecentApfWeek.checked = initialState.w7apf;
+    if (toggleRecentKeckWeek) toggleRecentKeckWeek.checked = initialState.w7keck;
+    for (let i = 0; i < YES_NO_PARAMS.length; i++) {
+        if (yesNoToggleControls[i] && typeof yesNoToggleControls[i].value !== "undefined") {
+            yesNoToggleControls[i].value = initialState[YES_NO_PARAMS[i].datasetKey] || "";
+        }
+    }
+    if (pageSizeSelect && ["50", "100", "all"].includes(initialState.rows)) {
+        pageSizeSelect.value = initialState.rows;
+        pageSize = initialState.rows;
+    }
+    if (!Number.isNaN(initialState.page) && initialState.page > 0) {
+        currentPage = initialState.page;
+    }
+    if (initialState.sort !== null && !Number.isNaN(parseInt(initialState.sort, 10))) {
+        sortColumn = parseInt(initialState.sort, 10);
+        sortDirection = initialState.dir === "desc" ? "desc" : "asc";
+    }
+    for (let i = 0; i < headers_array.length; i++) {
+        const label = headers_array[i];
+        const start = document.getElementById(`${label}_start`);
+        const end = document.getElementById(`${label}_end`);
+        if (start && end && initialState.ranges[label]) {
+            start.value = initialState.ranges[label][0];
+            end.value = initialState.ranges[label][1];
+        }
+    }
+    suppressUrlSync = false;
+
+    starInput.addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
+            starSearch();
+        }
+    });
+    starInput.addEventListener("input", function () {
+        currentPage = 1;
+        applyFiltersAndPagination();
+    });
+
+    if (toggleRv) toggleRv.addEventListener("change", () => { currentPage = 1; applyFiltersAndPagination(); });
+    if (toggleFlux) toggleFlux.addEventListener("change", () => { currentPage = 1; applyFiltersAndPagination(); });
+    if (toggleSource) toggleSource.addEventListener("change", () => { currentPage = 1; applyFiltersAndPagination(); });
+    if (toggleApfData) toggleApfData.addEventListener("change", () => { currentPage = 1; applyFiltersAndPagination(); });
+    if (toggleKeck) toggleKeck.addEventListener("change", () => { currentPage = 1; applyFiltersAndPagination(); });
+    if (toggleRecentApf) toggleRecentApf.addEventListener("change", () => { currentPage = 1; applyFiltersAndPagination(); });
+    if (toggleRecentKeck) toggleRecentKeck.addEventListener("change", () => { currentPage = 1; applyFiltersAndPagination(); });
+    if (toggleRecentApfWeek) toggleRecentApfWeek.addEventListener("change", () => { currentPage = 1; applyFiltersAndPagination(); });
+    if (toggleRecentKeckWeek) toggleRecentKeckWeek.addEventListener("change", () => { currentPage = 1; applyFiltersAndPagination(); });
+    for (let i = 0; i < yesNoToggleControls.length; i++) {
+        if (yesNoToggleControls[i]) {
+            yesNoToggleControls[i].addEventListener("change", () => { currentPage = 1; applyFiltersAndPagination(); });
+        }
+    }
+
+    if (pageSizeSelect) {
+        pageSizeSelect.addEventListener("change", function () {
+            pageSize = this.value;
+            currentPage = 1;
+            applyFiltersAndPagination();
+        });
+    }
+
+    if (prevBtn) {
+        prevBtn.addEventListener("click", function () {
+            if (currentPage > 1) {
+                currentPage -= 1;
+                applyFiltersAndPagination();
+            }
+        });
+    }
+
+    if (firstBtn) {
+        firstBtn.addEventListener("click", function () {
+            currentPage = 1;
+            applyFiltersAndPagination();
+        });
+    }
+
+    if (nextBtn) {
+        nextBtn.addEventListener("click", function () {
+            const rows = getDataRows();
+            const matched = rows.filter(r => rowMatchesFilters(r));
+            const perPage = pageSize === "all" ? matched.length : parseInt(pageSize, 10);
+            const totalPages = Math.max(1, pageSize === "all" ? 1 : Math.ceil(matched.length / perPage));
+            if (currentPage < totalPages) {
+                currentPage += 1;
+                applyFiltersAndPagination();
+            }
+        });
+    }
+
+    if (lastBtn) {
+        lastBtn.addEventListener("click", function () {
+            const rows = getDataRows();
+            const matched = rows.filter(r => rowMatchesFilters(r));
+            const perPage = pageSize === "all" ? matched.length : parseInt(pageSize, 10);
+            const totalPages = Math.max(1, pageSize === "all" ? 1 : Math.ceil(matched.length / perPage));
+            currentPage = totalPages;
+            applyFiltersAndPagination();
+        });
+    }
+
+    if (copyViewLinkBtn) {
+        copyViewLinkBtn.addEventListener("click", function () {
+            copyViewLink(copyViewLinkBtn);
+        });
+    }
+
+    if (downloadSelectedBtn) {
+        downloadSelectedBtn.addEventListener("click", function () {
+            downloadSelectedCsv();
+        });
+    }
+
+    if (sortApfCountBtn) {
+        sortApfCountBtn.addEventListener("click", function () {
+            sortRowsByApfCount();
+        });
+    }
+
+    if (sortKeckCountBtn) {
+        sortKeckCountBtn.addEventListener("click", function () {
+            sortRowsByKeckCount();
+        });
+    }
+
+    if (sortApfRecentBtn) {
+        sortApfRecentBtn.addEventListener("click", function () {
+            sortRowsByApfRecent();
+        });
+    }
+
+    if (sortKeckRecentBtn) {
+        sortKeckRecentBtn.addEventListener("click", function () {
+            sortRowsByKeckRecent();
+        });
+    }
+}
+
+Promise.all([
+    fetch("tables/data.csv")
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`Failed to load CSV: ${response.status}`);
+            }
+            considerLastUpdated(response.headers.get("last-modified"));
+            return response.text();
+        }),
+    loadOptionalKeckCatalog(),
+    loadOptionalSimbadCatalog(),
+    refreshLastUpdatedFromWebsiteFiles()
+])
+    .then(([data]) => {
+        writeInputs();
+        loadCSV(data);
+    })
+    .catch(() => {
+        input_container.innerHTML = "Failed to load table.";
+        if (last_updated) {
+            last_updated.innerHTML = "Last updated: unavailable";
+        }
+    });
+
+table.addEventListener("click", async function (event) {
+    const btn = event.target.closest(".copy-gaia-btn");
+    if (!btn) {
+        return;
+    }
+    event.preventDefault();
+    let value = btn.getAttribute("data-copy") || "";
+    const rowText = btn.parentElement ? btn.parentElement.textContent : "";
+    const idMatch = rowText.match(/(\d{8,})/);
+    if (idMatch && idMatch[1]) {
+        value = idMatch[1];
+    }
+    value = String(value).replace(/\D/g, "");
+    if (!value) {
+        return;
+    }
+    try {
+        await navigator.clipboard.writeText(value);
+        const originalBg = btn.style.backgroundColor;
+        const originalColor = btn.style.color;
+        btn.style.backgroundColor = "#fff4b3";
+        btn.style.color = "#111";
+        setTimeout(() => {
+            btn.style.backgroundColor = originalBg;
+            btn.style.color = originalColor;
+        }, 900);
+    } catch {
+        const originalBg = btn.style.backgroundColor;
+        const originalColor = btn.style.color;
+        btn.style.backgroundColor = "#b71c1c";
+        btn.style.color = "#fff";
+        setTimeout(() => {
+            btn.style.backgroundColor = originalBg;
+            btn.style.color = originalColor;
+        }, 900);
+    }
+});
+setInterval(renderLastUpdated, 60000);
+
+document.addEventListener("keydown", function (event) {
+    const tag = (event.target && event.target.tagName) ? event.target.tagName.toLowerCase() : "";
+    const typing = tag === "input" || tag === "textarea";
+    const starInput = document.getElementById("STARinput");
+
+    if (event.key === "/" && !typing) {
+        event.preventDefault();
+        if (starInput) starInput.focus();
+        return;
+    }
+
+    if (event.key === "Escape") {
+        if (starInput) {
+            starInput.value = "";
+            currentPage = 1;
+            applyFiltersAndPagination();
+        }
+        return;
+    }
+
+    if (typing) {
+        return;
+    }
+
+    if (event.key.toLowerCase() === "n") {
+        const nextBtn = document.getElementById("page-next");
+        if (nextBtn) nextBtn.click();
+        return;
+    }
+    if (event.key.toLowerCase() === "p") {
+        const prevBtn = document.getElementById("page-prev");
+        if (prevBtn) prevBtn.click();
+    }
+});

--- a/website/rv/style.css
+++ b/website/rv/style.css
@@ -1,0 +1,414 @@
+:root {
+    --bg: #ffffff;
+    --text: #111111;
+    --muted-text: #444444;
+    --header-bg: #9fc4e8;
+    --header-text: #111111;
+    --border: #cfd8e3;
+    --row-even: #e6edf5;
+    --row-odd: #ffffff;
+    --panel-bg: #f6f8fb;
+    --panel-border: #d6dde7;
+    --input-bg: #ffffff;
+}
+
+body.dark-mode {
+    --bg: #101419;
+    --text: #e6edf3;
+    --muted-text: #b8c0cc;
+    --header-bg: #2d4358;
+    --header-text: #e6edf3;
+    --border: #33404f;
+    --row-even: #1a222c;
+    --row-odd: #121920;
+    --panel-bg: #17202a;
+    --panel-border: #33404f;
+    --input-bg: #0f151c;
+}
+
+html {
+    height: 100%;
+    width: 100%;
+}
+body {
+    min-height:100%;
+    max-width: 100%;
+    overflow: scroll;
+    background: var(--bg);
+    color: var(--text);
+}
+
+.site-header {
+    text-align: center;
+    padding: 8px 0 4px 0;
+}
+
+.site-header h1 {
+    margin: 0;
+}
+
+table {
+    table-layout: fixed;
+    margin:1%;
+    border-collapse: collapse;
+}
+td, th {
+    word-wrap: normal;
+}
+td {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width:fit-content;
+    height:auto;
+}
+th {
+    font-size: medium;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background-color: var(--header-bg);
+    color: var(--header-text);
+}
+
+#csv-container td,
+#csv-container th {
+    border: 1px solid var(--border);
+}
+
+#csv-container td {
+    vertical-align: middle;
+    padding: 6px 6px;
+}
+
+/* Keep science plot columns readable */
+#csv-container th:nth-child(11),
+#csv-container td:nth-child(11) {
+    min-width: 260px;
+}
+
+/* RV fit column width */
+#csv-container th:nth-child(12),
+#csv-container td:nth-child(12) {
+    min-width: 300px;
+}
+
+#csv-container th:nth-child(9),
+#csv-container td:nth-child(9),
+#csv-container th:nth-child(10),
+#csv-container td:nth-child(10) {
+    min-width: 110px;
+}
+
+#csv-container th:nth-child(13),
+#csv-container td:nth-child(13) {
+    min-width: 230px;
+}
+
+#csv-container th:nth-child(14),
+#csv-container td:nth-child(14) {
+    min-width: 260px;
+}
+
+/* Hide UV image column in main table view */
+#csv-container th:nth-child(14),
+#csv-container td:nth-child(14) {
+    display: none;
+}
+
+#csv-container td:nth-child(11) img,
+#csv-container td:nth-child(12) img,
+#csv-container td:nth-child(13) img,
+#csv-container td:nth-child(14) img {
+    width: 100%;
+    max-width: 300px;
+    height: auto;
+    display: block;
+    margin: 0 auto;
+}
+
+img {
+    width:100%;
+    height:auto;
+}
+
+#input-box {
+    text-align: center;
+    font-size: 17px;
+    line-height: 1.25;
+}
+
+#input-box td,
+#input-box input,
+#input-box button,
+#input-box div {
+    font-size: 17px;
+}
+
+#team-line {
+    margin-top: 2px;
+    font-size: 16px;
+}
+
+.input-container {
+    width: auto;
+    display:inline;
+    float:left;
+    table-layout:fixed;
+}
+
+.start-cell {
+    width:3%;
+}
+
+.input-cell {
+    width:10.444%;
+}
+
+#submit-button {
+    display: inline-block;
+    margin: auto 1%;
+    width:fit-content;
+}
+
+#reset-button {
+    display: inline-block;
+    margin: auto 1%;
+    width:fit-content;
+}
+
+input {
+    width:100%;
+    background: var(--input-bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+}
+
+#last-updated {
+    margin: 8px 1% 4px 1%;
+    font-size: 14px;
+    color: var(--muted-text);
+    font-weight: 600;
+}
+
+#freshness-badge {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 12px;
+    font-weight: 700;
+}
+
+#freshness-badge.fresh {
+    background: #d9f2d9;
+    color: #1f5c1f;
+}
+
+#freshness-badge.stale {
+    background: #fff1cc;
+    color: #7a5a00;
+}
+
+#freshness-badge.old {
+    background: #fbd7d7;
+    color: #7a1e1e;
+}
+
+#page-credit {
+    margin: 0 1% 18px 1%;
+    padding: 8px 10px;
+    font-size: 14px;
+    color: var(--text);
+    text-align: left;
+    line-height: 1.35;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 6px;
+}
+
+#sample-paper-link {
+    font-weight: 600;
+}
+
+.credit-label {
+    color: var(--muted-text);
+    font-weight: 600;
+}
+
+.credit-value {
+    color: var(--text);
+}
+
+#table-controls {
+    margin: 2px 1% 6px 1%;
+    font-size: 17px;
+    display: flex;
+    width: calc(100% - 2%);
+    justify-content: flex-start;
+}
+
+#table-controls label,
+#query-toggles-row label {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+
+#query-toggles-row select {
+    width: auto;
+    min-width: 62px;
+}
+
+#table-controls input[type="checkbox"],
+#query-toggles-row input[type="checkbox"] {
+    width: auto;
+    margin: 0;
+    transform: scale(1.15);
+    transform-origin: center;
+}
+
+#table-controls select,
+#table-controls button {
+    margin: 0;
+    font-size: 17px;
+    line-height: 1.2;
+    background: var(--input-bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+}
+
+#table-controls label,
+#page-status,
+.toggle-title {
+    font-size: 17px;
+}
+
+#controls-left {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    display: flex;
+    width: 100%;
+}
+
+#pagination-row {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 8px;
+    width: 100%;
+}
+
+#action-row {
+    margin-top: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 8px;
+    width: 100%;
+}
+
+#query-toggles-row {
+    margin: 6px 0 0 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    width: 100%;
+}
+
+.toggle-row {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 12px;
+    width: 100%;
+}
+
+.toggle-tile {
+    display: inline-flex !important;
+    align-items: center !important;
+    gap: 5px;
+}
+
+.toggle-tile input[type="checkbox"] {
+    margin-top: 0 !important;
+}
+
+.toggle-tile .toggle-count {
+    margin: 0;
+}
+
+.toggle-count {
+    color: #4f5b66;
+    font-size: 15px;
+}
+
+.control-action {
+    min-width: 110px;
+}
+
+.copy-gaia-btn {
+    position: static;
+    margin: 0;
+    display: inline-block;
+    padding: 0 6px;
+    font-size: 12px;
+    line-height: 1.2;
+    cursor: pointer;
+    min-width: 48px;
+    box-sizing: border-box;
+    text-align: center;
+    white-space: nowrap;
+}
+
+.product-links {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+}
+
+.product-line {
+    display: inline-flex;
+    align-items: baseline;
+}
+
+.product-links a {
+    font-weight: 600;
+}
+
+.gaia-id-wrap {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 44px;
+    text-align: center;
+}
+
+.gaia-id-text {
+    display: inline-block;
+    line-height: 1.2;
+}
+
+.apf-state {
+    font-size: 11px;
+    margin-left: 3px;
+    font-weight: 700;
+}
+
+.apf-recent { color: #1f7a1f; }
+.apf-old { color: #8a5a00; }
+.apf-unknown { color: #666; }
+
+.theme-label {
+    margin-left: 6px;
+    margin-right: 2px;
+}
+
+.control-gap {
+    display: inline-block;
+    width: 10px;
+}

--- a/website/rv/tables/README.md
+++ b/website/rv/tables/README.md
@@ -1,0 +1,20 @@
+# Website tables
+
+Required files (loaded by `script.js`):
+
+| File | Required |
+|------|----------|
+| `data.csv` | Yes |
+| `keck_targets.csv` | Yes (may be empty header + rows) |
+
+Optional:
+
+| File | Purpose |
+|------|---------|
+| `simbad_gaia_ids.csv` | SIMBAD links in Gaia ID column |
+
+Seed from the legacy site once:
+
+```bash
+bash scripts/bootstrap_website_tables.sh
+```


### PR DESCRIPTION
## Summary

- Add versioned static site under `website/rv/` (`index.html`, `script.js`, `style.css`) for the Dark Hunters Gaia Binary Explorer.
- Add deploy scripts: `setup_website.sh` (install static files), `bootstrap_website_tables.sh` (seed `tables/` from legacy site), `populate_website.sh` (wrapper around batch sync).
- Document server workflow in `docs/website.md`.
- Update `batch_fits_plots_sync.sh`: default `WEB_ROOT=/var/www/html/darkhunter/rv`, add `RUN_FITS=0` to skip Keplerian refits when refreshing plots/staging only.
- Fix frontend paths: relative data-product links, auto-load APF RV plots from `stars/.../Gaia_DR3_<id>_rv_plot.png`, display names for new mass columns.

## Test plan

- [ ] Merge PR and `git pull` on ziggy
- [ ] `bash scripts/setup_website.sh`
- [ ] `LEGACY_WEB_ROOT=/var/www/html/ktaggart/rv_website_v1 bash scripts/bootstrap_website_tables.sh`
- [ ] `WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 MIN_POINTS=5 bash scripts/populate_website.sh` (canary with `STAR_ID=...`)
- [ ] Open `https://ziggy.ucolick.org/darkhunter/rv/` and verify table loads, RV curve/fit images, and data-product links


Made with [Cursor](https://cursor.com)