### PR TITLE
Fix table plot sizes, GAIA DATA column, UV column, next RV dates

### DIFF
--- a/darkhunter_rv/website_table_csv.py
+++ b/darkhunter_rv/website_table_csv.py
@@ -240,13 +240,9 @@ def parse_next_rv_cell_to_mjd(value: str) -> Optional[float]:
     m = re.match(r"^(\d{4})/(\d{1,2})/(\d{1,2})$", s)
     if m:
         try:
-            return float(
-                Time(
-                    {"year": int(m.group(1)), "month": int(m.group(2)), "day": int(m.group(3))},
-                    format="ymd",
-                    scale="utc",
-                ).mjd
-            )
+            y, mo, d = int(m.group(1)), int(m.group(2)), int(m.group(3))
+            iso = f"{y:04d}-{mo:02d}-{d:02d}"
+            return float(Time(iso, format="iso", scale="utc").mjd)
         except Exception:
             return None
     try:

--- a/darkhunter_rv/website_table_csv.py
+++ b/darkhunter_rv/website_table_csv.py
@@ -13,13 +13,27 @@ MEDIA_COLUMNS = frozenset({"RV PLOT", "RV FIT", "FLUX PLOT", "SOURCE IMAGE"})
 
 MASS_COLUMNS = ("M2sin i (Msun)", "(M2sin i)/(sin i) (Msun)")
 
-SCHEDULE_COLUMNS = ("DAYS SINCE LAST APF", "NEXT RV EVENT (MJD)")
+GAIA_DATA_COLUMN = "GAIA DATA"
+SCHEDULE_COLUMNS = ("DAYS SINCE LAST APF", "NEXT RV EVENT (DATE)")
+LEGACY_COLUMN_RENAMES = {"NEXT RV EVENT (MJD)": "NEXT RV EVENT (DATE)"}
 
 # Inserted immediately after these anchors when rebuilding header order.
 _INSERT_AFTER: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
     ("M2 (Msun)", MASS_COLUMNS),
-    ("DATA PRODUCTS", SCHEDULE_COLUMNS),
+    ("DATA PRODUCTS", (GAIA_DATA_COLUMN,)),
+    (GAIA_DATA_COLUMN, SCHEDULE_COLUMNS),
 )
+
+
+def mjd_to_yyyy_mm_dd(mjd: float) -> str:
+    t = Time(float(mjd), format="mjd", scale="utc")
+    return t.datetime.strftime("%Y/%m/%d")
+
+
+def format_next_rv_event_cell(mjd: Optional[float]) -> str:
+    if mjd is None or not np.isfinite(mjd):
+        return ""
+    return mjd_to_yyyy_mm_dd(float(mjd))
 
 
 def row_dict(hdr: List[str], row: List[str]) -> Dict[str, str]:
@@ -28,6 +42,7 @@ def row_dict(hdr: List[str], row: List[str]) -> Dict[str, str]:
         key = (name or "").strip()
         if not key:
             continue
+        key = LEGACY_COLUMN_RENAMES.get(key, key)
         out[key] = row[i] if i < len(row) else ""
     return out
 
@@ -85,12 +100,13 @@ def build_canonical_header(hdr: List[str]) -> List[str]:
 
     for _, names in _INSERT_AFTER:
         _ensure_columns_present(base, names)
+    _ensure_columns_present(base, (GAIA_DATA_COLUMN,))
 
     out: List[str] = []
     inserted_mass = False
     inserted_sched = False
     for h in base:
-        if h in MASS_COLUMNS or h in SCHEDULE_COLUMNS:
+        if h in MASS_COLUMNS or h in SCHEDULE_COLUMNS or h == GAIA_DATA_COLUMN:
             continue
         out.append(h)
         if h == "M2 (Msun)" and not inserted_mass:
@@ -98,11 +114,14 @@ def build_canonical_header(hdr: List[str]) -> List[str]:
                 if c in base:
                     out.append(c)
             inserted_mass = True
