### PR TITLE
Add full website refresh script and daily cron workflow

### DIFF
--- a/docs/website.md
+++ b/docs/website.md
@@ -77,14 +77,26 @@ cd /data2/darkhunter/dark-hunter_rv
 WEB_ROOT=/var/www/html/darkhunter/rv MIN_POINTS=5 FIT_FORCE=1 bash scripts/populate_website.sh
 ```
 
-Detached (full fits):
+### Full overnight refresh (detached screen)
+
+Refits every star with **≥5** valid epochs (pipeline + literature; drops −9999 / NaN / |RV|≥5000 km/s), **force**-rebuilds all Keplerian and Hβ plots, repairs `data.csv`, and stages to the website. Run after merging website fixes (#19+):
 
 ```bash
-screen -dmS darkhunter_fits bash -lc '
-cd /data2/darkhunter/dark-hunter_rv
-WEB_ROOT=/var/www/html/darkhunter/rv MIN_POINTS=5 FIT_FORCE=1 RUN_FITS=1 \
-  bash scripts/populate_website.sh >> batch_fits_plots_sync.log 2>&1
+screen -dmS darkhunter_full_refresh bash -lc '
+  REPO=/data2/darkhunter/dark-hunter_rv
+  cd "$REPO" && git pull && bash scripts/full_website_refresh.sh
 '
+```
+
+Attach: `screen -r darkhunter_full_refresh` — Detach: `Ctrl-a d`  
+Logs: `/data2/darkhunter/dark-hunter_rv/logs/full_website_refresh.log` and `logs/batch_fits_plots_sync.log`
+
+Same without screen:
+
+```bash
+cd /data2/darkhunter/dark-hunter_rv
+git pull
+bash scripts/full_website_refresh.sh
 ```
 
 Plots/staging only (no refit):
@@ -120,9 +132,23 @@ PYTHONPATH=. python3 scripts/build_hbeta_website_plots.py \
   --spec-root /data2/gaia_stars/apf_reductions
 ```
 
-## Cron (new spectra → RVs → website)
+## Cron (daily: new spectra → RVs → fits → website)
+
+`scripts/cron_update_rv_website.sh` runs:
+
+1. **Pipeline** `--update` on `SPEC_ROOT` (new/changed `.flm` / `.txt` / `.fits` only).
+2. **Populate**: Keplerian fits (≥`MIN_POINTS`, literature included, bad RVs filtered), RV/Hβ plots, `data.csv` mass columns, staging to `WEB_ROOT`. Skips refit when the JSON is newer than the summary (`FIT_FORCE=0`).
+
+Install crontab (`crontab -e`):
+
+```cron
+0 6 * * * REPO=/data2/darkhunter/dark-hunter_rv WEB_ROOT=/var/www/html/darkhunter/rv SPEC_ROOT=/data2/gaia_stars/apf_reductions MIN_POINTS=5 /bin/bash $REPO/scripts/cron_update_rv_website.sh >> $REPO/logs/cron_rv_website.log 2>&1
+```
+
+Manual test:
 
 ```bash
+cd /data2/darkhunter/dark-hunter_rv
 REPO=/data2/darkhunter/dark-hunter_rv \
 WEB_ROOT=/var/www/html/darkhunter/rv \
 SPEC_ROOT=/data2/gaia_stars/apf_reductions \
@@ -130,11 +156,7 @@ MIN_POINTS=5 \
 bash scripts/cron_update_rv_website.sh
 ```
 
-Example crontab line:
-
-```cron
-0 6 * * * REPO=/data2/darkhunter/dark-hunter_rv WEB_ROOT=/var/www/html/darkhunter/rv SPEC_ROOT=/data2/gaia_stars/apf_reductions bash $REPO/scripts/cron_update_rv_website.sh >> $REPO/logs/cron_rv_website.log 2>&1
-```
+Log: `/data2/darkhunter/dark-hunter_rv/logs/cron_rv_website.log`
 
 ## Repo source of truth
 

--- a/scripts/cron_update_rv_website.sh
+++ b/scripts/cron_update_rv_website.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-# Cron-friendly: measure RVs on new spectra, then refresh website assets for updated stars.
+# Cron-friendly: measure RVs on new/changed spectra, then Keplerian fits + website assets.
 #
