### PR TITLE
Add repair_website_table.sh for fast CSV fix before full refresh

### DIFF
--- a/docs/website.md
+++ b/docs/website.md
@@ -114,22 +114,30 @@ WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 RUN_RV_PLOTS=1 MIN_POINTS=5 \
   bash scripts/populate_website.sh
 ```
 
-**Symptoms without a full deploy:** RV thumbnails under **M2 sin i** (stray `<img>` in `data.csv`), correct RV plots only in **RV Curve** (new `script.js`), no **H-beta** (PNGs missing or not built). Run the repair block below.
+**Symptoms without a full deploy:** RV thumbnails under **M2 sin i** (stray `<img>` in `data.csv`), correct RV plots only in **RV Curve** (new `script.js`), no **H-beta** (PNGs missing or not built).
 
-**Repair shifted columns / stale embedded `<img>` in `data.csv`** (after a bad populate, or once after upgrading):
+### Step 1 — Repair table + frontend only (fast, no refit)
 
 ```bash
 cd /data2/darkhunter/dark-hunter_rv
 git pull
-bash scripts/setup_website.sh
-PYTHONPATH=. python3 scripts/fix_data_csv_column_order.py \
-  --data-csv /var/www/html/darkhunter/rv/tables/data.csv
-WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 RUN_HBETA_PLOTS=1 \
-  SPEC_ROOT=/data2/gaia_stars/apf_reductions \
-  bash scripts/populate_website.sh
+bash scripts/repair_website_table.sh
 ```
 
-Hard-refresh the browser once (`script.js` builds plot URLs from Gaia ID; thumbnails use a per-load cache-bust query).
+Hard-refresh the browser (Cmd+Shift+R). This deploys `script.js`, fixes column alignment, clears stray plot HTML, and fills **DAYS SINCE LAST APF** / mass / **NEXT RV EVENT** from existing summaries and `rv_fit_reports` JSON if they are already on disk.
+
+### Step 2 — Full refresh when ready (long: refit + all plots + Hβ + staging)
+
+```bash
+bash scripts/full_website_refresh.sh
+```
+
+CSV-only normalize (no column value fill):
+
+```bash
+PYTHONPATH=. python3 scripts/fix_data_csv_column_order.py \
+  --data-csv /var/www/html/darkhunter/rv/tables/data.csv
+```
 
 Hβ overlays read spectra under `SPEC_ROOT` (not per-epoch pipeline PNGs). Build alone:
 

--- a/scripts/fix_data_csv_column_order.py
+++ b/scripts/fix_data_csv_column_order.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Repair tables/data.csv column alignment and clear stale plot HTML."""
+"""Repair tables/data.csv after header-only column reorder (restores row alignment)."""
 
 from __future__ import annotations
 
@@ -37,6 +37,7 @@ def main() -> int:
         f"fixed: {path} ({len(rows) - 1} data rows, {len(hdr)} columns, "
         f"cleared {n_stray} stray <img> cells)"
     )
+    print("For mass/APF/next-RV values too, run: bash scripts/repair_website_table.sh")
     return 0
 
 

--- a/scripts/repair_website_table.sh
+++ b/scripts/repair_website_table.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Quick website table + frontend repair (no Keplerian refit, no plot rebuild).
+#
+# - Deploys website/rv → WEB_ROOT (script.js builds plot cells by header name)
+# - Normalizes tables/data.csv column order and clears stray <img> in mass columns
+# - Fills DAYS SINCE LAST APF from output summaries (if present)
+# - Fills M2 / M2 sin i / M2 at i / NEXT RV EVENT from existing rv_fit_reports JSON (if present)
+#
+# Run this first, then full_website_refresh.sh when you are ready for a long refit pass.
+#
+# Usage (ziggy):
+#   cd /data2/darkhunter/dark-hunter_rv
+#   git pull   # needs PR #22+ (website_table_csv.py, script.js)
+#   bash scripts/repair_website_table.sh
+#
+# Then later:
+#   bash scripts/full_website_refresh.sh
+
+set -euo pipefail
+
+REPO="${REPO:-/data2/darkhunter/dark-hunter_rv}"
+OUT="${OUT:-$REPO/output}"
+WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
+REPORTS_DIR="${REPORTS_DIR:-$REPO/rv_fit_reports}"
+PY="${PY:-/home/marley/anaconda2/envs/gaia-env/bin/python}"
+LOG="${LOG:-$REPO/logs/repair_website_table.log}"
+
+cd "$REPO"
+mkdir -p "$(dirname "$LOG")" "$REPO/logs"
+export PYTHONPATH="$REPO"
+export DARKHUNTER_OUTPUT_DIR="$OUT"
+
+exec > >(tee -a "$LOG") 2>&1
+echo "=== $(date -Is) repair_website_table start (pid $$) ==="
+echo "repo=$REPO web_root=$WEB_ROOT out=$OUT reports=$REPORTS_DIR"
+
+if [[ ! -f "$WEB_ROOT/tables/data.csv" ]]; then
+  echo "[ERROR] $WEB_ROOT/tables/data.csv missing — run scripts/bootstrap_website_tables.sh first." >&2
+  exit 2
+fi
+
+echo "=== Deploy script.js / style.css / index.html ==="
+export WEB_ROOT
+bash scripts/setup_website.sh
+
+if [[ ! -f "$REPO/scripts/update_website_table_columns.py" ]]; then
+  echo "[ERROR] scripts/update_website_table_columns.py missing — git pull (merge PR #22+) first." >&2
+  exit 2
+fi
+
+echo "=== Normalize data.csv + fill columns from existing summaries/reports ==="
+"$PY" scripts/update_website_table_columns.py \
+  --data-csv "$WEB_ROOT/tables/data.csv" \
+  --output-dir "$OUT" \
+  --reports-dir "$REPORTS_DIR"
+
+echo "=== $(date -Is) repair_website_table done ==="
+echo "Next: hard-refresh the browser, then when ready:"
+echo "  bash scripts/full_website_refresh.sh"
+echo "Log: $LOG"

--- a/scripts/update_website_table_columns.py
+++ b/scripts/update_website_table_columns.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Repair tables/data.csv layout and refresh column values from existing summaries/fits."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+from fit_apf_rv_keplerian import website_table_masses_from_report
+from darkhunter_rv.website_table_csv import (
+    days_since_last_apf_from_summary,
+    gaia_id_from_row,
+    next_rv_event_from_fit_report,
+    normalize_data_csv,
+)
+
+
+def update_table_columns(
+    data_csv: Path,
+    *,
+    out_dir: Path,
+    reports_dir: Path,
+) -> dict[str, int]:
+    rows: list[list[str]] = []
+    with data_csv.open(newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+    if not rows:
+        raise SystemExit("tables/data.csv is empty")
+
+    hdr = rows[0]
+    data_rows = rows[1:]
+    _, n_stray = normalize_data_csv(hdr, data_rows)
+
+    gaia_i = hdr.index("GAIA NAME")
+    m2_i = hdr.index("M2 (Msun)")
+    m2sini_i = hdr.index("M2sin i (Msun)")
+    m2over_i = hdr.index("(M2sin i)/(sin i) (Msun)")
+    apf_days_i = hdr.index("DAYS SINCE LAST APF")
+    next_rv_i = hdr.index("NEXT RV EVENT (MJD)")
+
+    reports: dict[str, dict] = {}
+    if reports_dir.is_dir():
+        for p in sorted(reports_dir.glob("*_keplerian_fit.json")):
+            sid = p.stem.replace("_keplerian_fit", "")
+            try:
+                reports[sid] = json.loads(p.read_text())
+            except Exception:
+                continue
+
+    n_apf_days = 0
+    n_m2 = 0
+    n_next = 0
+    for r in data_rows:
+        if not r:
+            continue
+        gaia = (r[gaia_i] if gaia_i < len(r) else "").strip()
+        sid = gaia_id_from_row(gaia)
+        if not sid:
+            continue
+
+        summ = out_dir / f"Gaia_DR3_{sid}_summary.txt"
+        if summ.is_file():
+            age = days_since_last_apf_from_summary(summ)
+            if age is not None:
+                while len(r) <= apf_days_i:
+                    r.append("")
+                r[apf_days_i] = f"{age:.2f}"
+                n_apf_days += 1
+
+        if sid not in reports:
+            continue
+        rep = reports[sid]
+        masses = website_table_masses_from_report(rep)
+        if masses["m2_msun"] is not None:
+            while len(r) <= m2_i:
+                r.append("")
+            r[m2_i] = f"{masses['m2_msun']:.5f}"
+            n_m2 += 1
+        if masses["m2sin_i_msun"] is not None:
+            while len(r) <= m2sini_i:
+                r.append("")
+            r[m2sini_i] = f"{masses['m2sin_i_msun']:.5f}"
+        if masses["m2_at_i_msun"] is not None:
+            while len(r) <= m2over_i:
+                r.append("")
+            r[m2over_i] = f"{masses['m2_at_i_msun']:.5f}"
+        nxt = next_rv_event_from_fit_report(rep)
+        if nxt is not None:
+            while len(r) <= next_rv_i:
+                r.append("")
+            r[next_rv_i] = f"{nxt:.3f}"
+            n_next += 1
+
+    with data_csv.open("w", newline="", encoding="utf-8") as fh:
+        csv.writer(fh).writerows(rows)
+
+    return {
+        "data_rows": len(data_rows),
+        "columns": len(hdr),
+        "stray_img_cleared": n_stray,
+        "apf_days_filled": n_apf_days,
+        "m2_filled": n_m2,
+        "next_rv_filled": n_next,
+        "reports_loaded": len(reports),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Normalize data.csv and fill schedule/mass columns from existing assets (no refit)."
+    )
+    ap.add_argument(
+        "--data-csv",
+        default="/var/www/html/darkhunter/rv/tables/data.csv",
+    )
+    ap.add_argument(
+        "--output-dir",
+        default=None,
+        help="Pipeline summaries (default: REPO/output)",
+    )
+    ap.add_argument(
+        "--reports-dir",
+        default=None,
+        help="Keplerian JSON reports (default: REPO/rv_fit_reports)",
+    )
+    args = ap.parse_args()
+    repo = Path(__file__).resolve().parents[1]
+    out_dir = Path(args.output_dir) if args.output_dir else repo / "output"
+    reports_dir = Path(args.reports_dir) if args.reports_dir else repo / "rv_fit_reports"
+    stats = update_table_columns(
+        Path(args.data_csv),
+        out_dir=out_dir,
+        reports_dir=reports_dir,
+    )
+    print(
+        f"updated {args.data_csv}: {stats['data_rows']} rows, {stats['columns']} columns, "
+        f"cleared {stats['stray_img_cleared']} stray <img>, "
+        f"apf_days={stats['apf_days_filled']}, m2={stats['m2_filled']}, "
+        f"next_rv={stats['next_rv_filled']} (from {stats['reports_loaded']} reports)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
PR #22 merged the table-column / `script.js` fixes. This adds a **fast repair path** that was committed after that merge:

- **`scripts/repair_website_table.sh`** — deploy static site assets, normalize `tables/data.csv`, fill schedule/mass columns from existing summaries + `rv_fit_reports` (no Keplerian refit).
- **`scripts/update_website_table_columns.py`** — shared logic used by repair (and documented in `fix_data_csv_column_order.py`).

## Workflow on ziggy

```bash
cd /data2/darkhunter/dark-hunter_rv
git pull
bash scripts/repair_website_table.sh   # step 1: columns + frontend
# hard-refresh browser
bash scripts/full_website_refresh.sh   # step 2: when ready (long refit)
```

## Test plan
- [x] `pytest tests/test_website_table_csv.py tests/test_fix_data_csv_column_order.py`
- [ ] `bash scripts/repair_website_table.sh` on ziggy after merge


Made with [Cursor](https://cursor.com)