### PR TITLE
Fix website table column alignment and plot cells

### DIFF
--- a/docs/website.md
+++ b/docs/website.md
@@ -58,7 +58,9 @@ Ensure Apache serves `/var/www/html/darkhunter/rv/` (existing `Alias` or symlink
 | `Gaia_DR3_<id>_rv_plot.png` | Our data only (APF/KPF/…); Today + APF window |
 | `Gaia_DR3_<id>_keplerian_fit.png` | Four fits (free P/e, fixed P, fixed e, fixed P+e) |
 | `Gaia_DR3_<id>_keplerian_residuals.png` | Residuals vs RV-only fit (±5 km/s cap) |
-| `Gaia_DR3_<id>_28_hbeta.png` | Stacked Hβ epochs (viridis vs time) |
+| `Gaia_DR3_<id>_28_hbeta.png` | All epochs on one axes (viridis by MJD) |
+| Table **RV Fit** thumb | `RV_Fit/<id>_keplerian_fit.png` (fits only) |
+| Table **RV Fit** click | `Plots/<id>_keplerian_residuals.png` (fits + residuals) |
 
 ```bash
 cd /data2/darkhunter/dark-hunter_rv
@@ -84,11 +86,28 @@ WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 RUN_RV_PLOTS=1 MIN_POINTS=5 \
   bash scripts/populate_website.sh
 ```
 
-Hβ stacks need per-epoch `*_h_beta*.png` from pipeline (`--plots` / `--plots-focus`). Build stacks alone:
+**Repair shifted columns / stale embedded `<img>` in `data.csv`** (after a bad populate, or once after upgrading):
+
+```bash
+cd /data2/darkhunter/dark-hunter_rv
+git pull
+bash scripts/setup_website.sh
+PYTHONPATH=. python3 scripts/fix_data_csv_column_order.py \
+  --data-csv /var/www/html/darkhunter/rv/tables/data.csv
+WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 RUN_HBETA_PLOTS=1 \
+  SPEC_ROOT=/data2/gaia_stars/apf_reductions \
+  bash scripts/populate_website.sh
+```
+
+Hard-refresh the browser once (`script.js` builds plot URLs from Gaia ID; thumbnails use a per-load cache-bust query).
+
+Hβ overlays read spectra under `SPEC_ROOT` (not per-epoch pipeline PNGs). Build alone:
 
 ```bash
 PYTHONPATH=. python3 scripts/build_hbeta_website_plots.py \
-  --summary-dir output --plots-root output
+  --summary-dir output \
+  --plots-root /var/www/html/darkhunter/rv/stars \
+  --spec-root /data2/gaia_stars/apf_reductions
 ```
 
 ## Cron (new spectra → RVs → website)

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -32,6 +32,7 @@ FIT_FORCE="${FIT_FORCE:-1}"
 QUERY_GAIA_ONLINE="${QUERY_GAIA_ONLINE:-0}"
 DRY_RUN="${DRY_RUN:-0}"
 STAR_ID="${STAR_ID:-}" # optional canary mode
+SPEC_ROOT="${SPEC_ROOT:-/data2/gaia_stars/apf_reductions}"
 
 WEBSITE_STARS_DIR="$WEB_ROOT/stars"
 WEBSITE_TABLES_DIR="$WEB_ROOT/tables"
@@ -152,6 +153,7 @@ if [[ "$RUN_HBETA_PLOTS" == "1" ]]; then
     scripts/build_hbeta_website_plots.py
     --summary-dir "$OUT"
     --plots-root "$OUT"
+    --spec-root "${SPEC_ROOT:-/data2/gaia_stars/apf_reductions}"
   )
   if [[ -n "$STAR_ID" ]]; then
     hbeta_args+=(--star-id "$STAR_ID")
@@ -246,19 +248,40 @@ col_m2over = "(M2sin i)/(sin i) (Msun)"
 for col in (col_m2sini, col_m2over):
     if col not in hdr:
         hdr.append(col)
