### PR TITLE
Fix website mass columns and clear stray plot HTML in data.csv

### DIFF
--- a/docs/website.md
+++ b/docs/website.md
@@ -94,6 +94,8 @@ WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 RUN_RV_PLOTS=1 MIN_POINTS=5 \
   bash scripts/populate_website.sh
 ```
 
+**Symptoms without a full deploy:** RV thumbnails under **M2 sin i** (stray `<img>` in `data.csv`), correct RV plots only in **RV Curve** (new `script.js`), no **H-beta** (PNGs missing or not built). Run the repair block below.
+
 **Repair shifted columns / stale embedded `<img>` in `data.csv`** (after a bad populate, or once after upgrading):
 
 ```bash

--- a/docs/website.md
+++ b/docs/website.md
@@ -62,6 +62,14 @@ Ensure Apache serves `/var/www/html/darkhunter/rv/` (existing `Alias` or symlink
 | Table **RV Fit** thumb | `RV_Fit/<id>_keplerian_fit.png` (fits only) |
 | Table **RV Fit** click | `Plots/<id>_keplerian_residuals.png` (fits + residuals) |
 
+**Mass columns in `tables/data.csv`** (from `*_keplerian_fit.json` after a fit pass):
+
+| Column | Meaning |
+|--------|---------|
+| **M2 (Msun)** | Gaia NSS astrometric secondary mass (`used_m2_msun`), not from the RV fit |
+| **M2sin i (Msun)** | RV-only Keplerian fit, with assumed M1 |
+| **(M2sin i)/(sin i) (Msun)** | Same RV-only f(M) and M1, with Gaia astrometric inclination |
+
 ```bash
 cd /data2/darkhunter/dark-hunter_rv
 

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -846,6 +846,48 @@ def solve_m2_with_inclination_msun(f_mass: float, m1: float, inclination_deg: fl
     return float(out) if np.isfinite(out) and out > 0 else None
 
 
+def _finite_mass_value(value: Any) -> Optional[float]:
+    if isinstance(value, (int, float)) and np.isfinite(value) and float(value) > 0:
+        return float(value)
+    return None
+
+
+def website_table_masses_from_report(report: dict) -> Dict[str, Optional[float]]:
+    """
+    Map a Keplerian fit JSON report to website ``data.csv`` mass columns.
+
+    - ``m2_msun``: Gaia NSS astrometric M2 (with Gaia M1), not from the RV fit.
+    - ``m2sin_i_msun``: M2 sin i from the RV-only (free) fit and assumed M1.
+    - ``m2_at_i_msun``: M2 at i from the RV-only f(M), assumed M1, and astrometric i.
+    """
+    return {
+        "m2_msun": _finite_mass_value(report.get("used_m2_msun")),
+        "m2sin_i_msun": _finite_mass_value(report.get("m2sini_msun")),
+        "m2_at_i_msun": _finite_mass_value(report.get("m2_given_inclination_msun")),
+    }
+
+
+def rv_only_mass_estimates(
+    rep_free: dict,
+    m1_msun: Optional[float],
+    inclination_deg: Optional[float],
+) -> Tuple[Optional[float], Optional[float]]:
+    """M2 sin i and M2 at i from the RV-only Keplerian report and astrometric inputs."""
+    fm = rep_free.get("mass_function_msun")
+    if fm is None or not np.isfinite(fm):
+        fm = mass_function_msun(rep_free["P_days"], rep_free["K_kms"], rep_free["e"])
+    if fm is None or not np.isfinite(fm) or fm <= 0:
+        return None, None
+    m1 = _finite_mass_value(m1_msun)
+    if m1 is None:
+        return None, None
+    m2sini = float(solve_m2sini_msun(float(fm), m1))
+    m2_at_i = None
+    if inclination_deg is not None and np.isfinite(inclination_deg):
+        m2_at_i = solve_m2_with_inclination_msun(float(fm), m1, float(inclination_deg))
+    return m2sini, m2_at_i
+
+
 def fit_all_variants(
     t: np.ndarray,
     y: np.ndarray,
@@ -1329,35 +1371,11 @@ def run_one(
         None if fit_inclination_deg is None else float(fit_inclination_deg)
     )
 
-    f_mass = report.get("mass_function_msun")
-    if f_mass is None or not np.isfinite(f_mass):
-        fm_calc = mass_function_msun(report["P_days"], report["K_kms"], report["e"])
-        f_mass = float(fm_calc) if np.isfinite(fm_calc) else None
-    report["mass_function_msun"] = f_mass
-    m2sini = None
-    if (
-        f_mass is not None
-        and np.isfinite(f_mass)
-        and f_mass > 0
-        and fit_m1_msun is not None
-        and np.isfinite(fit_m1_msun)
-        and fit_m1_msun > 0
-    ):
-        m2sini = solve_m2sini_msun(float(f_mass), float(fit_m1_msun))
-    report["m2sini_msun"] = None if m2sini is None else float(m2sini)
-
-    m2_incl = None
-    if (
-        fit_m1_msun is not None
-        and np.isfinite(fit_m1_msun)
-        and fit_m1_msun > 0
-        and fit_inclination_deg is not None
-        and np.isfinite(fit_inclination_deg)
-    ):
-        m2_incl = solve_m2_with_inclination_msun(
-            f_mass, float(fit_m1_msun), float(fit_inclination_deg)
-        )
-    report["m2_given_inclination_msun"] = None if m2_incl is None else float(m2_incl)
+    _, rep_free = fit_variants["free"]
+    m2sini, m2_at_i = rv_only_mass_estimates(rep_free, fit_m1_msun, fit_inclination_deg)
+    report["m2sini_msun"] = m2sini
+    report["m2_given_inclination_msun"] = m2_at_i
+    report["m2_astrometric_msun"] = report["used_m2_msun"]
 
     plot_multi_fit(summary_path, points_fit, fit_variants, report, out_png, m1_msun=fit_m1_msun)
     plot_fit_residuals(

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -4,7 +4,7 @@
 # 2) Generate APF RV plots from summaries (no pipeline rerun)
 # 3) Stage files into website contract:
 #    stars/Gaia_DR3_<id>/Gaia/{<id>_summary.txt,Plots/*,RV_Fit/*}
-# 4) Update tables/data.csv M2 column from fit JSON
+# 4) Update tables/data.csv M2 / M2sin i / M2 at i from fit JSON
 # 5) Produce QC reports
 # 6) rsync staged content to web root
 #
@@ -215,6 +215,8 @@ import json
 import os
 from pathlib import Path
 
+from fit_apf_rv_keplerian import website_table_masses_from_report
+
 report_dir = Path(os.environ["REPORTS_DIR"])
 data_csv = Path(os.environ["DATA_CSV"])
 missing_csv = Path(os.environ["MISSING_ASSETS_CSV"])
@@ -298,18 +300,23 @@ for r in rows[1:]:
     if not sid or sid not in reports:
         continue
     rep = reports[sid]
-    m2i = rep.get("m2_given_inclination_msun")
-    m2s = rep.get("m2sini_msun")
-    m2 = m2i if isinstance(m2i, (int, float)) else m2s
-    if isinstance(m2, (int, float)):
+    masses = website_table_masses_from_report(rep)
+    m2_astro = masses["m2_msun"]
+    m2s = masses["m2sin_i_msun"]
+    m2i = masses["m2_at_i_msun"]
+    if m2_astro is not None:
         while len(r) <= m2_i:
             r.append("")
-        r[m2_i] = f"{float(m2):.5f}"
+        r[m2_i] = f"{m2_astro:.5f}"
         updated += 1
-    if isinstance(m2s, (int, float)):
-        r[m2sini_i] = f"{float(m2s):.5f}"
-    if isinstance(m2i, (int, float)):
-        r[m2over_i] = f"{float(m2i):.5f}"
+    if m2s is not None:
+        while len(r) <= m2sini_i:
+            r.append("")
+        r[m2sini_i] = f"{m2s:.5f}"
+    if m2i is not None:
+        while len(r) <= m2over_i:
+            r.append("")
+        r[m2over_i] = f"{m2i:.5f}"
 
 with data_csv.open("w", newline="", encoding="utf-8") as fh:
     writer = csv.writer(fh)

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -272,8 +272,10 @@ def move_columns_after(hdr, rows, names, after):
         for r, val in zip(rows, col_vals):
             r.insert(insert_at + offset, val)
 
+MEDIA_COLUMNS = frozenset({"RV PLOT", "RV FIT", "FLUX PLOT", "SOURCE IMAGE"})
+
 def clear_media_cells(hdr, rows):
-    for name in ("RV PLOT", "RV FIT", "FLUX PLOT", "SOURCE IMAGE"):
+    for name in MEDIA_COLUMNS:
         if name not in hdr:
             continue
         ci = hdr.index(name)
@@ -282,8 +284,19 @@ def clear_media_cells(hdr, rows):
                 r.append("")
             r[ci] = ""
 
+def clear_stray_plot_html(hdr, rows):
+    for ci, name in enumerate(hdr):
+        if name in MEDIA_COLUMNS:
+            continue
+        for r in rows:
+            while len(r) <= ci:
+                r.append("")
+            if r[ci] and "<img" in r[ci].lower():
+                r[ci] = ""
+
 move_columns_after(hdr, rows[1:], [col_m2sini, col_m2over], "M2 (Msun)")
 clear_media_cells(hdr, rows[1:])
+clear_stray_plot_html(hdr, rows[1:])
 m2sini_i = hdr.index(col_m2sini)
 m2over_i = hdr.index(col_m2over)
 

--- a/scripts/fix_data_csv_column_order.py
+++ b/scripts/fix_data_csv_column_order.py
@@ -36,9 +36,12 @@ def move_columns_after(hdr: list[str], rows: list[list[str]], names: list[str], 
             r.insert(insert_at + offset, val)
 
 
+MEDIA_COLUMNS = frozenset({"RV PLOT", "RV FIT", "FLUX PLOT", "SOURCE IMAGE"})
+
+
 def clear_media_cells(hdr: list[str], rows: list[list[str]]) -> None:
     """Drop legacy embedded <img> tags; the website builds plot URLs in script.js."""
-    for name in ("RV PLOT", "RV FIT", "FLUX PLOT", "SOURCE IMAGE"):
+    for name in MEDIA_COLUMNS:
         if name not in hdr:
             continue
         ci = hdr.index(name)
@@ -46,6 +49,21 @@ def clear_media_cells(hdr: list[str], rows: list[list[str]]) -> None:
             while len(r) <= ci:
                 r.append("")
             r[ci] = ""
+
+
+def clear_stray_plot_html(hdr: list[str], rows: list[list[str]]) -> int:
+    """Remove mis-placed <img> HTML from non-plot columns (e.g. M2 sin i after header reorder)."""
+    cleared = 0
+    for ci, name in enumerate(hdr):
+        if name in MEDIA_COLUMNS:
+            continue
+        for r in rows:
+            while len(r) <= ci:
+                r.append("")
+            if r[ci] and "<img" in r[ci].lower():
+                r[ci] = ""
+                cleared += 1
+    return cleared
 
 
 def main() -> int:
@@ -81,10 +99,14 @@ def main() -> int:
         "M2 (Msun)",
     )
     clear_media_cells(hdr, data_rows)
+    n_stray = clear_stray_plot_html(hdr, data_rows)
 
     with path.open("w", newline="", encoding="utf-8") as fh:
         csv.writer(fh).writerows(rows)
-    print(f"fixed: {path} ({len(rows) - 1} data rows, {len(hdr)} columns)")
+    print(
+        f"fixed: {path} ({len(rows) - 1} data rows, {len(hdr)} columns, "
+        f"cleared {n_stray} stray <img> cells)"
+    )
     return 0
 
 

--- a/tests/test_fit_apf_rv_keplerian.py
+++ b/tests/test_fit_apf_rv_keplerian.py
@@ -252,6 +252,26 @@ def test_load_nss_priors_includes_inclination(tmp_path: Path) -> None:
     assert priors["inclination_deg"] == pytest.approx(74.5)
 
 
+def test_website_table_masses_from_report_separates_sources() -> None:
+    rep = {
+        "used_m2_msun": 0.55,
+        "m2sini_msun": 0.42,
+        "m2_given_inclination_msun": 0.48,
+    }
+    cols = fitmod.website_table_masses_from_report(rep)
+    assert cols["m2_msun"] == pytest.approx(0.55)
+    assert cols["m2sin_i_msun"] == pytest.approx(0.42)
+    assert cols["m2_at_i_msun"] == pytest.approx(0.48)
+
+
+def test_rv_only_mass_estimates_use_free_fit() -> None:
+    rep_free = {"P_days": 10.0, "K_kms": 40.0, "e": 0.1, "mass_function_msun": 0.05}
+    m2s, m2i = fitmod.rv_only_mass_estimates(rep_free, m1_msun=1.0, inclination_deg=90.0)
+    assert m2s is not None
+    assert m2i is not None
+    assert m2i == pytest.approx(m2s, rel=1e-6)
+
+
 def test_solve_m2_with_inclination_matches_edge_on() -> None:
     # At i=90 deg, m2(with i) should match m2 sin(i).
     f_mass = 0.12

--- a/tests/test_fix_data_csv_column_order.py
+++ b/tests/test_fix_data_csv_column_order.py
@@ -11,6 +11,7 @@ assert _spec.loader is not None
 _spec.loader.exec_module(_mod)
 move_columns_after = _mod.move_columns_after
 clear_media_cells = _mod.clear_media_cells
+clear_stray_plot_html = _mod.clear_stray_plot_html
 
 
 def test_move_columns_after_reorders_row_values(tmp_path: Path) -> None:
@@ -19,6 +20,14 @@ def test_move_columns_after_reorders_row_values(tmp_path: Path) -> None:
     move_columns_after(hdr, [data], ["M2sin i (Msun)"], "M2 (Msun)")
     assert hdr == ["GAIA NAME", "M2 (Msun)", "M2sin i (Msun)", "RV PLOT", "RV FIT"]
     assert data == ["id1", "1.0", "2.0", "<img rv>", "<img fit>"]
+
+
+def test_clear_stray_plot_html_in_mass_column() -> None:
+    hdr = ["M2 (Msun)", "M2sin i (Msun)", "RV PLOT"]
+    data = ["1.0", '<a href="x"><img src="rv.png"></a>', ""]
+    clear_stray_plot_html(hdr, [data])
+    assert data[1] == ""
+    assert data[0] == "1.0"
 
 
 def test_clear_media_cells(tmp_path: Path) -> None:

--- a/website/rv/script.js
+++ b/website/rv/script.js
@@ -1359,6 +1359,15 @@ function arrayToTable(tableData) {
                 row.dataset[param.datasetKey] = normalized;
             }
             const headerName = i === 0 ? String(text ?? "").trim() : headerNameForIndex(colIdx);
+            if (
+                i > 0
+                && headerName
+                && !isMediaHeader(headerName)
+                && typeof text === "string"
+                && /<img\b/i.test(text)
+            ) {
+                text = "";
+            }
             if (i > 0 && colIdx !== 0 && !isMediaHeader(headerName) && !Number.isNaN(Number(text))) {
                 text = Number(text).toFixed(5);
             }


### PR DESCRIPTION
## Summary
Follow-up to merged #17 / #18. PR #18 shipped the Keplerian plot layout only; this adds the remaining website fixes:

- **M2 (Msun):** Gaia NSS astrometric M₂ (`used_m2_msun`) only — no longer falls back to RV-derived M₂ at i / M₂ sin i.
- **M2 sin i / M2 at i:** RV-only Keplerian fit (+ assumed M₁; M₂ at i also uses Gaia inclination).
- **`fix_data_csv_column_order.py`:** strips mis-placed `<img>` HTML from mass (and other non-plot) columns after the header reorder bug.
- **`script.js`:** ignores `<img>` in non-media columns so stray CSV HTML cannot show RV thumbs under mass columns.
- **`batch_fits_plots_sync.sh`:** same stray-HTML cleanup on populate; uses `website_table_masses_from_report()`.

## Test plan
- [x] `pytest tests/test_fix_data_csv_column_order.py`
- [x] `pytest tests/test_fit_apf_rv_keplerian.py` (mass column helpers)
- [ ] On ziggy after merge:
  ```bash
  cd /data2/darkhunter/dark-hunter_rv && git pull
  bash scripts/setup_website.sh
  PYTHONPATH=. python3 scripts/fix_data_csv_column_order.py \
    --data-csv /var/www/html/darkhunter/rv/tables/data.csv
  WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 RUN_HBETA_PLOTS=1 RUN_RV_PLOTS=1 \
    SPEC_ROOT=/data2/gaia_stars/apf_reductions \
    bash scripts/populate_website.sh
  ```


Made with [Cursor](https://cursor.com)