### PR TITLE
RV multi-fit plots, bad-RV filter, Hβ stacks, and cron

### DIFF
--- a/darkhunter_rv/rv_keplerian_plots.py
+++ b/darkhunter_rv/rv_keplerian_plots.py
@@ -1,0 +1,441 @@
+"""Keplerian RV fit figures (data-only, multi-model, residuals)."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy.time import Time
+from matplotlib.offsetbox import AnnotationBbox, HPacker, TextArea, VPacker
+from matplotlib.ticker import AutoMinorLocator
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fit_apf_rv_keplerian import RVPoint
+
+
+def _fitmod():
+    import fit_apf_rv_keplerian as m
+
+    return m
+
+from darkhunter_rv.rv_point_filters import rv_value_is_valid
+
+FIT_VARIANT_ORDER = ("free", "fix_period", "fix_ecc", "fix_period_ecc")
+FIT_VARIANT_STYLE: Dict[str, Tuple[str, str]] = {
+    "free": ("tab:blue", "-"),
+    "fix_period": ("tab:orange", "--"),
+    "fix_ecc": ("tab:green", "-."),
+    "fix_period_ecc": ("tab:red", ":"),
+}
+FIT_VARIANT_LABEL = {
+    "free": "RV only",
+    "fix_period": "P fixed (Gaia)",
+    "fix_ecc": "e fixed (Gaia)",
+    "fix_period_ecc": "P & e fixed (Gaia)",
+}
+
+TEL_MARKER = {"APF": "o", "KPF": "s", "GHOST": "p", "MAROON-X": "x"}
+
+
+def filter_valid_points(points: Sequence["RVPoint"]) -> List["RVPoint"]:
+    return [p for p in points if rv_value_is_valid(p.rv)]
+
+
+def our_telescope_points(points: Sequence["RVPoint"]) -> List["RVPoint"]:
+    return [p for p in points if not p.is_literature]
+
+
+def _time_window(
+    t: np.ndarray,
+    report: dict,
+    *,
+    include_future: bool,
+) -> Tuple[float, float, float]:
+    t_ref = float(report["t_ref_mjd"])
+    now_mjd = float(report.get("now_mjd", Time.now().mjd))
+    t_span = float(np.ptp(t) + 1.0) if t.size else 1.0
+    t_start = float(np.min(t) - 0.02 * t_span) if t.size else now_mjd - 30.0
+
+    t_next_max = float(report.get("next_rv_max_mjd", np.nan))
+    t_next_min = float(report.get("next_rv_min_mjd", np.nan))
+    next_event = t_next_min
+    if np.isfinite(t_next_max) and np.isfinite(t_next_min):
+        next_event = t_next_max if t_next_max <= t_next_min else t_next_min
+
+    t_end_candidates = [float(np.max(t) + 0.02 * t_span) if t.size else now_mjd + 30.0]
+    if include_future:
+        t_end_candidates.append(now_mjd)
+        if np.isfinite(next_event):
+            t_end_candidates.append(next_event)
+        obs_win = report.get("observability_window")
+        if isinstance(obs_win, dict):
+            try:
+                obs_end = float(Time(obs_win["end_date"], format="iso", scale="utc").mjd) + 1.0
+                t_end_candidates.append(obs_end)
+            except Exception:
+                pass
+    t_end = float(max(t_end_candidates))
+    return t_start, t_end, now_mjd
+
+
+def _observability_span(report: dict) -> Tuple[Optional[float], Optional[float], Optional[dict]]:
+    obs_win = report.get("observability_window")
+    if not isinstance(obs_win, dict):
+        return None, None, None
+    try:
+        obs_start = float(Time(obs_win["start_date"], format="iso", scale="utc").mjd)
+        obs_end = float(Time(obs_win["end_date"], format="iso", scale="utc").mjd) + 1.0
+        return obs_start, obs_end, obs_win
+    except Exception:
+        return None, None, None
+
+
+def _shade_apf_window(ax, t_start: float, t_end: float, report: dict) -> None:
+    obs_start, obs_end, obs_win = _observability_span(report)
+    if obs_start is None or obs_end is None or obs_win is None:
+        return
+    left = max(t_start, obs_start)
+    right = min(t_end, obs_end)
+    if right <= left:
+        return
+    ax.axvspan(left, right, color="tab:blue", alpha=0.12, zorder=0)
+    ax.text(
+        0.985,
+        0.02,
+        f"APF window {obs_win['start_date']} to {obs_win['end_date']}",
+        transform=ax.transAxes,
+        fontsize=8.5,
+        color="tab:blue",
+        ha="right",
+        va="bottom",
+        bbox=dict(facecolor="white", edgecolor="tab:blue", alpha=0.85, boxstyle="round,pad=0.2"),
+    )
+
+
+def _mark_today(ax, now_mjd: float, y_top_in: float) -> None:
+    ax.axvline(now_mjd, color="0.35", ls="--", lw=1.2, alpha=0.9)
+    ax.text(
+        now_mjd,
+        y_top_in,
+        "Today",
+        fontsize=9,
+        color="0.25",
+        ha="right",
+        va="top",
+        bbox=dict(facecolor="0.93", edgecolor="0.5", alpha=0.95, boxstyle="round,pad=0.15"),
+    )
+
+
+def _plot_points(ax, points: Sequence["RVPoint"], *, include_literature: bool) -> bool:
+    plotted = False
+    t = np.array([p.mjd for p in points], dtype=float)
+    y = np.array([p.rv for p in points], dtype=float)
+    yerr = np.array([p.rms for p in points], dtype=float)
+
+    for tel, marker in TEL_MARKER.items():
+        idx = [
+            i
+            for i, p in enumerate(points)
+            if (not p.is_literature and str(p.telescope).upper() == tel)
+        ]
+        if not idx:
+            continue
+        ax.errorbar(
+            t[idx],
+            y[idx],
+            yerr=yerr[idx],
+            fmt=marker,
+            ms=5,
+            lw=1,
+            capsize=2,
+            color="black",
+            ecolor="black",
+            mec="black",
+            mfc=("black" if marker != "x" else "none"),
+            label=tel,
+        )
+        plotted = True
+
+    if include_literature:
+        idx_lit = [i for i, p in enumerate(points) if p.is_literature]
+        if idx_lit:
+            ax.errorbar(
+                t[idx_lit],
+                y[idx_lit],
+                yerr=yerr[idx_lit],
+                fmt="D",
+                ms=4.8,
+                lw=1,
+                capsize=2,
+                color="0.35",
+                ecolor="0.35",
+                mec="0.35",
+                mfc="0.35",
+                label="Literature",
+            )
+            plotted = True
+
+    if not plotted and len(points):
+        ax.errorbar(t, y, yerr=yerr, fmt="o", ms=5, lw=1, capsize=2, color="black")
+        plotted = True
+    return plotted
+
+
+def _y_limits_data_and_models(
+    t: np.ndarray,
+    y: np.ndarray,
+    model_curves: Sequence[np.ndarray],
+) -> Tuple[float, float]:
+    y_low = float(np.min(y))
+    y_high = float(np.max(y))
+    for curve in model_curves:
+        if curve.size:
+            y_low = min(y_low, float(np.min(curve)))
+            y_high = max(y_high, float(np.max(curve)))
+    y_pad = max(1.0, 0.08 * (y_high - y_low if y_high > y_low else 1.0))
+    return y_low - y_pad, y_high + y_pad
+
+
+def _variant_annotation(rep: dict) -> str:
+    m = _fitmod()
+    p = int(round(float(rep["P_days"])))
+    e = float(rep["e"])
+    fm = float(
+        rep.get("mass_function_msun", m.mass_function_msun(rep["P_days"], rep["K_kms"], rep["e"]))
+    )
+    return f"P={p} d, e={e:.3f}, f(M)={fm:.4f} M☉"
+
+
+def plot_rv_data_only(
+    summary_path: Path,
+    points: Sequence["RVPoint"],
+    report: dict,
+    out_png: Path,
+    *,
+    title_prefix: str = "RV data",
+) -> None:
+    """Our telescope epochs only; Today + APF window markers."""
+    pts = our_telescope_points(points)
+    if len(pts) < 2:
+        raise ValueError("need at least 2 our-telescope points for data plot")
+
+    t = np.array([p.mjd for p in pts], dtype=float)
+    y = np.array([p.rv for p in pts], dtype=float)
+    t_start, t_end, now_mjd = _time_window(t, report, include_future=True)
+
+    fig, ax = plt.subplots(figsize=(10.5, 4.9))
+    _shade_apf_window(ax, t_start, t_end, report)
+    _plot_points(ax, pts, include_literature=False)
+
+    y_lim = _y_limits_data_and_models(t, y, [])
+    ax.set_ylim(*y_lim)
+    y_top_in = y_lim[1] - 0.02 * (y_lim[1] - y_lim[0])
+    _mark_today(ax, now_mjd, y_top_in)
+
+    sid = _fitmod().parse_object_id_from_summary(summary_path) or summary_path.stem.replace("_summary", "")
+    ax.set_xlabel("MJD")
+    ax.set_ylabel("RV (km/s)")
+    ax.set_title(f"{title_prefix}: Gaia DR3 {sid}")
+    ax.set_xlim(t_start, t_end)
+    ax.grid(alpha=0.25)
+    ax.xaxis.set_minor_locator(AutoMinorLocator())
+    ax.yaxis.set_minor_locator(AutoMinorLocator())
+    ax.tick_params(axis="both", which="major", direction="in", length=7, width=1.1, top=True, right=True)
+    ax.tick_params(axis="both", which="minor", direction="in", length=3.5, width=0.9, top=True, right=True)
+    ax.legend(loc="best", fontsize=8.5)
+
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=180, bbox_inches="tight", pad_inches=0.06)
+    plt.close(fig)
+
+
+def plot_multi_fit(
+    summary_path: Path,
+    points: Sequence["RVPoint"],
+    fit_variants: Dict[str, Tuple[np.ndarray, dict]],
+    report: dict,
+    out_png: Path,
+    *,
+    m1_msun: Optional[float] = None,
+) -> None:
+    """All epochs (incl. literature) with up to four Keplerian models."""
+    if len(points) < 2:
+        raise ValueError("need at least 2 points")
+
+    t = np.array([p.mjd for p in points], dtype=float)
+    y = np.array([p.rv for p in points], dtype=float)
+    t_ref = float(report["t_ref_mjd"])
+    t_start, t_end, now_mjd = _time_window(t, report, include_future=True)
+    t_dense = np.linspace(t_start, t_end, 2000)
+
+    curves: List[np.ndarray] = []
+    fig, ax = plt.subplots(figsize=(10.8, 5.2))
+    _shade_apf_window(ax, t_start, t_end, report)
+    _plot_points(ax, points, include_literature=True)
+
+    for key in FIT_VARIANT_ORDER:
+        if key not in fit_variants:
+            continue
+        params, vrep = fit_variants[key]
+        y_dense = _fitmod().rv_model(params, t_dense, t_ref)
+        curves.append(y_dense)
+        color, ls = FIT_VARIANT_STYLE[key]
+        label = f"{FIT_VARIANT_LABEL[key]} ({_variant_annotation(vrep)})"
+        ax.plot(t_dense, y_dense, ls=ls, lw=1.8, color=color, alpha=0.92, label=label)
+
+    y_lim = _y_limits_data_and_models(t, y, curves)
+    ax.set_ylim(*y_lim)
+    y_top_in = y_lim[1] - 0.02 * (y_lim[1] - y_lim[0])
+    _mark_today(ax, now_mjd, y_top_in)
+
+    # Nearest upcoming extremum from primary (free) fit if present.
+    primary = fit_variants.get("free")
+    if primary is not None:
+        params0, rep0 = primary
+        p_days = float(rep0["P_days"])
+        t_next_max, t_next_min = _fitmod().next_extrema_after(params0, t_ref, p_days, now_mjd)
+        next_event = t_next_max if (t_next_max is not None and (t_next_min is None or t_next_max <= t_next_min)) else t_next_min
+        if next_event is not None:
+            ax.axvline(next_event, color="tab:red", ls="--", lw=1.2, alpha=0.9)
+
+    sid = _fitmod().parse_object_id_from_summary(summary_path) or summary_path.stem.replace("_summary", "")
+    ax.set_xlabel("MJD")
+    ax.set_ylabel("RV (km/s)")
+    ax.set_title(f"Keplerian fits: Gaia DR3 {sid}")
+    ax.set_xlim(t_start, t_end)
+    ax.grid(alpha=0.25)
+    ax.legend(loc="best", fontsize=7.5)
+    ax.xaxis.set_minor_locator(AutoMinorLocator())
+    ax.yaxis.set_minor_locator(AutoMinorLocator())
+
+    if m1_msun is not None and primary is not None:
+        _rep0 = primary[1]
+        fm = float(_rep0.get("mass_function_msun", 0.0))
+        m2sini = _fitmod().solve_m2sini_msun(fm, float(m1_msun)) if fm > 0 else None
+        if m2sini is not None:
+            ax.text(
+                0.015,
+                0.98,
+                f"M₁={m1_msun:.4f} M☉   M₂ sin i={m2sini:.4f} M☉",
+                transform=ax.transAxes,
+                fontsize=9.0,
+                va="top",
+                ha="left",
+                bbox=dict(facecolor="white", edgecolor="black", alpha=0.95, boxstyle="round,pad=0.2"),
+            )
+
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=180, bbox_inches="tight", pad_inches=0.06)
+    plt.close(fig)
+
+
+def _residual_ylim(
+    y: np.ndarray,
+    yerr: np.ndarray,
+    residuals: Sequence[np.ndarray],
+) -> Tuple[float, float]:
+    scales = [float(np.nanmax(np.abs(y)))]
+    if yerr.size:
+        scales.append(float(np.nanmax(yerr[np.isfinite(yerr)])))
+    for r in residuals:
+        if r.size:
+            scales.append(float(np.nanmax(np.abs(r[np.isfinite(r)]))))
+    spread = max(scales) if scales else 1.0
+    half = min(5.0, max(0.4, 1.6 * spread))
+    return -half, half
+
+
+def plot_fit_residuals(
+    summary_path: Path,
+    points: Sequence["RVPoint"],
+    fit_variants: Dict[str, Tuple[np.ndarray, dict]],
+    report: dict,
+    out_png: Path,
+) -> None:
+    if "free" not in fit_variants:
+        raise ValueError("residual plot requires a free RV fit")
+    if len(points) < 2:
+        raise ValueError("need at least 2 points")
+
+    t = np.array([p.mjd for p in points], dtype=float)
+    y = np.array([p.rv for p in points], dtype=float)
+    yerr = np.array([p.rms for p in points], dtype=float)
+    t_ref = float(report["t_ref_mjd"])
+    params_free, rep_free = fit_variants["free"]
+    t_start, t_end, now_mjd = _time_window(t, report, include_future=True)
+    t_dense = np.linspace(t_start, t_end, 2000)
+
+    rv_model = _fitmod().rv_model
+    model_free_obs = rv_model(params_free, t, t_ref)
+    model_free_dense = rv_model(params_free, t_dense, t_ref)
+    resid_map: Dict[str, np.ndarray] = {}
+    dense_map: Dict[str, np.ndarray] = {}
+    for key in FIT_VARIANT_ORDER:
+        if key not in fit_variants:
+            continue
+        params, _vrep = fit_variants[key]
+        model_obs = rv_model(params, t, t_ref)
+        resid_map[key] = y - model_obs
+        dense_map[key] = rv_model(params, t_dense, t_ref) - model_free_dense
+
+    fig, (ax_top, ax_bot) = plt.subplots(
+        2, 1, figsize=(10.8, 6.4), sharex=True, gridspec_kw={"height_ratios": [2.2, 1.0], "hspace": 0.08}
+    )
+    _shade_apf_window(ax_top, t_start, t_end, report)
+    _plot_points(ax_top, points, include_literature=True)
+    ax_top.plot(t_dense, model_free_dense, "-", color=FIT_VARIANT_STYLE["free"][0], lw=2.0, label=FIT_VARIANT_LABEL["free"])
+    y_lim = _y_limits_data_and_models(t, y, [model_free_dense])
+    ax_top.set_ylim(*y_lim)
+    y_top_in = y_lim[1] - 0.02 * (y_lim[1] - y_lim[0])
+    _mark_today(ax_top, now_mjd, y_top_in)
+    sid = _fitmod().parse_object_id_from_summary(summary_path) or summary_path.stem.replace("_summary", "")
+    ax_top.set_ylabel("RV (km/s)")
+    ax_top.set_title(f"Keplerian fits + residuals: Gaia DR3 {sid}")
+    ax_top.grid(alpha=0.25)
+    ax_top.legend(loc="best", fontsize=8)
+
+    ax_bot.axhline(0.0, color="0.4", lw=1.0)
+    ax_bot.errorbar(
+        t,
+        y - model_free_obs,
+        yerr=yerr,
+        fmt="o",
+        ms=4,
+        capsize=2,
+        color="black",
+        ecolor="black",
+        label="Data − RV-only",
+    )
+    for key in FIT_VARIANT_ORDER:
+        if key == "free" or key not in fit_variants:
+            continue
+        color, ls = FIT_VARIANT_STYLE[key]
+        ax_bot.plot(
+            t_dense,
+            dense_map[key],
+            ls=ls,
+            lw=1.4,
+            color=color,
+            alpha=0.9,
+            label=f"{FIT_VARIANT_LABEL[key]} − RV-only",
+        )
+
+    r_ylim = _residual_ylim(y - model_free_obs, yerr, list(resid_map.values()))
+    ax_bot.set_ylim(*r_ylim)
+    ax_bot.set_xlabel("MJD")
+    ax_bot.set_ylabel("ΔRV (km/s)")
+    ax_bot.set_xlim(t_start, t_end)
+    ax_bot.grid(alpha=0.25)
+    ax_bot.legend(loc="best", fontsize=7)
+
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=180, bbox_inches="tight", pad_inches=0.06)
+    plt.close(fig)

--- a/darkhunter_rv/rv_point_filters.py
+++ b/darkhunter_rv/rv_point_filters.py
@@ -1,0 +1,16 @@
+"""Shared RV epoch validity rules."""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Legacy sentinels and other non-physical RVs (e.g. -9999 km/s).
+RV_ABS_MAX_KMS = 5000.0
+
+
+def rv_value_is_valid(rv: float) -> bool:
+    if not np.isfinite(rv):
+        return False
+    if abs(float(rv)) >= RV_ABS_MAX_KMS:
+        return False
+    return True

--- a/docs/website.md
+++ b/docs/website.md
@@ -51,27 +51,60 @@ Ensure Apache serves `/var/www/html/darkhunter/rv/` (existing `Alias` or symlink
 
 ## Populate / refresh star assets
 
-Plots + staging write directly under `WEB_ROOT` (no separate Kirsty mirror).
+`populate_website.sh` runs Keplerian fits (pipeline + literature epochs, excluding legacy sentinels such as −9999 km/s), writes:
+
+| File | Description |
+|------|-------------|
+| `Gaia_DR3_<id>_rv_plot.png` | Our data only (APF/KPF/…); Today + APF window |
+| `Gaia_DR3_<id>_keplerian_fit.png` | Four fits (free P/e, fixed P, fixed e, fixed P+e) |
+| `Gaia_DR3_<id>_keplerian_residuals.png` | Residuals vs RV-only fit (±5 km/s cap) |
+| `Gaia_DR3_<id>_28_hbeta.png` | Stacked Hβ epochs (viridis vs time) |
 
 ```bash
 cd /data2/darkhunter/dark-hunter_rv
 
-# Full refresh (fits + plots + table M2 columns + rsync archives)
-WEB_ROOT=/var/www/html/darkhunter/rv MIN_POINTS=5 bash scripts/populate_website.sh
+# Regenerate everything (≥5 epochs per star, literature included in fits)
+WEB_ROOT=/var/www/html/darkhunter/rv MIN_POINTS=5 FIT_FORCE=1 bash scripts/populate_website.sh
+```
 
-# Skip refitting; reuse existing rv_fit_reports/*.json
-WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 FIT_FORCE=0 MIN_POINTS=5 \
+Detached (full fits):
+
+```bash
+screen -dmS darkhunter_fits bash -lc '
+cd /data2/darkhunter/dark-hunter_rv
+WEB_ROOT=/var/www/html/darkhunter/rv MIN_POINTS=5 FIT_FORCE=1 RUN_FITS=1 \
+  bash scripts/populate_website.sh >> batch_fits_plots_sync.log 2>&1
+'
+```
+
+Plots/staging only (no refit):
+
+```bash
+WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 RUN_RV_PLOTS=1 MIN_POINTS=5 \
   bash scripts/populate_website.sh
 ```
 
-Detached:
+Hβ stacks need per-epoch `*_h_beta*.png` from pipeline (`--plots` / `--plots-focus`). Build stacks alone:
 
 ```bash
-screen -dmS darkhunter_web bash -lc '
-cd /data2/darkhunter/dark-hunter_rv
-WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 FIT_FORCE=0 MIN_POINTS=5 \
-  bash scripts/populate_website.sh >> batch_fits_plots_sync.log 2>&1
-'
+PYTHONPATH=. python3 scripts/build_hbeta_website_plots.py \
+  --summary-dir output --plots-root output
+```
+
+## Cron (new spectra → RVs → website)
+
+```bash
+REPO=/data2/darkhunter/dark-hunter_rv \
+WEB_ROOT=/var/www/html/darkhunter/rv \
+SPEC_ROOT=/data2/gaia_stars/apf_reductions \
+MIN_POINTS=5 \
+bash scripts/cron_update_rv_website.sh
+```
+
+Example crontab line:
+
+```cron
+0 6 * * * REPO=/data2/darkhunter/dark-hunter_rv WEB_ROOT=/var/www/html/darkhunter/rv SPEC_ROOT=/data2/gaia_stars/apf_reductions bash $REPO/scripts/cron_update_rv_website.sh >> $REPO/logs/cron_rv_website.log 2>&1
 ```
 
 ## Repo source of truth

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -421,11 +421,19 @@ def parse_summary(path: Path) -> List[RVPoint]:
         if len(parts) < 5:
             continue
         try:
+            rv = float(parts[2])
+        except ValueError:
+            continue
+        from darkhunter_rv.rv_point_filters import rv_value_is_valid
+
+        if not rv_value_is_valid(rv):
+            continue
+        try:
             points.append(
                 RVPoint(
                     file=parts[0],
                     mjd=float(parts[1]),
-                    rv=float(parts[2]),
+                    rv=rv,
                     rv_err=max(float(parts[3]), 1e-4),
                     rms=max(abs(float(parts[4])), 1e-4),
                     telescope=_pipeline_telescope_from_filename(parts[0]),
@@ -449,7 +457,9 @@ def parse_summary(path: Path) -> List[RVPoint]:
             tel = str(r.get("telescope", "LITERATURE") or "LITERATURE")
         except Exception:
             continue
-        if not np.isfinite(mjd) or not np.isfinite(rv):
+        from darkhunter_rv.rv_point_filters import rv_value_is_valid
+
+        if not np.isfinite(mjd) or not rv_value_is_valid(rv):
             continue
         if not np.isfinite(rv_err) or rv_err <= 0:
             rv_err = 1.0
@@ -824,6 +834,63 @@ def solve_m2_with_inclination_msun(f_mass: float, m1: float, inclination_deg: fl
     return float(out) if np.isfinite(out) and out > 0 else None
 
 
+def fit_all_variants(
+    t: np.ndarray,
+    y: np.ndarray,
+    yerr: np.ndarray,
+    gaia_nss: Optional[Dict[str, float]],
+    *,
+    period_min: Optional[float],
+    period_max: Optional[float],
+    period_prior_sigma: float,
+) -> Dict[str, Tuple[np.ndarray, dict]]:
+    """Four Keplerian fits: free P/e; fixed P; fixed e; fixed P and e (Gaia when available)."""
+    out: Dict[str, Tuple[np.ndarray, dict]] = {}
+    nss_p = None
+    nss_e = None
+    if gaia_nss is not None:
+        nss_p = gaia_nss.get("period_days")
+        nss_e = gaia_nss.get("eccentricity")
+
+    specs: List[Tuple[str, Optional[float], Optional[float]]] = [
+        ("free", None, None),
+    ]
+    if nss_p is not None and nss_e is not None and nss_p > 0 and 0 <= nss_e < 1:
+        specs.extend(
+            [
+                ("fix_period", float(nss_p), None),
+                ("fix_ecc", None, float(nss_e)),
+                ("fix_period_ecc", float(nss_p), float(nss_e)),
+            ]
+        )
+
+    for key, fix_p, fix_e in specs:
+        try:
+            params, rep = fit_keplerian(
+                t,
+                y,
+                yerr,
+                period_min=period_min,
+                period_max=period_max,
+                period_prior=None,
+                period_prior_sigma=period_prior_sigma,
+                fix_period=fix_p,
+                fix_e=fix_e,
+            )
+        except (ValueError, RuntimeError):
+            continue
+        rep["fit_variant"] = key
+        rep["mass_function_msun"] = float(
+            mass_function_msun(rep["P_days"], rep["K_kms"], rep["e"])
+        )
+        if fix_p is not None:
+            rep["fixed_period_days"] = float(fix_p)
+        if fix_e is not None:
+            rep["fixed_eccentricity"] = float(fix_e)
+        out[key] = (params, rep)
+    return out
+
+
 def build_plot(
     summary_path: Path,
     points: List[RVPoint],
@@ -1152,7 +1219,15 @@ def run_one(
     gaia_cache_path: Optional[Path],
     observability_cache_path: Optional[Path],
     query_gaia_online: bool,
+    plots_root: Optional[Path] = None,
 ) -> Optional[dict]:
+    from darkhunter_rv.rv_keplerian_plots import (
+        our_telescope_points,
+        plot_fit_residuals,
+        plot_multi_fit,
+        plot_rv_data_only,
+    )
+
     points = parse_summary(summary_path)
     n_epochs = len(points)
     if n_epochs < min_points:
@@ -1196,16 +1271,10 @@ def run_one(
             if gaia_nss is not None:
                 nss_source = "online"
 
-    fit_period_prior = period_prior
-    fit_fix_e = fix_e
     fit_m1_msun = m1_msun
     fit_m2_msun = None
     fit_inclination_deg = None
     if gaia_nss is not None:
-        if fit_period_prior is None:
-            fit_period_prior = gaia_nss.get("period_days")
-        if fit_fix_e is None:
-            fit_fix_e = gaia_nss.get("eccentricity")
         if fit_m1_msun is None:
             fit_m1_msun = gaia_nss.get("m1_msun")
         fit_m2_msun = gaia_nss.get("m2_msun")
@@ -1213,32 +1282,32 @@ def run_one(
     if fit_m1_msun is None:
         fit_m1_msun = parse_m1_from_summary(summary_path)
 
-    try:
-        params, report = fit_keplerian(
-            t,
-            y,
-            yerr,
-            period_min=period_min,
-            period_max=period_max,
-            period_prior=fit_period_prior,
-            period_prior_sigma=period_prior_sigma,
-            fix_period=fix_period,
-            fix_e=fit_fix_e,
-        )
-    except (ValueError, RuntimeError) as exc:
-        print(f"[SKIP] {summary_path.name}: fit failed ({exc})")
+    fit_variants = fit_all_variants(
+        t,
+        y,
+        yerr,
+        gaia_nss if use_gaia_nss else None,
+        period_min=period_min,
+        period_max=period_max,
+        period_prior_sigma=period_prior_sigma,
+    )
+    if "free" not in fit_variants:
+        print(f"[SKIP] {summary_path.name}: free RV fit failed")
         return None
 
+    params, report = fit_variants["free"]
     report["summary_file"] = str(summary_path)
     report["gaia_source_id"] = gaia_source_id
     report["gaia_nss"] = gaia_nss
     report["nss_priors_source"] = nss_source
     report["observability_window"] = load_observability_window(gaia_source_id, observability_cache_path)
-    report["used_gaia_period_prior"] = fit_period_prior if gaia_nss is not None else None
-    report["used_gaia_eccentricity"] = fit_fix_e if gaia_nss is not None else None
+    report["fit_variants"] = {k: v[1] for k, v in fit_variants.items()}
+    report["params_by_variant"] = {k: np.asarray(v[0], dtype=float).tolist() for k, v in fit_variants.items()}
 
     stem = report_stem(summary_path, gaia_source_id)
     out_png = out_dir / f"{stem}_keplerian_fit.png"
+    data_png = out_dir / f"{stem}_rv_data.png"
+    resid_png = out_dir / f"{stem}_keplerian_residuals.png"
     out_json = out_dir / f"{stem}_keplerian_fit.json"
 
     report["used_m1_msun"] = None if fit_m1_msun is None else float(fit_m1_msun)
@@ -1247,8 +1316,8 @@ def run_one(
         None if fit_inclination_deg is None else float(fit_inclination_deg)
     )
 
-    f_mass = mass_function_msun(report["P_days"], report["K_kms"], report["e"])
-    report["mass_function_msun"] = float(f_mass)
+    f_mass = float(report.get("mass_function_msun", mass_function_msun(report["P_days"], report["K_kms"], report["e"])))
+    report["mass_function_msun"] = f_mass
     m2sini = None
     if fit_m1_msun is not None and np.isfinite(fit_m1_msun) and fit_m1_msun > 0:
         m2sini = solve_m2sini_msun(f_mass, float(fit_m1_msun))
@@ -1267,7 +1336,23 @@ def run_one(
         )
     report["m2_given_inclination_msun"] = None if m2_incl is None else float(m2_incl)
 
-    build_plot(summary_path, points_fit, params, report, out_png, m1_msun=fit_m1_msun)
+    plot_multi_fit(summary_path, points_fit, fit_variants, report, out_png, m1_msun=fit_m1_msun)
+    plot_fit_residuals(summary_path, points_fit, fit_variants, report, resid_png)
+    ours = our_telescope_points(points_fit)
+    if len(ours) >= 2:
+        plot_rv_data_only(summary_path, ours, report, data_png)
+
+    if plots_root is not None and gaia_source_id:
+        import shutil
+
+        star_dir = plots_root / f"Gaia_DR3_{gaia_source_id}"
+        star_dir.mkdir(parents=True, exist_ok=True)
+        if data_png.is_file():
+            shutil.copy2(data_png, star_dir / f"Gaia_DR3_{gaia_source_id}_rv_plot.png")
+        shutil.copy2(out_png, star_dir / f"Gaia_DR3_{gaia_source_id}_keplerian_fit.png")
+        if resid_png.is_file():
+            shutil.copy2(resid_png, star_dir / f"Gaia_DR3_{gaia_source_id}_keplerian_residuals.png")
+
     out_json.write_text(json.dumps(report, indent=2))
     return report
 
@@ -1389,7 +1474,8 @@ def main() -> None:
             args.use_gaia_nss,
             gaia_cache_path,
             observability_cache_path,
-            args.query_gaia_online,
+            args.            query_gaia_online,
+            plots_root=output_dir,
         )
         if report is None:
             skipped += 1

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -26,6 +26,8 @@ REPORTS_DIR="${REPORTS_DIR:-$REPO/rv_fit_reports}"
 LOG="${LOG:-$REPO/batch_fits_plots_sync.log}"
 MIN_POINTS="${MIN_POINTS:-7}"
 RUN_FITS="${RUN_FITS:-1}"
+RUN_RV_PLOTS="${RUN_RV_PLOTS:-1}"
+RUN_HBETA_PLOTS="${RUN_HBETA_PLOTS:-1}"
 FIT_FORCE="${FIT_FORCE:-1}"
 QUERY_GAIA_ONLINE="${QUERY_GAIA_ONLINE:-0}"
 DRY_RUN="${DRY_RUN:-0}"
@@ -131,17 +133,31 @@ else
   echo "=== Keplerian fits (skipped: RUN_FITS=0) ==="
 fi
 
-echo "=== Summary-based RV plots (no pipeline rerun) ==="
-plot_args=(
-  scripts/plot_rv_from_summaries.py
-  --summary-dir "$OUT"
-  --plots-root "$OUT"
-  --reports-dir "$REPORTS_DIR"
-)
-if [[ -n "$STAR_ID" ]]; then
-  plot_args+=(--star-id "$STAR_ID")
+if [[ "$RUN_RV_PLOTS" == "1" && "$RUN_FITS" != "1" ]]; then
+  echo "=== Summary-based RV data plots (no fits) ==="
+  plot_args=(
+    scripts/plot_rv_from_summaries.py
+    --summary-dir "$OUT"
+    --plots-root "$OUT"
+  )
+  if [[ -n "$STAR_ID" ]]; then
+    plot_args+=(--star-id "$STAR_ID")
+  fi
+  run_cmd "$PY" "${plot_args[@]}"
 fi
-run_cmd "$PY" "${plot_args[@]}"
+
+if [[ "$RUN_HBETA_PLOTS" == "1" ]]; then
+  echo "=== Hβ epoch stack plots for website ==="
+  hbeta_args=(
+    scripts/build_hbeta_website_plots.py
+    --summary-dir "$OUT"
+    --plots-root "$OUT"
+  )
+  if [[ -n "$STAR_ID" ]]; then
+    hbeta_args+=(--star-id "$STAR_ID")
+  fi
+  run_cmd "$PY" "${hbeta_args[@]}"
+fi
 
 echo "=== Stage website files into stars/Gaia_DR3_<id>/Gaia/... ==="
 staged_stars=0
@@ -225,13 +241,21 @@ try:
 except ValueError as exc:
     raise SystemExit(f"Required data.csv column missing: {exc}")
 
-# Add requested derived-mass columns when missing.
 col_m2sini = "M2sin i (Msun)"
 col_m2over = "(M2sin i)/(sin i) (Msun)"
-if col_m2sini not in hdr:
-    hdr.append(col_m2sini)
-if col_m2over not in hdr:
-    hdr.append(col_m2over)
+for col in (col_m2sini, col_m2over):
+    if col not in hdr:
+        hdr.append(col)
+# Place M2sin i and M2 at i immediately after Dark M2.
+col_m2 = "M2 (Msun)"
+if col_m2 in hdr:
+    m2_idx = hdr.index(col_m2)
+    for extra in (col_m2sini, col_m2over):
+        if extra in hdr:
+            hdr.remove(extra)
+    insert_at = m2_idx + 1
+    hdr.insert(insert_at, col_m2sini)
+    hdr.insert(insert_at + 1, col_m2over)
 for r in rows[1:]:
     while len(r) < len(hdr):
         r.append("")

--- a/scripts/build_hbeta_website_plots.py
+++ b/scripts/build_hbeta_website_plots.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Stack per-epoch Hβ diagnostic PNGs into website Gaia_DR3_<id>_28_hbeta.png."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.image as mpimg
+import matplotlib.pyplot as plt
+import numpy as np
+
+from fit_apf_rv_keplerian import discover_summary_files, parse_object_id_from_summary
+
+
+def _epoch_rows(summary_path: Path) -> list[tuple[float, str]]:
+    text = summary_path.read_text(encoding="utf-8", errors="replace")
+    if "[PIPELINE RESULTS]" not in text:
+        return []
+    lines = text.split("[PIPELINE RESULTS]", 1)[-1].splitlines()
+    rows: list[tuple[float, str]] = []
+    for raw in lines:
+        s = raw.strip()
+        if not s or s.startswith("#"):
+            continue
+        parts = s.split()
+        if len(parts) < 2:
+            continue
+        try:
+            rows.append((float(parts[1]), parts[0]))
+        except ValueError:
+            continue
+    rows.sort(key=lambda x: x[0])
+    return rows
+
+
+def _find_hbeta_png(plot_dir: Path, basename: str) -> Path | None:
+    stem = Path(basename).stem
+    candidates = sorted(plot_dir.glob(f"{stem}*h_beta*.png"))
+    if not candidates:
+        candidates = sorted(plot_dir.glob(f"*{stem}*h_beta*.png"))
+    return candidates[0] if candidates else None
+
+
+def build_stack(epochs: list[tuple[float, str]], plot_dir: Path, out_png: Path) -> bool:
+    images: list[tuple[float, np.ndarray]] = []
+    for mjd, bn in epochs:
+        p = _find_hbeta_png(plot_dir, bn)
+        if p is None:
+            continue
+        try:
+            images.append((mjd, mpimg.imread(p)))
+        except Exception:
+            continue
+    if not images:
+        return False
+
+    n = len(images)
+    cmap = plt.get_cmap("viridis")
+    fig_h = max(3.0, 2.35 * n)
+    fig, axes = plt.subplots(n, 1, figsize=(10.0, fig_h), squeeze=False)
+    axs = axes.ravel()
+    mjds = np.array([im[0] for im in images], dtype=float)
+    mmin, mmax = float(np.min(mjds)), float(np.max(mjds))
+    for i, (mjd, img) in enumerate(images):
+        ax = axs[i]
+        ax.imshow(img, aspect="auto")
+        frac = 0.0 if mmax <= mmin else (mjd - mmin) / (mmax - mmin)
+        edge = cmap(frac)
+        for spine in ax.spines.values():
+            spine.set_edgecolor(edge)
+            spine.set_linewidth(3.0)
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.set_ylabel(f"MJD {mjd:.1f}", fontsize=8, rotation=0, labelpad=42, va="center")
+    fig.suptitle("Hβ epochs (color = time)", fontsize=11, y=0.995)
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout(rect=[0.08, 0.02, 1.0, 0.98])
+    fig.savefig(out_png, dpi=160, bbox_inches="tight", pad_inches=0.05)
+    plt.close(fig)
+    return True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Build stacked Hβ website PNGs from epoch diagnostics.")
+    ap.add_argument("--summary-dir", required=True)
+    ap.add_argument("--plots-root", required=True, help="Per-star plot directory root (output/Gaia_DR3_<id>)")
+    ap.add_argument("--star-id", default=None)
+    args = ap.parse_args()
+
+    summary_dir = Path(args.summary_dir)
+    plots_root = Path(args.plots_root)
+    if args.star_id:
+        summaries = [summary_dir / f"Gaia_DR3_{args.star_id}_summary.txt"]
+    else:
+        summaries = discover_summary_files(summary_dir)
+
+    built = 0
+    skipped = 0
+    for summ in summaries:
+        if not summ.is_file():
+            skipped += 1
+            continue
+        sid = parse_object_id_from_summary(summ)
+        if not sid:
+            skipped += 1
+            continue
+        plot_dir = plots_root / f"Gaia_DR3_{sid}"
+        out_png = plot_dir / f"Gaia_DR3_{sid}_28_hbeta.png"
+        epochs = _epoch_rows(summ)
+        if build_stack(epochs, plot_dir, out_png):
+            built += 1
+        else:
+            skipped += 1
+    print(f"Built {built} Hβ stack plots (skipped {skipped}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cron_update_rv_website.sh
+++ b/scripts/cron_update_rv_website.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Cron-friendly: measure RVs on new spectra, then refresh website assets for updated stars.
+#
+# Example crontab (daily 06:00):
+#   0 6 * * * REPO=/data2/darkhunter/dark-hunter_rv WEB_ROOT=/var/www/html/darkhunter/rv SPEC_ROOT=/data2/gaia_stars/apf_reductions bash $REPO/scripts/cron_update_rv_website.sh >> $REPO/logs/cron_rv_website.log 2>&1
+#
+# Env:
+#   REPO, OUT, WEB_ROOT, SPEC_ROOT, PY, MIN_POINTS, LOG
+
+set -euo pipefail
+
+REPO="${REPO:-/data2/darkhunter/dark-hunter_rv}"
+OUT="${OUT:-$REPO/output}"
+WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
+SPEC_ROOT="${SPEC_ROOT:-/data2/gaia_stars/apf_reductions}"
+PY="${PY:-/home/marley/anaconda2/envs/gaia-env/bin/python}"
+MIN_POINTS="${MIN_POINTS:-5}"
+LOG="${LOG:-$REPO/logs/cron_rv_website.log}"
+
+mkdir -p "$(dirname "$LOG")" "$OUT"
+cd "$REPO"
+export PYTHONPATH="$REPO"
+export DARKHUNTER_OUTPUT_DIR="$OUT"
+
+exec >>"$LOG" 2>&1
+echo "=== $(date -Is) cron_update_rv_website start ==="
+
+# 1) Pipeline: new/changed spectra under SPEC_ROOT (--update skips unchanged diagnostics).
+if [[ -d "$SPEC_ROOT" ]]; then
+  echo "=== Pipeline --update on $SPEC_ROOT ==="
+  find "$SPEC_ROOT" -type f \( -name '*_ap1.flm' -o -name '*_ap1.txt' -o -name '*.fits' \) -print0 2>/dev/null \
+    | xargs -0 -r "$PY" -m darkhunter_rv.pipeline --instrument APF --update --plots --plots-focus 2>/dev/null \
+    || echo "[WARN] pipeline pass had errors (continuing)"
+else
+  echo "[WARN] SPEC_ROOT missing: $SPEC_ROOT"
+fi
+
+# 2) Fits (incl. literature), plots, Hβ stacks, website staging.
+echo "=== Website populate (fits + assets) ==="
+export WEB_ROOT MIN_POINTS
+RUN_FITS=1 FIT_FORCE=0 bash scripts/populate_website.sh
+
+echo "=== $(date -Is) cron_update_rv_website done ==="

--- a/scripts/plot_rv_from_summaries.py
+++ b/scripts/plot_rv_from_summaries.py
@@ -1,32 +1,31 @@
 #!/usr/bin/env python3
-"""Generate APF RV-vs-MJD plots directly from summary files (no pipeline rerun)."""
+"""Generate RV data-only plots from summary files (no pipeline rerun)."""
 
 from __future__ import annotations
 
 import argparse
-import json
 import re
 from pathlib import Path
 
 import matplotlib
 
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt
 import numpy as np
+from astropy.time import Time
+
+from darkhunter_rv.rv_keplerian_plots import our_telescope_points, plot_rv_data_only
+from darkhunter_rv.rv_point_filters import rv_value_is_valid
+from fit_apf_rv_keplerian import RVPoint, _pipeline_telescope_from_filename, parse_object_id_from_summary
 
 
 def parse_gaia_id(path: Path) -> str | None:
-    m = re.search(r"Gaia_DR3_(\d{8,19})", f"{path.parent.name}/{path.stem}")
-    if m:
-        return m.group(1)
-    m2 = re.match(r"(\d{8,19})_summary$", path.stem)
-    return m2.group(1) if m2 else None
+    return parse_object_id_from_summary(path)
 
 
-def parse_points(summary_path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+def parse_points(summary_path: Path) -> list[RVPoint]:
     text = summary_path.read_text(encoding="utf-8", errors="replace")
     lines = text.split("[PIPELINE RESULTS]", 1)[-1].splitlines() if "[PIPELINE RESULTS]" in text else text.splitlines()
-    t, y, e = [], [], []
+    points: list[RVPoint] = []
     for raw in lines:
         s = raw.strip()
         if not s or s.startswith("#") or (s.startswith("[") and s.endswith("]")):
@@ -39,87 +38,55 @@ def parse_points(summary_path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray
         if len(parts) < 5:
             continue
         try:
-            mjd = float(parts[1])
             rv = float(parts[2])
-            err = float(parts[3])
-            rms = float(parts[4])
+            if not rv_value_is_valid(rv):
+                continue
+            points.append(
+                RVPoint(
+                    file=parts[0],
+                    mjd=float(parts[1]),
+                    rv=rv,
+                    rv_err=max(float(parts[3]), 1e-4),
+                    rms=max(abs(float(parts[4])), 1e-4),
+                    telescope=_pipeline_telescope_from_filename(parts[0]),
+                    is_literature=False,
+                )
+            )
         except ValueError:
             continue
-        if not np.isfinite(mjd) or not np.isfinite(rv):
-            continue
-        t.append(mjd)
-        y.append(rv)
-        if np.isfinite(rms) and rms > 0:
-            e.append(rms)
-        elif np.isfinite(err) and err > 0:
-            e.append(err)
-        else:
-            e.append(0.25)
-    return np.array(t, dtype=float), np.array(y, dtype=float), np.array(e, dtype=float)
+    points.sort(key=lambda p: p.mjd)
+    return points
 
 
-def build_plot(summary_path: Path, out_png: Path, fit_json: Path | None = None) -> bool:
-    t, y, e = parse_points(summary_path)
-    if t.size < 2:
+def minimal_report(points: list[RVPoint]) -> dict:
+    t = np.array([p.mjd for p in points], dtype=float)
+    t_ref = float(np.median(t)) if t.size else float(Time.now().mjd)
+    return {
+        "t_ref_mjd": t_ref,
+        "now_mjd": float(Time.now().mjd),
+        "next_rv_max_mjd": t_ref,
+        "next_rv_min_mjd": t_ref,
+        "observability_window": None,
+    }
+
+
+def build_plot(summary_path: Path, out_png: Path) -> bool:
+    points = our_telescope_points(parse_points(summary_path))
+    if len(points) < 2:
         return False
-    order = np.argsort(t)
-    t, y, e = t[order], y[order], e[order]
-
-    fig, ax = plt.subplots(figsize=(10, 4.8))
-    ax.errorbar(t, y, yerr=e, fmt="o", ms=4.5, capsize=2, lw=1, label="APF epochs")
-    ax.set_xlabel("MJD")
-    ax.set_ylabel("RV (km/s)")
-    gaia_id = parse_gaia_id(summary_path) or summary_path.stem.replace("_summary", "")
-    ax.set_title(f"Gaia DR3 {gaia_id} RV vs MJD")
-    ax.grid(alpha=0.25)
-
-    # Optional model overlay from keplerian fit JSON.
-    if fit_json is not None and fit_json.is_file():
-        try:
-            rep = json.loads(fit_json.read_text(encoding="utf-8"))
-            p = rep.get("params_raw")
-            t_ref = float(rep.get("t_ref_mjd"))
-            if isinstance(p, list) and len(p) == 6:
-                arr = np.array(p, dtype=float)
-                td = np.linspace(float(np.min(t) - 0.02 * (np.ptp(t) + 1)), float(np.max(t) + 0.02 * (np.ptp(t) + 1)), 1200)
-                logp, k, h, kk, m0, gamma = arr
-                period = np.exp(logp)
-                ecc = np.clip(np.hypot(h, kk), 1e-8, 0.95)
-                omega = float(np.arctan2(kk, h))
-                n = 2.0 * np.pi / period
-                mean_anom = n * (td - t_ref) + m0
-                E = np.array(mean_anom, dtype=float)
-                for _ in range(30):
-                    f = E - ecc * np.sin(E) - mean_anom
-                    fp = 1.0 - ecc * np.cos(E)
-                    E -= f / np.clip(fp, 1e-10, None)
-                cosf = (np.cos(E) - ecc) / (1.0 - ecc * np.cos(E))
-                sinf = (np.sqrt(1.0 - ecc * ecc) * np.sin(E)) / (1.0 - ecc * np.cos(E))
-                true_anom = np.arctan2(sinf, cosf)
-                model = gamma + k * (np.cos(true_anom + omega) + ecc * np.cos(omega))
-                ax.plot(td, model, "-", lw=1.6, alpha=0.9, label="Keplerian fit")
-                ax.legend(loc="best", fontsize=9)
-        except Exception:
-            pass
-
-    out_png.parent.mkdir(parents=True, exist_ok=True)
-    fig.tight_layout()
-    fig.savefig(out_png, dpi=160)
-    plt.close(fig)
+    plot_rv_data_only(summary_path, points, minimal_report(points), out_png)
     return True
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description="Build RV plots from Gaia summary files only.")
+    ap = argparse.ArgumentParser(description="Build RV data plots from Gaia summary files only.")
     ap.add_argument("--summary-dir", required=True, help="Directory containing Gaia_DR3_*_summary.txt")
     ap.add_argument("--plots-root", required=True, help="Output root for per-star plot subdirs")
-    ap.add_argument("--reports-dir", default=None, help="Optional dir with <id>_keplerian_fit.json to overlay model")
     ap.add_argument("--star-id", default=None, help="Optional single Gaia source id")
     args = ap.parse_args()
 
     summary_dir = Path(args.summary_dir)
     plots_root = Path(args.plots_root)
-    reports_dir = Path(args.reports_dir) if args.reports_dir else None
 
     pattern = f"Gaia_DR3_{args.star_id}_summary.txt" if args.star_id else "Gaia_DR3_*_summary.txt"
     files = sorted(summary_dir.glob(pattern))
@@ -135,13 +102,11 @@ def main() -> int:
             skipped += 1
             continue
         out_png = plots_root / f"Gaia_DR3_{sid}" / f"Gaia_DR3_{sid}_rv_plot.png"
-        fit_json = (reports_dir / f"{sid}_keplerian_fit.json") if reports_dir else None
-        ok = build_plot(summ, out_png, fit_json=fit_json)
-        if ok:
+        if build_plot(summ, out_png):
             built += 1
         else:
             skipped += 1
-    print(f"Built {built} summary-based RV plots (skipped {skipped}).")
+    print(f"Built {built} summary-based RV data plots (skipped {skipped}).")
     return 0
 
 

--- a/tests/test_fit_apf_rv_keplerian.py
+++ b/tests/test_fit_apf_rv_keplerian.py
@@ -124,11 +124,8 @@ def test_parse_summary_counts_nan_rv_epochs(tmp_path: Path) -> None:
         "Gaia_DR3_1702370142434513152_epoch_8.txt 60716.36 -9.54 0.72 1.40 False\n"
     )
     pts = fitmod.parse_summary(flat)
-    assert len(pts) == 8
-    t = np.array([p.mjd for p in pts])
-    y = np.array([p.rv for p in pts])
-    ok = np.isfinite(t) & np.isfinite(y)
-    assert ok.sum() == 6
+    assert len(pts) == 6
+    assert all(np.isfinite(p.rv) for p in pts)
 
 
 def test_report_stem_uses_numeric_id(tmp_path: Path) -> None:
@@ -161,6 +158,33 @@ def test_fit_keplerian_clips_initial_guess() -> None:
     yerr = np.full_like(t, 0.2)
     params, _ = fitmod.fit_keplerian(t, y, yerr, period_prior=1e6, period_prior_sigma=0.15)
     assert np.all(np.isfinite(params))
+
+
+def test_parse_summary_excludes_legacy_sentinel_rv(tmp_path: Path) -> None:
+    summ = tmp_path / "Gaia_DR3_958479989998172288_summary.txt"
+    summ.write_text(
+        "[PIPELINE RESULTS]\n"
+        "# File | MJD | RV | Err | RMS\n"
+        "f1.txt 60000.0 -10.0 0.1 0.2\n"
+        "f2.txt 60010.0 -9999.0 0.1 0.2\n"
+        "f3.txt 60020.0 -10.5 0.1 0.2\n"
+        "f4.txt 60030.0 -11.0 0.1 0.2\n"
+        "f5.txt 60040.0 -10.2 0.1 0.2\n"
+    )
+    pts = fitmod.parse_summary(summ)
+    rvs = [p.rv for p in pts]
+    assert -9999.0 not in rvs
+    assert len(pts) == 4
+
+
+def test_fit_all_variants_includes_four_when_nss_present() -> None:
+    t = np.linspace(60000, 60100, 12)
+    y = 10.0 * np.sin(2 * np.pi * t / 20.0) + np.random.default_rng(0).normal(0, 0.2, t.size)
+    yerr = np.full_like(y, 0.25)
+    nss = {"period_days": 20.0, "eccentricity": 0.1}
+    variants = fitmod.fit_all_variants(t, y, yerr, nss, period_min=5.0, period_max=200.0, period_prior_sigma=0.2)
+    assert "free" in variants
+    assert len(variants) == 4
 
 
 def test_parse_summary_includes_external_rvs(tmp_path: Path) -> None:

--- a/tests/test_rv_point_filters.py
+++ b/tests/test_rv_point_filters.py
@@ -1,0 +1,11 @@
+from darkhunter_rv.rv_point_filters import rv_value_is_valid
+
+
+def test_rejects_legacy_sentinel() -> None:
+    assert not rv_value_is_valid(-9999.0)
+    assert not rv_value_is_valid(-10000.0)
+
+
+def test_accepts_normal_rv() -> None:
+    assert rv_value_is_valid(-15.5)
+    assert rv_value_is_valid(120.0)


### PR DESCRIPTION
## Summary

- Exclude non-physical RVs (|RV| ≥ 5000 km/s, e.g. legacy −9999) from parsing, fits, and plots.
- Fit four Keplerian models per star (RV-only; Gaia P fixed; Gaia e fixed; both fixed) when NSS metadata exists; literature epochs included in fits.
- New plot products per star:
  - `*_rv_data.png` — our telescopes only; Today + APF window; same markers as fit plots
  - `*_keplerian_fit.png` — four models with P, e, f(M) in legend
  - `*_keplerian_residuals.png` — residuals vs RV-only fit (y-axis capped at ±5 km/s or tighter)
- `scripts/build_hbeta_website_plots.py` stacks epoch `*_h_beta*.png` into `Gaia_DR3_<id>_28_hbeta.png` (viridis vs MJD).
- Batch: Hβ step, M2sin i / M2 at i columns placed after Dark M2; `scripts/cron_update_rv_website.sh` for new spectra → pipeline → website populate.

## Test plan

- [x] `pytest tests/test_rv_point_filters.py tests/test_fit_apf_rv_keplerian.py`
- [ ] Merge; on ziggy: `git pull` then full populate with `MIN_POINTS=5 FIT_FORCE=1`
- [ ] Spot-check one star: RV data plot has no literature; fit plot shows four curves; Hβ stack if pipeline Hβ PNGs exist
- [ ] Confirm `tables/data.csv` column order and populated M2sin i / M2 at i

## Server commands (after merge)

```bash
cd /data2/darkhunter/dark-hunter_rv && git pull
WEB_ROOT=/var/www/html/darkhunter/rv MIN_POINTS=5 FIT_FORCE=1 bash scripts/populate_website.sh
```

Detached fits (≥5 epochs, literature in fit):

```bash
screen -dmS darkhunter_fits bash -lc '
cd /data2/darkhunter/dark-hunter_rv
WEB_ROOT=/var/www/html/darkhunter/rv MIN_POINTS=5 FIT_FORCE=1 RUN_FITS=1 \
  bash scripts/populate_website.sh >> batch_fits_plots_sync.log 2>&1
'
```


Made with [Cursor](https://cursor.com)