### PR TITLE
Fix Keplerian fit JSON circular reference

### DIFF
--- a/darkhunter_rv/rv_keplerian_plots.py
+++ b/darkhunter_rv/rv_keplerian_plots.py
@@ -436,6 +436,6 @@ def plot_fit_residuals(
     ax_bot.legend(loc="best", fontsize=7)
 
     out_png.parent.mkdir(parents=True, exist_ok=True)
-    fig.tight_layout()
+    fig.subplots_adjust(hspace=0.12)
     fig.savefig(out_png, dpi=180, bbox_inches="tight", pad_inches=0.06)
     plt.close(fig)

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -20,6 +20,7 @@ Optional:
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import math
 import re
@@ -1295,13 +1296,15 @@ def run_one(
         print(f"[SKIP] {summary_path.name}: free RV fit failed")
         return None
 
-    params, report = fit_variants["free"]
+    params, _rep_free = fit_variants["free"]
+    # Deep copy so report["fit_variants"]["free"] is not the same dict as report (JSON circular ref).
+    report: dict = copy.deepcopy(_rep_free)
     report["summary_file"] = str(summary_path)
     report["gaia_source_id"] = gaia_source_id
     report["gaia_nss"] = gaia_nss
     report["nss_priors_source"] = nss_source
     report["observability_window"] = load_observability_window(gaia_source_id, observability_cache_path)
-    report["fit_variants"] = {k: v[1] for k, v in fit_variants.items()}
+    report["fit_variants"] = {k: copy.deepcopy(v[1]) for k, v in fit_variants.items()}
     report["params_by_variant"] = {k: np.asarray(v[0], dtype=float).tolist() for k, v in fit_variants.items()}
 
     stem = report_stem(summary_path, gaia_source_id)

--- a/tests/test_fit_apf_rv_keplerian.py
+++ b/tests/test_fit_apf_rv_keplerian.py
@@ -177,6 +177,22 @@ def test_parse_summary_excludes_legacy_sentinel_rv(tmp_path: Path) -> None:
     assert len(pts) == 4
 
 
+def test_fit_report_json_has_no_circular_reference() -> None:
+    t = np.linspace(60000, 60100, 10)
+    y = 10.0 * np.sin(2 * np.pi * t / 20.0)
+    yerr = np.full_like(y, 0.25)
+    variants = fitmod.fit_all_variants(
+        t, y, yerr, {"period_days": 20.0, "eccentricity": 0.1},
+        period_min=5.0, period_max=200.0, period_prior_sigma=0.2,
+    )
+    import copy
+    import json
+
+    report = copy.deepcopy(variants["free"][1])
+    report["fit_variants"] = {k: copy.deepcopy(v[1]) for k, v in variants.items()}
+    json.dumps(report)  # must not raise
+
+
 def test_fit_all_variants_includes_four_when_nss_present() -> None:
     t = np.linspace(60000, 60100, 12)
     y = 10.0 * np.sin(2 * np.pi * t / 20.0) + np.random.default_rng(0).normal(0, 0.2, t.size)


### PR DESCRIPTION
## Summary

Fixes `ValueError: Circular reference detected` when writing `*_keplerian_fit.json` after multi-variant fits.

The top-level `report` dict was the same object as `fit_variants["free"]`; nesting `report["fit_variants"]` created a cycle. We now `deepcopy` the free-fit report and each variant sub-report before serialization.

Also replaces `tight_layout()` on the residual figure (shared axes) with `subplots_adjust` to avoid the matplotlib warning.

## Test plan

- [x] `pytest tests/test_fit_apf_rv_keplerian.py::test_fit_report_json_has_no_circular_reference`
- [ ] Merge and `git pull` on ziggy
- [ ] Re-run `bash scripts/populate_website.sh` (fits should complete without JSON error)


Made with [Cursor](https://cursor.com)