-# Place M2sin i and M2 at i immediately after Dark M2.
-col_m2 = "M2 (Msun)"
-if col_m2 in hdr:
-    m2_idx = hdr.index(col_m2)
-    for extra in (col_m2sini, col_m2over):
-        if extra in hdr:
-            hdr.remove(extra)
-    insert_at = m2_idx + 1
-    hdr.insert(insert_at, col_m2sini)
-    hdr.insert(insert_at + 1, col_m2over)
 for r in rows[1:]:
     while len(r) < len(hdr):
         r.append("")
+
+def move_columns_after(hdr, rows, names, after):
+    if after not in hdr:
+        return
+    insert_at = hdr.index(after) + 1
+    moving = [(hdr.index(name), name) for name in names if name in hdr]
+    if not moving:
+        return
+    extracted = []
+    for old_i, name in sorted(moving, key=lambda x: x[0], reverse=True):
+        hdr.pop(old_i)
+        col_vals = [r.pop(old_i) if old_i < len(r) else "" for r in rows]
+        extracted.append((name, list(reversed(col_vals))))
+    extracted.reverse()
+    for offset, (name, col_vals) in enumerate(extracted):
+        hdr.insert(insert_at + offset, name)
+        for r, val in zip(rows, col_vals):
+            r.insert(insert_at + offset, val)
+
+def clear_media_cells(hdr, rows):
+    for name in ("RV PLOT", "RV FIT", "FLUX PLOT", "SOURCE IMAGE"):
+        if name not in hdr:
+            continue
+        ci = hdr.index(name)
+        for r in rows:
+            while len(r) <= ci:
+                r.append("")
+            r[ci] = ""
+
+move_columns_after(hdr, rows[1:], [col_m2sini, col_m2over], "M2 (Msun)")
+clear_media_cells(hdr, rows[1:])
 m2sini_i = hdr.index(col_m2sini)
 m2over_i = hdr.index(col_m2over)
 

--- a/scripts/build_hbeta_website_plots.py
+++ b/scripts/build_hbeta_website_plots.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python3
-"""Stack per-epoch Hβ diagnostic PNGs into website Gaia_DR3_<id>_28_hbeta.png."""
+"""Build Gaia_DR3_<id>_28_hbeta.png: all epochs on one axes, color by MJD."""
 
 from __future__ import annotations
 
 import argparse
+import os
 import re
 from pathlib import Path
 
 import matplotlib
 
 matplotlib.use("Agg")
-import matplotlib.image as mpimg
 import matplotlib.pyplot as plt
 import numpy as np
 
+from darkhunter_rv import continuum, io_utils, rv_core
 from fit_apf_rv_keplerian import discover_summary_files, parse_object_id_from_summary
 
 
@@ -38,62 +39,142 @@ def _epoch_rows(summary_path: Path) -> list[tuple[float, str]]:
     return rows
 
 
-def _find_hbeta_png(plot_dir: Path, basename: str) -> Path | None:
-    stem = Path(basename).stem
-    candidates = sorted(plot_dir.glob(f"{stem}*h_beta*.png"))
-    if not candidates:
-        candidates = sorted(plot_dir.glob(f"*{stem}*h_beta*.png"))
-    return candidates[0] if candidates else None
+def _parse_teff_from_summary(summary_path: Path) -> float:
+    try:
+        from darkhunter_rv.gaia_utils import parse_gaia_metadata_from_star_summary
+
+        meta = parse_gaia_metadata_from_star_summary(summary_path) or {}
+        for key in ("Teff", "teff", "TEFF"):
+            if key in meta:
+                return float(meta[key])
+    except Exception:
+        pass
+    return 5500.0
 
 
-def build_stack(epochs: list[tuple[float, str]], plot_dir: Path, out_png: Path) -> bool:
-    images: list[tuple[float, np.ndarray]] = []
-    for mjd, bn in epochs:
-        p = _find_hbeta_png(plot_dir, bn)
-        if p is None:
+def _find_spectrum(basename: str, roots: list[Path]) -> Path | None:
+    name = Path(basename).name
+    for root in roots:
+        if not root.is_dir():
+            continue
+        direct = root / name
+        if direct.is_file():
+            return direct
+        hits = sorted(root.rglob(name))
+        if hits:
+            return hits[0]
+    return None
+
+
+def _hbeta_profile_from_spectrum(spec_path: Path, teff: float) -> tuple[np.ndarray, np.ndarray] | None:
+    try:
+        if "ghost" in spec_path.name.lower():
+            _, spec_data = io_utils.read_spectrum_ghost(str(spec_path))
+        elif "maroon" in spec_path.name.lower():
+            _, spec_data = io_utils.read_spectrum_maroonx(str(spec_path))
+        else:
+            _, spec_data = io_utils.read_spectrum(str(spec_path))
+    except Exception:
+        return None
+
+    broad = teff > 5200.0
+    for order in sorted(spec_data.keys()):
+        w_raw = np.asarray(spec_data[order]["wavelength"], dtype=float)
+        f_raw = np.asarray(spec_data[order]["flux"], dtype=float)
+        e_raw = np.asarray(spec_data[order]["eflux"], dtype=float)
+        if w_raw.size < 30:
+            continue
+        if not (np.nanmin(w_raw) <= rv_core.HB_REST_A <= np.nanmax(w_raw)):
             continue
         try:
-            images.append((mjd, mpimg.imread(p)))
+            nw, nf, ne = continuum.fit_continuum(
+                w_raw,
+                f_raw,
+                e_raw,
+                continuum_mode="spline",
+            )
+            nw, nf, _ = continuum.despike_normalized_pre_ccf(nw, nf, np.ones_like(nf))
         except Exception:
             continue
-    if not images:
+        hb = rv_core.measure_h_beta_rv(nw, nf, broad_lines=broad)
+        if hb is None:
+            continue
+        v = np.asarray(hb.get("v_kms_plot", hb.get("v_kms")), dtype=float)
+        f = np.asarray(hb.get("flux_plot", hb.get("flux")), dtype=float)
+        if v.size < 10 or f.size != v.size:
+            continue
+        order = np.argsort(v)
+        return v[order], f[order]
+    return None
+
+
+def build_overlay(
+    epochs: list[tuple[float, str]],
+    summary_path: Path,
+    spec_roots: list[Path],
+    out_png: Path,
+) -> bool:
+    teff = _parse_teff_from_summary(summary_path)
+    curves: list[tuple[float, np.ndarray, np.ndarray]] = []
+    for mjd, bn in epochs:
+        spec = _find_spectrum(bn, spec_roots)
+        if spec is None:
+            continue
+        prof = _hbeta_profile_from_spectrum(spec, teff)
+        if prof is None:
+            continue
+        v, f = prof
+        curves.append((mjd, v, f))
+    if not curves:
         return False
 
-    n = len(images)
-    cmap = plt.get_cmap("viridis")
-    fig_h = max(3.0, 2.35 * n)
-    fig, axes = plt.subplots(n, 1, figsize=(10.0, fig_h), squeeze=False)
-    axs = axes.ravel()
-    mjds = np.array([im[0] for im in images], dtype=float)
+    fig, ax = plt.subplots(figsize=(10.0, 4.8))
+    mjds = np.array([c[0] for c in curves], dtype=float)
     mmin, mmax = float(np.min(mjds)), float(np.max(mjds))
-    for i, (mjd, img) in enumerate(images):
-        ax = axs[i]
-        ax.imshow(img, aspect="auto")
-        frac = 0.0 if mmax <= mmin else (mjd - mmin) / (mmax - mmin)
-        edge = cmap(frac)
-        for spine in ax.spines.values():
-            spine.set_edgecolor(edge)
-            spine.set_linewidth(3.0)
-        ax.set_xticks([])
-        ax.set_yticks([])
-        ax.set_ylabel(f"MJD {mjd:.1f}", fontsize=8, rotation=0, labelpad=42, va="center")
-    fig.suptitle("Hβ epochs (color = time)", fontsize=11, y=0.995)
+    cmap = plt.get_cmap("viridis")
+    for mjd, v, f in curves:
+        frac = 0.0 if mmax <= mmin else (float(mjd) - mmin) / (mmax - mmin)
+        color = cmap(frac)
+        ax.plot(v, f, "-", lw=1.1, color=color, alpha=0.88, label=f"MJD {mjd:.1f}")
+
+    ax.set_xlabel("Velocity (km/s)")
+    ax.set_ylabel("Normalized flux")
+    sid = parse_object_id_from_summary(summary_path) or summary_path.stem
+    ax.set_title(f"Hβ profiles — Gaia DR3 {sid}")
+    ax.grid(alpha=0.25)
+    if len(curves) <= 12:
+        ax.legend(loc="best", fontsize=7, ncol=2)
+    sm = plt.cm.ScalarMappable(cmap=cmap, norm=plt.Normalize(vmin=mmin, vmax=mmax))
+    sm.set_array([])
+    cbar = fig.colorbar(sm, ax=ax, pad=0.01)
+    cbar.set_label("MJD")
     out_png.parent.mkdir(parents=True, exist_ok=True)
