### PR TITLE
Revise Keplerian fit and residual RV plots

### DIFF
--- a/darkhunter_rv/rv_keplerian_plots.py
+++ b/darkhunter_rv/rv_keplerian_plots.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import math
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
 from astropy.time import Time
-from matplotlib.offsetbox import AnnotationBbox, HPacker, TextArea, VPacker
 from matplotlib.ticker import AutoMinorLocator
 
 from typing import TYPE_CHECKING
@@ -17,13 +15,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from fit_apf_rv_keplerian import RVPoint
 
+from darkhunter_rv.rv_point_filters import rv_value_is_valid
+
 
 def _fitmod():
     import fit_apf_rv_keplerian as m
 
     return m
 
-from darkhunter_rv.rv_point_filters import rv_value_is_valid
 
 FIT_VARIANT_ORDER = ("free", "fix_period", "fix_ecc", "fix_period_ecc")
 FIT_VARIANT_STYLE: Dict[str, Tuple[str, str]] = {
@@ -34,9 +33,9 @@ FIT_VARIANT_STYLE: Dict[str, Tuple[str, str]] = {
 }
 FIT_VARIANT_LABEL = {
     "free": "RV only",
-    "fix_period": "P fixed (Gaia)",
-    "fix_ecc": "e fixed (Gaia)",
-    "fix_period_ecc": "P & e fixed (Gaia)",
+    "fix_period": "P fixed",
+    "fix_ecc": "e fixed",
+    "fix_period_ecc": "P & e fixed",
 }
 
 TEL_MARKER = {"APF": "o", "KPF": "s", "GHOST": "p", "MAROON-X": "x"}
@@ -83,6 +82,24 @@ def _time_window(
     return t_start, t_end, now_mjd
 
 
+def _xlim_from_data(t: np.ndarray, report: dict) -> Tuple[float, float]:
+    """X limits spanning all RV epochs (small padding; include Today/APF markers if just outside)."""
+    now_mjd = float(report.get("now_mjd", Time.now().mjd))
+    if t.size == 0:
+        return now_mjd - 30.0, now_mjd + 30.0
+    t_span = float(np.ptp(t) + 1.0)
+    pad = 0.03 * t_span
+    t_lo = float(np.min(t) - pad)
+    t_hi = float(np.max(t) + pad)
+    t_lo = min(t_lo, now_mjd - 0.01 * t_span)
+    t_hi = max(t_hi, now_mjd + 0.01 * t_span)
+    obs_start, obs_end, _ = _observability_span(report)
+    if obs_start is not None and obs_end is not None:
+        t_lo = min(t_lo, obs_start - 0.01 * t_span)
+        t_hi = max(t_hi, obs_end + 0.01 * t_span)
+    return t_lo, t_hi
+
+
 def _observability_span(report: dict) -> Tuple[Optional[float], Optional[float], Optional[dict]]:
     obs_win = report.get("observability_window")
     if not isinstance(obs_win, dict):
@@ -95,7 +112,14 @@ def _observability_span(report: dict) -> Tuple[Optional[float], Optional[float],
         return None, None, None
 
 
-def _shade_apf_window(ax, t_start: float, t_end: float, report: dict) -> None:
+def _shade_apf_window(
+    ax,
+    t_start: float,
+    t_end: float,
+    report: dict,
+    *,
+    annotate: bool = True,
+) -> None:
     obs_start, obs_end, obs_win = _observability_span(report)
     if obs_start is None or obs_end is None or obs_win is None:
         return
@@ -104,37 +128,48 @@ def _shade_apf_window(ax, t_start: float, t_end: float, report: dict) -> None:
     if right <= left:
         return
     ax.axvspan(left, right, color="tab:blue", alpha=0.12, zorder=0)
-    ax.text(
-        0.985,
-        0.02,
-        f"APF window {obs_win['start_date']} to {obs_win['end_date']}",
-        transform=ax.transAxes,
-        fontsize=8.5,
-        color="tab:blue",
-        ha="right",
-        va="bottom",
-        bbox=dict(facecolor="white", edgecolor="tab:blue", alpha=0.85, boxstyle="round,pad=0.2"),
-    )
+    if annotate:
+        ax.text(
+            0.985,
+            0.02,
+            f"APF window {obs_win['start_date']} to {obs_win['end_date']}",
+            transform=ax.transAxes,
+            fontsize=8.5,
+            color="tab:blue",
+            ha="right",
+            va="bottom",
+            bbox=dict(facecolor="white", edgecolor="tab:blue", alpha=0.85, boxstyle="round,pad=0.2"),
+        )
 
 
-def _mark_today(ax, now_mjd: float, y_top_in: float) -> None:
-    ax.axvline(now_mjd, color="0.35", ls="--", lw=1.2, alpha=0.9)
-    ax.text(
-        now_mjd,
-        y_top_in,
-        "Today",
-        fontsize=9,
-        color="0.25",
-        ha="right",
-        va="top",
-        bbox=dict(facecolor="0.93", edgecolor="0.5", alpha=0.95, boxstyle="round,pad=0.15"),
-    )
+def _mark_today(ax, now_mjd: float, y_top_in: float, *, annotate: bool = True) -> None:
+    ax.axvline(now_mjd, color="0.35", ls="--", lw=1.2, alpha=0.9, zorder=1)
+    if annotate:
+        ax.text(
+            now_mjd,
+            y_top_in,
+            "Today",
+            fontsize=9,
+            color="0.25",
+            ha="right",
+            va="top",
+            bbox=dict(facecolor="0.93", edgecolor="0.5", alpha=0.95, boxstyle="round,pad=0.15"),
+        )
 
 
-def _plot_points(ax, points: Sequence["RVPoint"], *, include_literature: bool) -> bool:
+def _plot_points(
+    ax,
+    points: Sequence["RVPoint"],
+    *,
+    include_literature: bool,
+    y_values: Optional[np.ndarray] = None,
+) -> bool:
     plotted = False
     t = np.array([p.mjd for p in points], dtype=float)
-    y = np.array([p.rv for p in points], dtype=float)
+    if y_values is None:
+        y = np.array([p.rv for p in points], dtype=float)
+    else:
+        y = np.asarray(y_values, dtype=float)
     yerr = np.array([p.rms for p in points], dtype=float)
 
     for tel, marker in TEL_MARKER.items():
@@ -201,14 +236,81 @@ def _y_limits_data_and_models(
     return y_low - y_pad, y_high + y_pad
 
 
-def _variant_annotation(rep: dict) -> str:
+def _plot_fit_curves(
+    ax,
+    t_dense: np.ndarray,
+    fit_variants: Dict[str, Tuple[np.ndarray, dict]],
+    t_ref: float,
+) -> List[np.ndarray]:
+    curves: List[np.ndarray] = []
+    for key in FIT_VARIANT_ORDER:
+        if key not in fit_variants:
+            continue
+        params, _vrep = fit_variants[key]
+        y_dense = _fitmod().rv_model(params, t_dense, t_ref)
+        curves.append(y_dense)
+        color, ls = FIT_VARIANT_STYLE[key]
+        ax.plot(
+            t_dense,
+            y_dense,
+            ls=ls,
+            lw=1.8,
+            color=color,
+            alpha=0.92,
+            label=FIT_VARIANT_LABEL[key],
+        )
+    return curves
+
+
+def _mark_time_reference(ax, report: dict, t_lo: float, t_hi: float, y_top_in: float, *, annotate: bool) -> None:
+    now_mjd = float(report.get("now_mjd", Time.now().mjd))
+    if t_lo <= now_mjd <= t_hi:
+        _mark_today(ax, now_mjd, y_top_in, annotate=annotate)
+    _shade_apf_window(ax, t_lo, t_hi, report, annotate=annotate)
+
+
+def _m2sini_for_variant(vrep: dict, m1_msun: Optional[float]) -> Optional[float]:
     m = _fitmod()
-    p = int(round(float(rep["P_days"])))
-    e = float(rep["e"])
-    fm = float(
-        rep.get("mass_function_msun", m.mass_function_msun(rep["P_days"], rep["K_kms"], rep["e"]))
-    )
-    return f"P={p} d, e={e:.3f}, f(M)={fm:.4f} M☉"
+    fm = vrep.get("mass_function_msun")
+    if fm is None or not np.isfinite(fm):
+        fm = m.mass_function_msun(vrep["P_days"], vrep["K_kms"], vrep["e"])
+    if fm is None or not np.isfinite(fm) or fm <= 0:
+        return None
+    if m1_msun is not None and np.isfinite(m1_msun) and m1_msun > 0:
+        return float(m.solve_m2sini_msun(float(fm), float(m1_msun)))
+    return None
+
+
+def _variant_param_lines(
+    fit_variants: Dict[str, Tuple[np.ndarray, dict]],
+    m1_msun: Optional[float],
+) -> List[str]:
+    lines: List[str] = []
+    for key in FIT_VARIANT_ORDER:
+        if key not in fit_variants:
+            continue
+        _, vrep = fit_variants[key]
+        p_days = int(round(float(vrep["P_days"])))
+        ecc = float(vrep["e"])
+        m2sini = _m2sini_for_variant(vrep, m1_msun)
+        label = FIT_VARIANT_LABEL[key]
+        if m2sini is not None:
+            lines.append(f"{label}:  P = {p_days} d,  e = {ecc:.3f},  M₂ sin i = {m2sini:.4f} M☉")
+        else:
+            fm = vrep.get("mass_function_msun")
+            if fm is None or not np.isfinite(fm):
+                fm = _fitmod().mass_function_msun(vrep["P_days"], vrep["K_kms"], vrep["e"])
+            fm_s = f"{float(fm):.4f}" if fm is not None and np.isfinite(fm) else "—"
+            lines.append(f"{label}:  P = {p_days} d,  e = {ecc:.3f},  f(M) = {fm_s} M☉")
+    return lines
+
+
+def _style_rv_axes(ax) -> None:
+    ax.grid(alpha=0.25)
+    ax.xaxis.set_minor_locator(AutoMinorLocator())
+    ax.yaxis.set_minor_locator(AutoMinorLocator())
+    ax.tick_params(axis="both", which="major", direction="in", length=7, width=1.1, top=True, right=True)
+    ax.tick_params(axis="both", which="minor", direction="in", length=3.5, width=0.9, top=True, right=True)
 
 
 def plot_rv_data_only(
@@ -242,11 +344,7 @@ def plot_rv_data_only(
     ax.set_ylabel("RV (km/s)")
     ax.set_title(f"{title_prefix}: Gaia DR3 {sid}")
     ax.set_xlim(t_start, t_end)
-    ax.grid(alpha=0.25)
-    ax.xaxis.set_minor_locator(AutoMinorLocator())
-    ax.yaxis.set_minor_locator(AutoMinorLocator())
-    ax.tick_params(axis="both", which="major", direction="in", length=7, width=1.1, top=True, right=True)
-    ax.tick_params(axis="both", which="minor", direction="in", length=3.5, width=0.9, top=True, right=True)
+    _style_rv_axes(ax)
     ax.legend(loc="best", fontsize=8.5)
 
     out_png.parent.mkdir(parents=True, exist_ok=True)
@@ -264,71 +362,32 @@ def plot_multi_fit(
     *,
     m1_msun: Optional[float] = None,
 ) -> None:
-    """All epochs (incl. literature) with up to four Keplerian models."""
+    """Fits-only figure: all data and four models; Today/APF markers without text."""
+    del m1_msun  # mass annotations only on residuals figure
     if len(points) < 2:
         raise ValueError("need at least 2 points")
 
     t = np.array([p.mjd for p in points], dtype=float)
     y = np.array([p.rv for p in points], dtype=float)
     t_ref = float(report["t_ref_mjd"])
-    t_start, t_end, now_mjd = _time_window(t, report, include_future=True)
-    t_dense = np.linspace(t_start, t_end, 2000)
+    t_lo, t_hi = _xlim_from_data(t, report)
+    t_dense = np.linspace(t_lo, t_hi, 2000)
 
-    curves: List[np.ndarray] = []
     fig, ax = plt.subplots(figsize=(10.8, 5.2))
-    _shade_apf_window(ax, t_start, t_end, report)
     _plot_points(ax, points, include_literature=True)
-
-    for key in FIT_VARIANT_ORDER:
-        if key not in fit_variants:
-            continue
-        params, vrep = fit_variants[key]
-        y_dense = _fitmod().rv_model(params, t_dense, t_ref)
-        curves.append(y_dense)
-        color, ls = FIT_VARIANT_STYLE[key]
-        label = f"{FIT_VARIANT_LABEL[key]} ({_variant_annotation(vrep)})"
-        ax.plot(t_dense, y_dense, ls=ls, lw=1.8, color=color, alpha=0.92, label=label)
+    curves = _plot_fit_curves(ax, t_dense, fit_variants, t_ref)
 
     y_lim = _y_limits_data_and_models(t, y, curves)
     ax.set_ylim(*y_lim)
     y_top_in = y_lim[1] - 0.02 * (y_lim[1] - y_lim[0])
-    _mark_today(ax, now_mjd, y_top_in)
-
-    # Nearest upcoming extremum from primary (free) fit if present.
-    primary = fit_variants.get("free")
-    if primary is not None:
-        params0, rep0 = primary
-        p_days = float(rep0["P_days"])
-        t_next_max, t_next_min = _fitmod().next_extrema_after(params0, t_ref, p_days, now_mjd)
-        next_event = t_next_max if (t_next_max is not None and (t_next_min is None or t_next_max <= t_next_min)) else t_next_min
-        if next_event is not None:
-            ax.axvline(next_event, color="tab:red", ls="--", lw=1.2, alpha=0.9)
+    _mark_time_reference(ax, report, t_lo, t_hi, y_top_in, annotate=False)
 
     sid = _fitmod().parse_object_id_from_summary(summary_path) or summary_path.stem.replace("_summary", "")
     ax.set_xlabel("MJD")
     ax.set_ylabel("RV (km/s)")
     ax.set_title(f"Keplerian fits: Gaia DR3 {sid}")
-    ax.set_xlim(t_start, t_end)
-    ax.grid(alpha=0.25)
-    ax.legend(loc="best", fontsize=7.5)
-    ax.xaxis.set_minor_locator(AutoMinorLocator())
-    ax.yaxis.set_minor_locator(AutoMinorLocator())
-
-    if m1_msun is not None and primary is not None:
-        _rep0 = primary[1]
-        fm = float(_rep0.get("mass_function_msun", 0.0))
-        m2sini = _fitmod().solve_m2sini_msun(fm, float(m1_msun)) if fm > 0 else None
-        if m2sini is not None:
-            ax.text(
-                0.015,
-                0.98,
-                f"M₁={m1_msun:.4f} M☉   M₂ sin i={m2sini:.4f} M☉",
-                transform=ax.transAxes,
-                fontsize=9.0,
-                va="top",
-                ha="left",
-                bbox=dict(facecolor="white", edgecolor="black", alpha=0.95, boxstyle="round,pad=0.2"),
-            )
+    ax.set_xlim(t_lo, t_hi)
+    _style_rv_axes(ax)
 
     out_png.parent.mkdir(parents=True, exist_ok=True)
     fig.tight_layout()
@@ -358,24 +417,33 @@ def plot_fit_residuals(
     fit_variants: Dict[str, Tuple[np.ndarray, dict]],
     report: dict,
     out_png: Path,
+    *,
+    m1_msun: Optional[float] = None,
 ) -> None:
     if "free" not in fit_variants:
         raise ValueError("residual plot requires a free RV fit")
     if len(points) < 2:
         raise ValueError("need at least 2 points")
 
+    if m1_msun is None:
+        used = report.get("used_m1_msun")
+        if used is not None and np.isfinite(used):
+            m1_msun = float(used)
+
     t = np.array([p.mjd for p in points], dtype=float)
     y = np.array([p.rv for p in points], dtype=float)
     yerr = np.array([p.rms for p in points], dtype=float)
     t_ref = float(report["t_ref_mjd"])
-    params_free, rep_free = fit_variants["free"]
-    t_start, t_end, now_mjd = _time_window(t, report, include_future=True)
-    t_dense = np.linspace(t_start, t_end, 2000)
+    t_lo, t_hi = _xlim_from_data(t, report)
+    t_dense = np.linspace(t_lo, t_hi, 2000)
+    now_mjd = float(report.get("now_mjd", Time.now().mjd))
 
     rv_model = _fitmod().rv_model
+    params_free, _rep_free = fit_variants["free"]
     model_free_obs = rv_model(params_free, t, t_ref)
     model_free_dense = rv_model(params_free, t_dense, t_ref)
-    resid_map: Dict[str, np.ndarray] = {}
+    resid_data = y - model_free_obs
+    resid_map: Dict[str, np.ndarray] = {"free": resid_data}
     dense_map: Dict[str, np.ndarray] = {}
     for key in FIT_VARIANT_ORDER:
         if key not in fit_variants:
@@ -383,38 +451,41 @@ def plot_fit_residuals(
         params, _vrep = fit_variants[key]
         model_obs = rv_model(params, t, t_ref)
         resid_map[key] = y - model_obs
-        dense_map[key] = rv_model(params, t_dense, t_ref) - model_free_dense
+        if key != "free":
+            dense_map[key] = rv_model(params, t_dense, t_ref) - model_free_dense
 
-    fig, (ax_top, ax_bot) = plt.subplots(
-        2, 1, figsize=(10.8, 6.4), sharex=True, gridspec_kw={"height_ratios": [2.2, 1.0], "hspace": 0.08}
+    fig = plt.figure(figsize=(10.8, 7.6))
+    gs = fig.add_gridspec(
+        3,
+        1,
+        height_ratios=[2.25, 1.05, 0.55],
+        hspace=0.06,
     )
-    _shade_apf_window(ax_top, t_start, t_end, report)
+    ax_top = fig.add_subplot(gs[0])
+    ax_bot = fig.add_subplot(gs[1], sharex=ax_top)
+    ax_txt = fig.add_subplot(gs[2])
+    ax_txt.axis("off")
+
     _plot_points(ax_top, points, include_literature=True)
-    ax_top.plot(t_dense, model_free_dense, "-", color=FIT_VARIANT_STYLE["free"][0], lw=2.0, label=FIT_VARIANT_LABEL["free"])
-    y_lim = _y_limits_data_and_models(t, y, [model_free_dense])
+    curves = _plot_fit_curves(ax_top, t_dense, fit_variants, t_ref)
+    y_lim = _y_limits_data_and_models(t, y, curves)
     ax_top.set_ylim(*y_lim)
     y_top_in = y_lim[1] - 0.02 * (y_lim[1] - y_lim[0])
-    _mark_today(ax_top, now_mjd, y_top_in)
+    _mark_time_reference(ax_top, report, t_lo, t_hi, y_top_in, annotate=True)
+    if t_lo <= now_mjd <= t_hi:
+        ax_bot.axvline(now_mjd, color="0.35", ls="--", lw=1.2, alpha=0.9, zorder=1)
+    _shade_apf_window(ax_bot, t_lo, t_hi, report, annotate=False)
+
     sid = _fitmod().parse_object_id_from_summary(summary_path) or summary_path.stem.replace("_summary", "")
     ax_top.set_ylabel("RV (km/s)")
     ax_top.set_title(f"Keplerian fits + residuals: Gaia DR3 {sid}")
-    ax_top.grid(alpha=0.25)
-    ax_top.legend(loc="best", fontsize=8)
+    _style_rv_axes(ax_top)
+    plt.setp(ax_top.get_xticklabels(), visible=False)
 
-    ax_bot.axhline(0.0, color="0.4", lw=1.0)
-    ax_bot.errorbar(
-        t,
-        y - model_free_obs,
-        yerr=yerr,
-        fmt="o",
-        ms=4,
-        capsize=2,
-        color="black",
-        ecolor="black",
-        label="Data − RV-only",
-    )
+    ax_bot.axhline(0.0, color="0.4", lw=1.0, zorder=1)
+    _plot_points(ax_bot, points, include_literature=True, y_values=resid_data)
     for key in FIT_VARIANT_ORDER:
-        if key == "free" or key not in fit_variants:
+        if key == "free" or key not in dense_map:
             continue
         color, ls = FIT_VARIANT_STYLE[key]
         ax_bot.plot(
@@ -424,18 +495,41 @@ def plot_fit_residuals(
             lw=1.4,
             color=color,
             alpha=0.9,
-            label=f"{FIT_VARIANT_LABEL[key]} − RV-only",
+            label=FIT_VARIANT_LABEL[key],
         )
 
-    r_ylim = _residual_ylim(y - model_free_obs, yerr, list(resid_map.values()))
+    r_ylim = _residual_ylim(resid_data, yerr, list(resid_map.values()))
     ax_bot.set_ylim(*r_ylim)
-    ax_bot.set_xlabel("MJD")
     ax_bot.set_ylabel("ΔRV (km/s)")
-    ax_bot.set_xlim(t_start, t_end)
-    ax_bot.grid(alpha=0.25)
-    ax_bot.legend(loc="best", fontsize=7)
+    ax_bot.set_xlim(t_lo, t_hi)
+    ax_bot.set_xlabel("MJD")
+    _style_rv_axes(ax_bot)
+
+    handles, labels = ax_top.get_legend_handles_labels()
+    if handles:
+        ax_top.legend(
+            handles,
+            labels,
+            loc="upper left",
+            bbox_to_anchor=(1.01, 1.0),
+            borderaxespad=0.0,
+            fontsize=8.5,
+            framealpha=0.95,
+        )
+
+    param_lines = _variant_param_lines(fit_variants, m1_msun)
+    ax_txt.text(
+        0.01,
+        0.95,
+        "\n".join(param_lines),
+        transform=ax_txt.transAxes,
+        fontsize=8.5,
+        va="top",
+        ha="left",
+        family="monospace",
+    )
 
     out_png.parent.mkdir(parents=True, exist_ok=True)
-    fig.subplots_adjust(hspace=0.12)
-    fig.savefig(out_png, dpi=180, bbox_inches="tight", pad_inches=0.06)
+    fig.subplots_adjust(right=0.82)
+    fig.savefig(out_png, dpi=180, bbox_inches="tight", pad_inches=0.08)
     plt.close(fig)

--- a/docs/website.md
+++ b/docs/website.md
@@ -56,8 +56,8 @@ Ensure Apache serves `/var/www/html/darkhunter/rv/` (existing `Alias` or symlink
 | File | Description |
 |------|-------------|
 | `Gaia_DR3_<id>_rv_plot.png` | Our data only (APF/KPF/…); Today + APF window |
-| `Gaia_DR3_<id>_keplerian_fit.png` | Four fits (free P/e, fixed P, fixed e, fixed P+e) |
-| `Gaia_DR3_<id>_keplerian_residuals.png` | Residuals vs RV-only fit (±5 km/s cap) |
+| `Gaia_DR3_<id>_keplerian_fit.png` | Four fits + all epochs (lit + ours); no legend/text |
+| `Gaia_DR3_<id>_keplerian_residuals.png` | Same top panel + residuals (±5 km/s) + fit P, e, M₂ sin i |
 | `Gaia_DR3_<id>_28_hbeta.png` | All epochs on one axes (viridis by MJD) |
 | Table **RV Fit** thumb | `RV_Fit/<id>_keplerian_fit.png` (fits only) |
 | Table **RV Fit** click | `Plots/<id>_keplerian_residuals.png` (fits + residuals) |

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -1360,7 +1360,9 @@ def run_one(
     report["m2_given_inclination_msun"] = None if m2_incl is None else float(m2_incl)
 
     plot_multi_fit(summary_path, points_fit, fit_variants, report, out_png, m1_msun=fit_m1_msun)
-    plot_fit_residuals(summary_path, points_fit, fit_variants, report, resid_png)
+    plot_fit_residuals(
+        summary_path, points_fit, fit_variants, report, resid_png, m1_msun=fit_m1_msun
+    )
     ours = our_telescope_points(points_fit)
     if len(ours) >= 2:
         plot_rv_data_only(summary_path, ours, report, data_png)

--- a/tests/test_rv_keplerian_plots.py
+++ b/tests/test_rv_keplerian_plots.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from darkhunter_rv import rv_keplerian_plots as plots
+
+
+def test_residual_ylim_caps_at_five_kms() -> None:
+    y = np.array([20.0, -18.0])
+    yerr = np.array([1.0, 1.0])
+    lo, hi = plots._residual_ylim(y, yerr, [])
+    assert hi <= 5.0
+    assert lo >= -5.0
+
+
+def test_xlim_from_data_spans_epochs() -> None:
+    t = np.array([58000.0, 58100.0])
+    report = {"now_mjd": 59000.0}
+    lo, hi = plots._xlim_from_data(t, report)
+    assert lo < 58000.0
+    assert hi > 58100.0
+
+
+def test_variant_param_lines_includes_m2sini() -> None:
+    fit_variants = {
+        "free": (
+            np.zeros(6),
+            {"P_days": 100.0, "e": 0.1, "K_kms": 50.0, "mass_function_msun": 0.01},
+        ),
+    }
+    lines = plots._variant_param_lines(fit_variants, m1_msun=1.0)
+    assert len(lines) == 1
+    assert "RV only" in lines[0]
+    assert "M₂ sin i" in lines[0]


### PR DESCRIPTION
## Summary
PR #17 merged the website table/CSV/Hβ fixes (`69494ad`) but not the follow-up commit that revises the Keplerian figures. This PR adds that work on top of `main`.

- **`*_keplerian_fit.png`:** All four fits + all epochs (literature + ours); Today/APF markers without text or legend.
- **`*_keplerian_residuals.png`:** Matching styles on both panels; residual y-axis capped at ±5 km/s; compact legend (`RV only`, `P fixed`, `e fixed`, `P & e fixed`) outside the plot; P, e, M₂ sin i per fit below the residuals.

## Test plan
- [x] `pytest tests/test_rv_keplerian_plots.py`
- [ ] On ziggy: `RUN_FITS=1` or `RUN_FITS=0 RUN_RV_PLOTS=1` via `populate_website.sh`


Made with [Cursor](https://cursor.com)