-# Example crontab (daily 06:00):
-#   0 6 * * * REPO=/data2/darkhunter/dark-hunter_rv WEB_ROOT=/var/www/html/darkhunter/rv SPEC_ROOT=/data2/gaia_stars/apf_reductions bash $REPO/scripts/cron_update_rv_website.sh >> $REPO/logs/cron_rv_website.log 2>&1
+# Daily crontab (06:00 local) — append log; do not wrap in screen:
+#   0 6 * * * REPO=/data2/darkhunter/dark-hunter_rv WEB_ROOT=/var/www/html/darkhunter/rv SPEC_ROOT=/data2/gaia_stars/apf_reductions MIN_POINTS=5 /bin/bash $REPO/scripts/cron_update_rv_website.sh >> $REPO/logs/cron_rv_website.log 2>&1
 #
-# Env:
-#   REPO, OUT, WEB_ROOT, SPEC_ROOT, PY, MIN_POINTS, LOG
+# Env: REPO, OUT, WEB_ROOT, SPEC_ROOT, PY, MIN_POINTS, LOG, RUN_PIPELINE (default 1)
 
 set -euo pipefail
 
@@ -16,28 +15,32 @@ SPEC_ROOT="${SPEC_ROOT:-/data2/gaia_stars/apf_reductions}"
 PY="${PY:-/home/marley/anaconda2/envs/gaia-env/bin/python}"
 MIN_POINTS="${MIN_POINTS:-5}"
 LOG="${LOG:-$REPO/logs/cron_rv_website.log}"
+RUN_PIPELINE="${RUN_PIPELINE:-1}"
 
-mkdir -p "$(dirname "$LOG")" "$OUT"
+mkdir -p "$(dirname "$LOG")" "$OUT" "$REPO/logs"
 cd "$REPO"
 export PYTHONPATH="$REPO"
 export DARKHUNTER_OUTPUT_DIR="$OUT"
+export WEB_ROOT OUT SPEC_ROOT MIN_POINTS
+export RUN_FITS=1 RUN_RV_PLOTS=1 RUN_HBETA_PLOTS=1 FIT_FORCE=0 QUERY_GAIA_ONLINE=0
+export LOG="$REPO/logs/batch_fits_plots_sync.log"
 
-exec >>"$LOG" 2>&1
-echo "=== $(date -Is) cron_update_rv_website start ==="
+exec >>"$REPO/logs/cron_rv_website.log" 2>&1
+echo "=== $(date -Is) cron_update_rv_website start (pid $$) ==="
 
-# 1) Pipeline: new/changed spectra under SPEC_ROOT (--update skips unchanged diagnostics).
-if [[ -d "$SPEC_ROOT" ]]; then
+# 1) Pipeline: new/changed spectra (--update skips unchanged). Updates summaries in output/.
+if [[ "$RUN_PIPELINE" == "1" && -d "$SPEC_ROOT" ]]; then
   echo "=== Pipeline --update on $SPEC_ROOT ==="
   find "$SPEC_ROOT" -type f \( -name '*_ap1.flm' -o -name '*_ap1.txt' -o -name '*.fits' \) -print0 2>/dev/null \
     | xargs -0 -r "$PY" -m darkhunter_rv.pipeline --instrument APF --update --plots --plots-focus 2>/dev/null \
     || echo "[WARN] pipeline pass had errors (continuing)"
-else
+elif [[ "$RUN_PIPELINE" == "1" ]]; then
   echo "[WARN] SPEC_ROOT missing: $SPEC_ROOT"
 fi
 
-# 2) Fits (incl. literature), plots, Hβ stacks, website staging.
-echo "=== Website populate (fits + assets) ==="
-export WEB_ROOT MIN_POINTS
-RUN_FITS=1 FIT_FORCE=0 bash scripts/populate_website.sh
+# 2) Keplerian fits (pipeline + literature; bad RVs filtered), plots, Hβ, data.csv masses, staging.
+# FIT_FORCE=0: refit only when summary is newer than existing *_keplerian_fit.json.
+echo "=== Website populate (incremental fits + assets) ==="
+bash scripts/populate_website.sh
 
 echo "=== $(date -Is) cron_update_rv_website done ==="