-    fig.tight_layout(rect=[0.08, 0.02, 1.0, 0.98])
+    fig.tight_layout()
     fig.savefig(out_png, dpi=160, bbox_inches="tight", pad_inches=0.05)
     plt.close(fig)
     return True
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description="Build stacked Hβ website PNGs from epoch diagnostics.")
+    ap = argparse.ArgumentParser(description="Build multi-epoch Hβ overlay PNGs for the website.")
     ap.add_argument("--summary-dir", required=True)
     ap.add_argument("--plots-root", required=True, help="Per-star plot directory root (output/Gaia_DR3_<id>)")
+    ap.add_argument(
+        "--spec-root",
+        action="append",
+        default=[],
+        help="Spectrum search root (repeatable). Default: SPEC_ROOT env or /data2/gaia_stars/apf_reductions",
+    )
     ap.add_argument("--star-id", default=None)
     args = ap.parse_args()
 
     summary_dir = Path(args.summary_dir)
     plots_root = Path(args.plots_root)
+    spec_roots = [Path(p) for p in args.spec_root]
+    if not spec_roots:
+        env_root = os.environ.get("SPEC_ROOT", "/data2/gaia_stars/apf_reductions")
+        spec_roots = [Path(env_root), summary_dir, summary_dir.parent]
+
     if args.star_id:
         summaries = [summary_dir / f"Gaia_DR3_{args.star_id}_summary.txt"]
     else:
@@ -112,11 +193,11 @@ def main() -> int:
         plot_dir = plots_root / f"Gaia_DR3_{sid}"
         out_png = plot_dir / f"Gaia_DR3_{sid}_28_hbeta.png"
         epochs = _epoch_rows(summ)
-        if build_stack(epochs, plot_dir, out_png):
+        if build_overlay(epochs, summ, spec_roots, out_png):
             built += 1
         else:
             skipped += 1
-    print(f"Built {built} Hβ stack plots (skipped {skipped}).")
+    print(f"Built {built} Hβ overlay plots (skipped {skipped}).")
     return 0
 
 