-        if h == "DATA PRODUCTS" and not inserted_sched:
-            for c in SCHEDULE_COLUMNS:
-                if c in base:
-                    out.append(c)
-            inserted_sched = True
+        if h == "DATA PRODUCTS":
+            if GAIA_DATA_COLUMN in base and GAIA_DATA_COLUMN not in out:
+                out.append(GAIA_DATA_COLUMN)
+            if not inserted_sched:
+                for c in SCHEDULE_COLUMNS:
+                    if c in base:
+                        out.append(c)
+                inserted_sched = True
 
     if not inserted_mass:
         for c in MASS_COLUMNS:
@@ -124,7 +143,7 @@ def normalize_data_csv(hdr: List[str], data_rows: List[List[str]]) -> Tuple[List
     Rebuild rows keyed by column name (fixes off-by-one from header-only edits).
     Clears media / stray <img> cells. Returns (new_hdr, n_stray_cleared).
     """
-    _ensure_columns_present(hdr, MASS_COLUMNS + SCHEDULE_COLUMNS)
+    _ensure_columns_present(hdr, MASS_COLUMNS + (GAIA_DATA_COLUMN,) + SCHEDULE_COLUMNS)
     align_rows_to_header(hdr, data_rows)
 
     old_hdr = list(hdr)
@@ -211,6 +230,30 @@ def next_rv_event_from_fit_report(report: dict) -> Optional[float]:
             if t is not None:
                 return t
     return sooner_rv_extremum_mjd(report, now_mjd=report.get("now_mjd"))
+
+
+def parse_next_rv_cell_to_mjd(value: str) -> Optional[float]:
+    """Parse CSV cell: YYYY/MM/DD or legacy MJD float."""
+    s = (value or "").strip()
+    if not s:
+        return None
+    m = re.match(r"^(\d{4})/(\d{1,2})/(\d{1,2})$", s)
+    if m:
+        try:
+            return float(
+                Time(
+                    {"year": int(m.group(1)), "month": int(m.group(2)), "day": int(m.group(3))},
+                    format="ymd",
+                    scale="utc",
+                ).mjd
+            )
+        except Exception:
+            return None
+    try:
+        v = float(s)
+        return v if np.isfinite(v) else None
+    except ValueError:
+        return None
 
 
 def gaia_id_from_row(gaia_cell: str) -> str:

--- a/docs/website.md
+++ b/docs/website.md
@@ -66,9 +66,11 @@ Ensure Apache serves `/var/www/html/darkhunter/rv/` (existing `Alias` or symlink
 
 | Column | Meaning |
 |--------|---------|
-| **DATA PRODUCTS** | Link to `stars/Gaia_DR3_<id>/Gaia/` (Apache directory listing) |
+| **DATA PRODUCTS** | APF / KPF / Swift product links (instrument trees) |
+| **GAIA DATA** | Link to `stars/Gaia_DR3_<id>/Gaia/` (star file directory) |
+| **SOURCE IMAGE** | UV image from legacy CSV (restored; not hidden) |
 | **DAYS SINCE LAST APF** | Days since latest APF pipeline epoch (sortable; drives &lt;7d / &lt;30d filters) |
-| **NEXT RV EVENT (MJD)** | Sooner of next max/min RV from **P & e fixed** fit (Gaia NSS) |
+| **NEXT RV EVENT (DATE)** | Sooner of next max/min RV from **P & e fixed** fit, as `YYYY/MM/DD` |
 
 **Mass columns:**
 

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -218,9 +218,11 @@ from pathlib import Path
 from fit_apf_rv_keplerian import website_table_masses_from_report
 from darkhunter_rv.website_table_csv import (
     days_since_last_apf_from_summary,
+    format_next_rv_event_cell,
     gaia_id_from_row,
     next_rv_event_from_fit_report,
     normalize_data_csv,
+    parse_next_rv_cell_to_mjd,
 )
 
 report_dir = Path(os.environ["REPORTS_DIR"])
@@ -258,7 +260,7 @@ normalize_data_csv(hdr, data_rows)
 col_m2sini = "M2sin i (Msun)"
 col_m2over = "(M2sin i)/(sin i) (Msun)"
 col_apf_days = "DAYS SINCE LAST APF"
-col_next_rv = "NEXT RV EVENT (MJD)"
+col_next_rv = "NEXT RV EVENT (DATE)"
 m2sini_i = hdr.index(col_m2sini)
 m2over_i = hdr.index(col_m2over)
 apf_days_i = hdr.index(col_apf_days)
@@ -304,7 +306,7 @@ for r in data_rows:
         if nxt is not None:
             while len(r) <= next_rv_i:
                 r.append("")
-            r[next_rv_i] = f"{nxt:.3f}"
+            r[next_rv_i] = format_next_rv_event_cell(nxt)
 
 with data_csv.open("w", newline="", encoding="utf-8") as fh:
     writer = csv.writer(fh)

--- a/scripts/bootstrap_website_tables.sh
+++ b/scripts/bootstrap_website_tables.sh
@@ -59,8 +59,9 @@ hdr = rows[0]
 for col in (
     "M2sin i (Msun)",
     "(M2sin i)/(sin i) (Msun)",
+    "GAIA DATA",
     "DAYS SINCE LAST APF",
-    "NEXT RV EVENT (MJD)",
+    "NEXT RV EVENT (DATE)",
 ):
     if col not in hdr:
         hdr.append(col)

--- a/scripts/update_website_table_columns.py
+++ b/scripts/update_website_table_columns.py
@@ -11,9 +11,11 @@ from pathlib import Path
 from fit_apf_rv_keplerian import website_table_masses_from_report
 from darkhunter_rv.website_table_csv import (
     days_since_last_apf_from_summary,
+    format_next_rv_event_cell,
     gaia_id_from_row,
     next_rv_event_from_fit_report,
     normalize_data_csv,
+    parse_next_rv_cell_to_mjd,
 )
 
 
@@ -38,7 +40,7 @@ def update_table_columns(
     m2sini_i = hdr.index("M2sin i (Msun)")
     m2over_i = hdr.index("(M2sin i)/(sin i) (Msun)")
     apf_days_i = hdr.index("DAYS SINCE LAST APF")
-    next_rv_i = hdr.index("NEXT RV EVENT (MJD)")
+    next_rv_i = hdr.index("NEXT RV EVENT (DATE)")
 
     reports: dict[str, dict] = {}
     if reports_dir.is_dir():
@@ -90,8 +92,15 @@ def update_table_columns(
         if nxt is not None:
             while len(r) <= next_rv_i:
                 r.append("")
-            r[next_rv_i] = f"{nxt:.3f}"
+            r[next_rv_i] = format_next_rv_event_cell(nxt)
             n_next += 1
+
+    for r in data_rows:
+        if not r or next_rv_i >= len(r) or not r[next_rv_i]:
+            continue
+        mjd = parse_next_rv_cell_to_mjd(r[next_rv_i])
+        if mjd is not None and "/" not in r[next_rv_i]:
+            r[next_rv_i] = format_next_rv_event_cell(mjd)
 
     with data_csv.open("w", newline="", encoding="utf-8") as fh:
         csv.writer(fh).writerows(rows)

--- a/tests/test_website_table_csv.py
+++ b/tests/test_website_table_csv.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from darkhunter_rv.website_table_csv import (
     days_since_last_apf_from_summary,
     format_next_rv_event_cell,

--- a/tests/test_website_table_csv.py
+++ b/tests/test_website_table_csv.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 from darkhunter_rv.website_table_csv import (
     days_since_last_apf_from_summary,
+    format_next_rv_event_cell,
+    mjd_to_yyyy_mm_dd,
     next_rv_event_from_fit_report,
+    parse_next_rv_cell_to_mjd,
     sooner_rv_extremum_mjd,
 )
 from darkhunter_rv.rv_point_filters import mjd_is_valid, rv_epoch_is_valid
@@ -27,6 +30,12 @@ def test_next_rv_event_prefers_fix_period_ecc(tmp_path: Path) -> None:
         },
     }
     assert next_rv_event_from_fit_report(rep) == 60080.0
+
+
+def test_mjd_to_yyyy_mm_dd() -> None:
+    assert mjd_to_yyyy_mm_dd(60000.0) == "2023/02/25"
+    assert format_next_rv_event_cell(60000.0) == "2023/02/25"
+    assert parse_next_rv_cell_to_mjd("2023/02/25") == pytest.approx(60000.0, abs=0.5)
 
 
 def test_days_since_last_apf_from_summary(tmp_path: Path) -> None:

--- a/website/rv/script.js
+++ b/website/rv/script.js
@@ -55,8 +55,10 @@ const headerDisplayMap = {
     "FLUX PLOT": "H-beta",
     "SOURCE IMAGE": "UV Image",
     "DATA PRODUCTS": "Data Products",
+    "GAIA DATA": "Star files",
     "DAYS SINCE LAST APF": "Days since<br>last APF",
-    "NEXT RV EVENT (MJD)": "Next RV<br>min/max (MJD)",
+    "NEXT RV EVENT (DATE)": "Next RV<br>min/max",
+    "NEXT RV EVENT (MJD)": "Next RV<br>min/max",
     "BROAD LINES (HOT STAR/RAPID ROTATION)": "Broad lines",
     "COMPLETE ORBIT/MINIMA TO MAXIMA": "Complete orbit now",
     "JERK STAR": "Jerk star",
@@ -408,7 +410,8 @@ function colIndex(headerName) {
     return Object.prototype.hasOwnProperty.call(colByHeader, headerName) ? colByHeader[headerName] : -1;
 }
 
-const NUMERIC_TABLE_HEADERS = new Set(["DAYS SINCE LAST APF", "NEXT RV EVENT (MJD)"]);
+const NUMERIC_TABLE_HEADERS = new Set(["DAYS SINCE LAST APF"]);
+const DATE_TABLE_HEADERS = new Set(["NEXT RV EVENT (DATE)", "NEXT RV EVENT (MJD)"]);
 
 function cellAtColumn(row, headerName) {
     const idx = colIndex(headerName);
@@ -443,6 +446,55 @@ function setCellHtmlForColumn(row, headerName, html) {
     if (cell) {
         cell.innerHTML = html;
     }
+}
+
+function colIndexNextRvEvent() {
+    if (colIndex("NEXT RV EVENT (DATE)") >= 0) {
+        return colIndex("NEXT RV EVENT (DATE)");
+    }
+    return colIndex("NEXT RV EVENT (MJD)");
+}
+
+function mjdToYyyyMmDd(mjd) {
+    const unixMs = (mjd - 40587.0) * 86400000.0;
+    const d = new Date(unixMs);
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(d.getUTCDate()).padStart(2, "0");
+    return `${y}/${m}/${day}`;
+}
+
+function formatNextRvCellDisplay(text) {
+    const s = String(text ?? "").trim();
+    if (!s) {
+        return "";
+    }
+    if (/^\d{4}\/\d{1,2}\/\d{1,2}$/.test(s)) {
+        return s;
+    }
+    const mjd = parseFloat(s);
+    if (Number.isFinite(mjd)) {
+        return mjdToYyyyMmDd(mjd);
+    }
+    return s;
+}
+
+function parseNextRvForSort(text) {
+    const s = String(text ?? "").trim();
+    const m = s.match(/^(\d{4})\/(\d{1,2})\/(\d{1,2})$/);
+    if (m) {
+        return Date.UTC(parseInt(m[1], 10), parseInt(m[2], 10) - 1, parseInt(m[3], 10));
+    }
+    const mjd = parseFloat(s);
+    return Number.isFinite(mjd) ? (mjd - 40587.0) * 86400000.0 : Number.POSITIVE_INFINITY;
+}
+
+function buildGaiaDataCellHtml(gaiaId) {
+    if (!gaiaId) {
+        return "N/A";
+    }
+    const url = `stars/Gaia_DR3_${gaiaId}/Gaia/`;
+    return `<a href="${url}" target="_blank" rel="noopener noreferrer">Star files</a>`;
 }
 
 function headerNameForIndex(colIdx) {
@@ -904,23 +956,29 @@ function updateToggleCounts(baseRows) {
 
 function renderDataProductsCell(row) {
     const gaiaId = row.dataset.gaiaId || "";
-    if (!gaiaId) {
+    const base = row.dataset.starBase || (gaiaId ? `stars/Gaia_DR3_${gaiaId}` : "");
+    if (!base) {
         return "N/A";
     }
-    const base = `stars/Gaia_DR3_${gaiaId}`;
     const apfUrl = `${base}/Gaia/`;
     const swiftUrl = `${base}/Swift/`;
     const keckUrl = `${base}/Keck/`;
+    const hasApf = row.dataset.hasApf !== "0";
     const hasSwift = row.dataset.hasSwift === "1";
     const hasKeck = row.dataset.hasKeck === "1";
 
     let html = `<div class="product-links">`;
-    html += `<div class="product-line"><a href="${apfUrl}" target="_blank" rel="noopener noreferrer">Gaia data</a></div>`;
+    if (hasApf) {
+        html += `<div class="product-line"><a href="${apfUrl}" target="_blank" rel="noopener noreferrer">APF</a></div>`;
+    }
     if (hasKeck) {
         html += `<div class="product-line"><a href="${keckUrl}" target="_blank" rel="noopener noreferrer">KPF</a></div>`;
     }
     if (hasSwift) {
         html += `<div class="product-line"><a href="${swiftUrl}" target="_blank" rel="noopener noreferrer">Swift</a></div>`;
+    }
+    if (!hasApf && !hasKeck && !hasSwift) {
+        html += `<span class="product-muted">—</span>`;
     }
     html += `</div>`;
     return html;
@@ -1381,7 +1439,14 @@ function arrayToTable(tableData) {
             ) {
                 text = "";
             }
-            if (i > 0 && colIdx !== 0 && !isMediaHeader(headerName) && !NUMERIC_TABLE_HEADERS.has(headerName) && !Number.isNaN(Number(text))) {
+            if (
+                i > 0
+                && colIdx !== 0
+                && !isMediaHeader(headerName)
+                && !NUMERIC_TABLE_HEADERS.has(headerName)
+                && !DATE_TABLE_HEADERS.has(headerName)
+                && !Number.isNaN(Number(text))
+            ) {
                 text = Number(text).toFixed(5);
             }
             if (i > 0 && isMediaHeader(headerName) && hasNonNAContent(text)) {
@@ -1392,8 +1457,9 @@ function arrayToTable(tableData) {
             const fluxCol = colIndex("FLUX PLOT");
             const sourceCol = colIndex("SOURCE IMAGE");
             const dataProductsCol = colIndex("DATA PRODUCTS");
+            const gaiaDataCol = colIndex("GAIA DATA");
             const apfDaysCol = colIndex("DAYS SINCE LAST APF");
-            const nextRvCol = colIndex("NEXT RV EVENT (MJD)");
+            const nextRvCol = colIndexNextRvEvent();
             if (i > 0 && colIdx === rvPlotCol) {
                 cell.classList.add("col-rv-plot");
                 const gaiaId = row.dataset.gaiaId || normalizeGaiaId(rowData[String(colIndex("GAIA NAME"))] ?? rowData["0"]);
@@ -1404,6 +1470,10 @@ function arrayToTable(tableData) {
             }
             if (i > 0 && colIdx === sourceCol) {
                 cell.classList.add("col-source-image");
+                const gaiaId = row.dataset.gaiaId || normalizeGaiaId(rowData[String(colIndex("GAIA NAME"))] ?? rowData["0"]);
+                if (!hasNonNAContent(text)) {
+                    text = "N/A";
+                }
             }
             if (i > 0 && colIdx === fluxCol) {
                 cell.classList.add("col-flux-plot");
@@ -1423,8 +1493,12 @@ function arrayToTable(tableData) {
             }
             if (i > 0 && colIdx === nextRvCol) {
                 cell.classList.add("col-next-rv");
-                const evt = parseFloat(String(text ?? "").trim());
-                text = Number.isFinite(evt) ? evt.toFixed(3) : "";
+                text = formatNextRvCellDisplay(text);
+            }
+            if (i > 0 && colIdx === gaiaDataCol) {
+                cell.classList.add("col-gaia-data");
+                const gaiaId = row.dataset.gaiaId || normalizeGaiaId(rowData[String(colIndex("GAIA NAME"))] ?? rowData["0"]);
+                text = buildGaiaDataCellHtml(gaiaId);
             }
             if (i > 0 && colIdx === dataProductsCol) {
                 cell.classList.add("col-data-products");

--- a/website/rv/style.css
+++ b/website/rv/style.css
@@ -80,55 +80,46 @@ th {
     padding: 6px 6px;
 }
 
-/* Keep science plot columns readable */
-#csv-container th:nth-child(11),
-#csv-container td:nth-child(11) {
-    min-width: 260px;
-}
-
-/* RV fit column width */
-#csv-container th:nth-child(12),
-#csv-container td:nth-child(12) {
-    min-width: 300px;
-}
-
-#csv-container th:nth-child(9),
-#csv-container td:nth-child(9),
-#csv-container th:nth-child(10),
-#csv-container td:nth-child(10) {
+/* Mass columns */
+#csv-container td.col-m2sin,
+#csv-container td.col-m2over,
+#csv-container th.col-m2sin,
+#csv-container th.col-m2over {
     min-width: 110px;
 }
 
-#csv-container th:nth-child(13),
-#csv-container td:nth-child(13) {
-    min-width: 230px;
-}
-
-#csv-container th:nth-child(14),
-#csv-container td:nth-child(14) {
-    min-width: 260px;
-}
-
-/* Hide UV image column in main table view */
+/* RV / H-beta plot columns (header-index independent) */
+#csv-container th.col-rv-plot,
+#csv-container td.col-rv-plot,
+#csv-container th.col-rv-fit,
+#csv-container td.col-rv-fit,
+#csv-container th.col-flux-plot,
+#csv-container td.col-flux-plot,
 #csv-container th.col-source-image,
 #csv-container td.col-source-image {
-    display: none;
+    min-width: 280px;
+    width: 280px;
 }
 
 #csv-container td.col-rv-plot img,
 #csv-container td.col-rv-fit img,
 #csv-container td.col-flux-plot img,
 #csv-container td.col-source-image img {
-    width: 100%;
-    max-width: 300px;
+    width: 280px;
+    max-width: 280px;
+    min-width: 200px;
     height: auto;
     display: block;
     margin: 0 auto;
 }
 
-img {
-    width:100%;
-    height:auto;
+#csv-container td.col-data-products,
+#csv-container td.col-gaia-data {
+    min-width: 100px;
+}
+
+#csv-container img {
+    height: auto;
 }
 
 #input-box {


### PR DESCRIPTION
## Summary
- **H-beta / RV / UV plots:** Same width (280px) via CSS classes, not brittle `nth-child` rules.
- **GAIA DATA** column ("Star files"): link to `stars/Gaia_DR3_<id>/Gaia/` — separate from **DATA PRODUCTS** (APF/KPF/Swift links).
- **SOURCE IMAGE (UV):** Column visible again (removed `display: none`); uses legacy CSV thumbnails when present.
- **NEXT RV EVENT (DATE):** Renamed from MJD; values shown and stored as `YYYY/MM/DD` (P+e fixed fit).

## On ziggy after merge
```bash
cd /data2/darkhunter/dark-hunter_rv && git pull
bash scripts/repair_website_table.sh
# hard-refresh browser
```

## Test plan
- [x] `pytest tests/test_website_table_csv.py tests/test_fix_data_csv_column_order.py`


Made with [Cursor](https://cursor.com)