### PR TITLE
Fix cron crontab example (absolute paths, no broken $REPO redirect)

### DIFF
--- a/docs/website.md
+++ b/docs/website.md
@@ -139,11 +139,20 @@ PYTHONPATH=. python3 scripts/build_hbeta_website_plots.py \
 1. **Pipeline** `--update` on `SPEC_ROOT` (new/changed `.flm` / `.txt` / `.fits` only).
 2. **Populate**: Keplerian fits (≥`MIN_POINTS`, literature included, bad RVs filtered), RV/Hβ plots, `data.csv` mass columns, staging to `WEB_ROOT`. Skips refit when the JSON is newer than the summary (`FIT_FORCE=0`).
 
-Install crontab (`crontab -e`):
+Install crontab: run **`crontab -e`** alone (do not put the schedule on the same shell line), then add:
 
 ```cron
-0 6 * * * REPO=/data2/darkhunter/dark-hunter_rv WEB_ROOT=/var/www/html/darkhunter/rv SPEC_ROOT=/data2/gaia_stars/apf_reductions MIN_POINTS=5 /bin/bash $REPO/scripts/cron_update_rv_website.sh >> $REPO/logs/cron_rv_website.log 2>&1
+# Optional defaults for all jobs on this machine:
+REPO=/data2/darkhunter/dark-hunter_rv
+WEB_ROOT=/var/www/html/darkhunter/rv
+SPEC_ROOT=/data2/gaia_stars/apf_reductions
+MIN_POINTS=5
+
+# 10:00 daily — use absolute path to the script (no >> $REPO/... on the job line)
+0 10 * * * /bin/bash /data2/darkhunter/dark-hunter_rv/scripts/cron_update_rv_website.sh
 ```
+
+Do **not** use `>> $REPO/logs/...` on the same line as `REPO=/path/...`; cron expands `$REPO` in redirects before that assignment, which yields `/logs/cron_rv_website.log`. The script logs to `$REPO/logs/cron_rv_website.log` internally.
 
 Manual test:
 

--- a/scripts/cron_update_rv_website.sh
+++ b/scripts/cron_update_rv_website.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # Cron-friendly: measure RVs on new/changed spectra, then Keplerian fits + website assets.
 #
-# Daily crontab (06:00 local) — append log; do not wrap in screen:
-#   0 6 * * * REPO=/data2/darkhunter/dark-hunter_rv WEB_ROOT=/var/www/html/darkhunter/rv SPEC_ROOT=/data2/gaia_stars/apf_reductions MIN_POINTS=5 /bin/bash $REPO/scripts/cron_update_rv_website.sh >> $REPO/logs/cron_rv_website.log 2>&1
+# Daily crontab (10:00 local). Use absolute paths in the schedule line — cron does NOT
+# expand inline REPO=... before >> $REPO/logs/... (empty REPO → /logs/...).
+#
+#   0 10 * * * /bin/bash /data2/darkhunter/dark-hunter_rv/scripts/cron_update_rv_website.sh
+#
+# Optional env (or set at top of crontab): REPO, WEB_ROOT, SPEC_ROOT, MIN_POINTS, PY
+# Logging: script appends to $REPO/logs/cron_rv_website.log (defaults work without exports).
 #
 # Env: REPO, OUT, WEB_ROOT, SPEC_ROOT, PY, MIN_POINTS, LOG, RUN_PIPELINE (default 1)
 


### PR DESCRIPTION
## Summary
Clarifies crontab: absolute script path; do not use >> $REPO/logs on the same line as inline REPO= (cron expands redirect before assignment).

## Test plan
- [ ] crontab -l on ziggy

Made with [Cursor](https://cursor.com)