--- a/scripts/fix_data_csv_column_order.py
+++ b/scripts/fix_data_csv_column_order.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Repair tables/data.csv after header-only column reorder (restores row alignment)."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+
+def move_columns_after(hdr: list[str], rows: list[list[str]], names: list[str], after: str) -> None:
+    """Move columns in hdr and every data row so names appear right after `after`."""
+    if after not in hdr:
+        return
+    insert_at = hdr.index(after) + 1
+    moving: list[tuple[int, str]] = []
+    for name in names:
+        if name not in hdr:
+            continue
+        old_i = hdr.index(name)
+        moving.append((old_i, name))
+    if not moving:
+        return
+    # Preserve cell values while removing columns from right to left.
+    extracted: list[tuple[str, list[str]]] = []
+    for old_i, name in sorted(moving, key=lambda x: x[0], reverse=True):
+        hdr.pop(old_i)
+        col_vals = []
+        for r in rows:
+            col_vals.append(r.pop(old_i) if old_i < len(r) else "")
+        extracted.append((name, list(reversed(col_vals))))
+    extracted.reverse()
+    for offset, (name, col_vals) in enumerate(extracted):
+        hdr.insert(insert_at + offset, name)
+        for r, val in zip(rows, col_vals):
+            r.insert(insert_at + offset, val)
+
+
+def clear_media_cells(hdr: list[str], rows: list[list[str]]) -> None:
+    """Drop legacy embedded <img> tags; the website builds plot URLs in script.js."""
+    for name in ("RV PLOT", "RV FIT", "FLUX PLOT", "SOURCE IMAGE"):
+        if name not in hdr:
+            continue
+        ci = hdr.index(name)
+        for r in rows:
+            while len(r) <= ci:
+                r.append("")
+            r[ci] = ""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Fix data.csv column order and clear stale plot HTML.")
+    ap.add_argument(
+        "--data-csv",
+        default="/var/www/html/darkhunter/rv/tables/data.csv",
+        help="Path to tables/data.csv",
+    )
+    args = ap.parse_args()
+    path = Path(args.data_csv)
+    if not path.is_file():
+        raise SystemExit(f"not found: {path}")
+
+    with path.open(newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+    if not rows:
+        raise SystemExit("empty csv")
+
+    hdr = rows[0]
+    data_rows = rows[1:]
+    for col in ("M2sin i (Msun)", "(M2sin i)/(sin i) (Msun)"):
+        if col not in hdr:
+            hdr.append(col)
+    for r in data_rows:
+        while len(r) < len(hdr):
+            r.append("")
+
+    move_columns_after(
+        hdr,
+        data_rows,
+        ["M2sin i (Msun)", "(M2sin i)/(sin i) (Msun)"],
+        "M2 (Msun)",
+    )
+    clear_media_cells(hdr, data_rows)
+
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        csv.writer(fh).writerows(rows)
+    print(f"fixed: {path} ({len(rows) - 1} data rows, {len(hdr)} columns)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fix_data_csv_column_order.py
+++ b/tests/test_fix_data_csv_column_order.py
@@ -1,0 +1,28 @@
+import importlib.util
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "fix_data_csv_column_order",
+    _ROOT / "scripts" / "fix_data_csv_column_order.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_mod)
+move_columns_after = _mod.move_columns_after
+clear_media_cells = _mod.clear_media_cells
+
+
+def test_move_columns_after_reorders_row_values(tmp_path: Path) -> None:
+    hdr = ["GAIA NAME", "M2 (Msun)", "RV PLOT", "M2sin i (Msun)", "RV FIT"]
+    data = ["id1", "1.0", "<img rv>", "2.0", "<img fit>"]
+    move_columns_after(hdr, [data], ["M2sin i (Msun)"], "M2 (Msun)")
+    assert hdr == ["GAIA NAME", "M2 (Msun)", "M2sin i (Msun)", "RV PLOT", "RV FIT"]
+    assert data == ["id1", "1.0", "2.0", "<img rv>", "<img fit>"]
+
+
+def test_clear_media_cells(tmp_path: Path) -> None:
+    hdr = ["RV PLOT", "M2 (Msun)"]
+    data = ["<img>", "1.0"]
+    clear_media_cells(hdr, [data])
+    assert data[0] == ""

--- a/website/rv/script.js
+++ b/website/rv/script.js
@@ -5,7 +5,9 @@ let last_updated = document.getElementById("last-updated");
 let page_status = document.getElementById("page-status");
 let lastUpdatedDate = null;
 const headers_array = ["RA", "DEC", "PARALLAX", "PMRA", "PMDEC", "PERIOD", "ECCENTRICITY", "M1", "M2"];
-const mediaColumns = new Set([10, 12, 13]); // RV PLOT, FLUX PLOT, SOURCE IMAGE
+const MEDIA_HEADERS = new Set(["RV PLOT", "RV FIT", "FLUX PLOT", "SOURCE IMAGE"]);
+let colByHeader = {};
+const ASSET_CACHE_BUST = String(Date.now());
 const RECENT_APF_DAYS = 30;
 const RECENT_KECK_DAYS = 30;
 const RECENT_WEEK_DAYS = 7;
@@ -387,6 +389,42 @@ async function loadOptionalSimbadCatalog() {
     }
 }
 
+function rebuildColumnIndex(headerRow) {
+    colByHeader = {};
+    if (!Array.isArray(headerRow)) {
+        return;
+    }
+    for (let i = 0; i < headerRow.length; i++) {
+        const h = String(headerRow[i] ?? "").trim();
+        if (h) {
+            colByHeader[h] = i;
+        }
+    }
+}
+
+function colIndex(headerName) {
+    return Object.prototype.hasOwnProperty.call(colByHeader, headerName) ? colByHeader[headerName] : -1;
+}
+
+function headerNameForIndex(colIdx) {
+    for (const name in colByHeader) {
+        if (colByHeader[name] === colIdx) {
+            return name;
+        }
+    }
+    return "";
+}
+
+function isMediaHeader(headerName) {
+    return MEDIA_HEADERS.has(headerName);
+}
+
+function buildPlotImgCell(thumbSrc, detailSrc, altText) {
+    const thumb = `${thumbSrc}?v=${ASSET_CACHE_BUST}`;
+    const href = detailSrc || thumbSrc;
+    return `<a href="${href}" target="_blank" rel="noopener noreferrer"><img src="${thumb}" alt="${altText}" onerror="this.closest('a').outerHTML='N/A';"></a>`;
+}
+
 function buildHbetaCellHtml(gaiaId) {
     if (!gaiaId) {
         return "N/A";
@@ -395,9 +433,10 @@ function buildHbetaCellHtml(gaiaId) {
     const kpfSrc = `stars/Gaia_DR3_${gaiaId}/Keck/Plots/Gaia_DR3_${gaiaId}_kpf_hbeta.png`;
     const hasKeck = KECK_GAIA_IDS.has(gaiaId);
     if (!hasKeck) {
-        return `<a href="${apfSrc}" target="_blank" rel="noopener noreferrer"><img src="${apfSrc}" alt="H-beta plot" onerror="this.closest('a').outerHTML='N/A';"></a>`;
+        return buildPlotImgCell(apfSrc, apfSrc, "H-beta plot");
     }
-    return `<a href="${apfSrc}" target="_blank" rel="noopener noreferrer" data-apf="${apfSrc}" data-kpf="${kpfSrc}"><img src="${apfSrc}" alt="H-beta plot" onerror="(function(img){var a=img.closest('a');if(!a){return;}if(!a.dataset.fallbackTried){a.dataset.fallbackTried='1';var kpf=a.getAttribute('data-kpf');if(kpf){a.href=kpf;img.src=kpf;return;}}a.outerHTML='N/A';})(this);"></a>`;
+    const thumb = `${apfSrc}?v=${ASSET_CACHE_BUST}`;
+    return `<a href="${apfSrc}" target="_blank" rel="noopener noreferrer" data-apf="${apfSrc}" data-kpf="${kpfSrc}"><img src="${thumb}" alt="H-beta plot" onerror="(function(img){var a=img.closest('a');if(!a){return;}if(!a.dataset.fallbackTried){a.dataset.fallbackTried='1';var kpf=a.getAttribute('data-kpf');if(kpf){a.href=kpf;img.src=kpf+'?v=${ASSET_CACHE_BUST}';return;}}a.outerHTML='N/A';})(this);"></a>`;
 }
 
 function buildApfRvPlotCellHtml(gaiaId) {
@@ -405,7 +444,7 @@ function buildApfRvPlotCellHtml(gaiaId) {
         return "N/A";
     }
     const src = `stars/Gaia_DR3_${gaiaId}/Gaia/Plots/Gaia_DR3_${gaiaId}_rv_plot.png`;
-    return `<a href="${src}" target="_blank" rel="noopener noreferrer"><img src="${src}" alt="APF RV plot" onerror="this.closest('a').outerHTML='N/A';"></a>`;
+    return buildPlotImgCell(src, src, "APF RV plot");
 }
 
 function buildKeckRvCellHtml(gaiaId) {
@@ -413,15 +452,16 @@ function buildKeckRvCellHtml(gaiaId) {
         return "N/A";
     }
     const src = `stars/Gaia_DR3_${gaiaId}/Keck/Plots/${gaiaId}_kpf_rv_plot.png`;
-    return `<a href="${src}" target="_blank" rel="noopener noreferrer"><img src="${src}" alt="KPF RV plot" onerror="this.closest('a').outerHTML='N/A';"></a>`;
+    return buildPlotImgCell(src, src, "KPF RV plot");
 }
 
 function buildRvFitCellHtml(gaiaId) {
     if (!gaiaId) {
         return "N/A";
     }
-    const src = `stars/Gaia_DR3_${gaiaId}/Gaia/RV_Fit/${gaiaId}_keplerian_fit.png`;
-    return `<a href="${src}" target="_blank" rel="noopener noreferrer"><img src="${src}" alt="APF RV fit" onerror="this.closest('a').outerHTML='N/A';"></a>`;
+    const thumb = `stars/Gaia_DR3_${gaiaId}/Gaia/RV_Fit/${gaiaId}_keplerian_fit.png`;
+    const detail = `stars/Gaia_DR3_${gaiaId}/Gaia/Plots/Gaia_DR3_${gaiaId}_keplerian_residuals.png`;
+    return buildPlotImgCell(thumb, detail, "APF RV fit");
 }
 
 function syncUrlState() {
@@ -1267,6 +1307,7 @@ function arrayToTable(tableData) {
     const yesNoColumnsByIndex = new Map();
     if (Array.isArray(tableData) && Array.isArray(tableData[0])) {
         const headerRow = tableData[0];
+        rebuildColumnIndex(headerRow);
         for (let i = 0; i < YES_NO_PARAMS.length; i++) {
             const colIdx = headerRow.indexOf(YES_NO_PARAMS[i].header);
             if (colIdx >= 0) {
@@ -1317,36 +1358,49 @@ function arrayToTable(tableData) {
                 text = normalized;
                 row.dataset[param.datasetKey] = normalized;
             }
-            if (i > 0 && colIdx !== 0 && !mediaColumns.has(colIdx) && !Number.isNaN(Number(text))) {
+            const headerName = i === 0 ? String(text ?? "").trim() : headerNameForIndex(colIdx);
+            if (i > 0 && colIdx !== 0 && !isMediaHeader(headerName) && !Number.isNaN(Number(text))) {
                 text = Number(text).toFixed(5);
             }
-            if (i > 0 && mediaColumns.has(colIdx)) {
+            if (i > 0 && isMediaHeader(headerName) && hasNonNAContent(text)) {
                 text = buildMediaCellHtml(text);
             }
-            if (i > 0 && colIdx === 10) {
-                const gaiaId = row.dataset.gaiaId || normalizeGaiaId(rowData["0"]);
-                const hasApfRvPlot = hasNonNAContent(rowData["10"]);
-                if (!hasApfRvPlot) {
-                    text = buildApfRvPlotCellHtml(gaiaId);
-                }
+            const rvPlotCol = colIndex("RV PLOT");
+            const rvFitCol = colIndex("RV FIT");
+            const fluxCol = colIndex("FLUX PLOT");
+            const sourceCol = colIndex("SOURCE IMAGE");
+            const dataProductsCol = colIndex("DATA PRODUCTS");
+            if (i > 0 && colIdx === rvPlotCol) {
+                cell.classList.add("col-rv-plot");
+                const gaiaId = row.dataset.gaiaId || normalizeGaiaId(rowData[String(colIndex("GAIA NAME"))] ?? rowData["0"]);
+                text = buildApfRvPlotCellHtml(gaiaId);
                 if (!hasNonNAContent(text) && KECK_GAIA_IDS.has(gaiaId)) {
                     text = buildKeckRvCellHtml(gaiaId);
                 }
             }
-            if (i > 0 && colIdx === 12) {
-                const gaiaId = row.dataset.gaiaId || normalizeGaiaId(rowData["0"]);
+            if (i > 0 && colIdx === sourceCol) {
+                cell.classList.add("col-source-image");
+            }
+            if (i > 0 && colIdx === fluxCol) {
+                cell.classList.add("col-flux-plot");
+                const gaiaId = row.dataset.gaiaId || normalizeGaiaId(rowData[String(colIndex("GAIA NAME"))] ?? rowData["0"]);
                 text = buildHbetaCellHtml(gaiaId);
             }
-            if (i > 0 && colIdx === 11) {
-                const gaiaId = row.dataset.gaiaId || normalizeGaiaId(rowData["0"]);
+            if (i > 0 && colIdx === rvFitCol) {
+                cell.classList.add("col-rv-fit");
+                const gaiaId = row.dataset.gaiaId || normalizeGaiaId(rowData[String(colIndex("GAIA NAME"))] ?? rowData["0"]);
                 text = buildRvFitCellHtml(gaiaId);
             }
-            if (i > 0 && colIdx === 14) {
+            if (i > 0 && colIdx === dataProductsCol) {
                 const base = extractHrefFromAnchorHtml(text);
                 const gaiaId = row.dataset.gaiaId || "";
                 row.dataset.starBase = gaiaId ? `stars/Gaia_DR3_${gaiaId}` : base;
-                row.dataset.hasApf = (hasNonNAContent(rowData["10"]) || hasNonNAContent(rowData["11"])) ? "1" : "0";
-                row.dataset.hasSwift = (hasNonNAContent(rowData["12"]) || hasNonNAContent(rowData["13"])) ? "1" : "0";
+                const rvPlotCell = rvPlotCol >= 0 ? rowData[String(rvPlotCol)] : "";
+                const rvFitCell = rvFitCol >= 0 ? rowData[String(rvFitCol)] : "";
+                const fluxCell = fluxCol >= 0 ? rowData[String(fluxCol)] : "";
+                const sourceCell = sourceCol >= 0 ? rowData[String(sourceCol)] : "";
+                row.dataset.hasApf = (hasNonNAContent(rvPlotCell) || hasNonNAContent(rvFitCell)) ? "1" : "0";
+                row.dataset.hasSwift = (hasNonNAContent(fluxCell) || hasNonNAContent(sourceCell)) ? "1" : "0";
                 row.dataset.hasKeck = KECK_GAIA_IDS.has(row.dataset.gaiaId || "") ? "1" : "0";
                 row.dataset.apfRecent = "unknown";
                 row.dataset.apfRecentWeek = "unknown";

--- a/website/rv/style.css
+++ b/website/rv/style.css
@@ -110,15 +110,15 @@ th {
 }
 
 /* Hide UV image column in main table view */
-#csv-container th:nth-child(14),
-#csv-container td:nth-child(14) {
+#csv-container th.col-source-image,
+#csv-container td.col-source-image {
     display: none;
 }
 
-#csv-container td:nth-child(11) img,
-#csv-container td:nth-child(12) img,
-#csv-container td:nth-child(13) img,
-#csv-container td:nth-child(14) img {
+#csv-container td.col-rv-plot img,
+#csv-container td.col-rv-fit img,
+#csv-container td.col-flux-plot img,
+#csv-container td.col-source-image img {
     width: 100%;
     max-width: 300px;
     height: auto;


### PR DESCRIPTION
## Summary
- Fixes `data.csv` column reorder so M2 sin i / M2 at i values move with their headers (root cause of RV/fit thumbnails under mass columns).
- Clears legacy embedded `<img>` HTML in plot columns; `script.js` builds URLs from Gaia ID by header name with cache-busting.
- **RV Fit** column: thumbnail = `RV_Fit/<id>_keplerian_fit.png`; click opens `Plots/<id>_keplerian_residuals.png`.
- **RV Curve** always uses `*_rv_plot.png` (no stale CSV thumbs).
- Hβ: all epochs on one axes, viridis by MJD (from spectra under `SPEC_ROOT`).
- Adds `scripts/fix_data_csv_column_order.py` for one-shot repair on ziggy.

## Test plan
- [x] `pytest tests/test_fix_data_csv_column_order.py`
- [ ] On ziggy after merge: `setup_website.sh`, `fix_data_csv_column_order.py`, `populate_website.sh` (see `docs/website.md`)


Made with [Cursor](https://cursor.com)