--- a/scripts/full_website_refresh.sh
+++ b/scripts/full_website_refresh.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# One-shot: deploy static site assets, repair data.csv, refit all stars (≥MIN_POINTS),
+# rebuild RV / Keplerian / Hβ plots, update mass columns, stage to WEB_ROOT.
+#
+# Fits use pipeline + literature epochs; invalid RVs (|RV|≥5000, NaN, -9999, etc.) are dropped
+# via darkhunter_rv.rv_point_filters.rv_value_is_valid.
+#
+# Usage (ziggy):
+#   cd /data2/darkhunter/dark-hunter_rv
+#   git pull   # merge website fixes (#19+) before first run
+#   bash scripts/full_website_refresh.sh
+#
+# Detached:
+#   screen -dmS darkhunter_full_refresh bash -lc '
+#     REPO=/data2/darkhunter/dark-hunter_rv
+#     cd "$REPO" && git pull && bash scripts/full_website_refresh.sh
+#   '
+
+set -euo pipefail
+
+REPO="${REPO:-/data2/darkhunter/dark-hunter_rv}"
+OUT="${OUT:-$REPO/output}"
+WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
+SPEC_ROOT="${SPEC_ROOT:-/data2/gaia_stars/apf_reductions}"
+PY="${PY:-/home/marley/anaconda2/envs/gaia-env/bin/python}"
+MIN_POINTS="${MIN_POINTS:-5}"
+LOG="${LOG:-$REPO/logs/full_website_refresh.log}"
+
+cd "$REPO"
+mkdir -p "$(dirname "$LOG")" "$OUT" "$REPO/logs"
+export PYTHONPATH="$REPO"
+export DARKHUNTER_OUTPUT_DIR="$OUT"
+export WEB_ROOT OUT SPEC_ROOT MIN_POINTS
+export RUN_FITS=1 RUN_RV_PLOTS=1 RUN_HBETA_PLOTS=1 FIT_FORCE=1 QUERY_GAIA_ONLINE="${QUERY_GAIA_ONLINE:-0}"
+export LOG="$REPO/logs/batch_fits_plots_sync.log"
+
+exec > >(tee -a "$LOG") 2>&1
+echo "=== $(date -Is) full_website_refresh start (pid $$) ==="
+echo "repo=$REPO out=$OUT web_root=$WEB_ROOT min_points=$MIN_POINTS"
+
+if [[ ! -f "$WEB_ROOT/tables/data.csv" ]]; then
+  echo "[ERROR] $WEB_ROOT/tables/data.csv missing — run scripts/bootstrap_website_tables.sh first." >&2
+  exit 2
+fi
+
+echo "=== Deploy script.js / style.css / index.html ==="
+bash scripts/setup_website.sh
+
+if [[ -f "$REPO/scripts/fix_data_csv_column_order.py" ]]; then
+  echo "=== Repair tables/data.csv column alignment + stray plot HTML ==="
+  "$PY" scripts/fix_data_csv_column_order.py --data-csv "$WEB_ROOT/tables/data.csv"
+else
+  echo "[WARN] scripts/fix_data_csv_column_order.py not found (git pull #19+?); skipping CSV repair"
+fi
+
+echo "=== Keplerian fits (all stars, force) + plots + Hβ + website staging ==="
+bash scripts/populate_website.sh
+
+echo "=== $(date -Is) full_website_refresh done ==="
+echo "Log: $LOG"
+echo "Batch detail: $REPO/logs/batch_fits_plots_sync.log"


### PR DESCRIPTION
## Summary
Follow-up after merged #19. The screen/cron helper commit landed on the closed #19 branch after that PR merged; this PR contains **only** that work on current `main`.

- **`scripts/full_website_refresh.sh`** — one-shot: `setup_website.sh`, `fix_data_csv_column_order.py`, forced Keplerian fits (`MIN_POINTS=5`, literature + bad-RV filter), all plots, Hβ, `data.csv` masses, website staging.
- **`scripts/cron_update_rv_website.sh`** — daily pipeline `--update` then incremental populate (`FIT_FORCE=0`).
- **`docs/website.md`** — detached `screen` command and crontab line.

## Test plan
- [ ] `bash -n scripts/full_website_refresh.sh scripts/cron_update_rv_website.sh`
- [ ] On ziggy after merge: `screen -dmS darkhunter_full_refresh bash -lc 'cd /data2/darkhunter/dark-hunter_rv && git pull && bash scripts/full_website_refresh.sh'`


Made with [Cursor](https://cursor.com)