### PR TITLE
Per-object website refit, Hβ axes, epoch spectra in cron

### DIFF
--- a/docs/website.md
+++ b/docs/website.md
@@ -80,22 +80,54 @@ Ensure Apache serves `/var/www/html/darkhunter/rv/` (existing `Alias` or symlink
 | **M2sin i (Msun)** | RV-only Keplerian fit, with assumed M1 |
 | **(M2sin i)/(sin i) (Msun)** | Same RV-only f(M) and M1, with Gaia astrometric inclination |
 
-```bash
-cd /data2/darkhunter/dark-hunter_rv
+## Three commands (ziggy)
 
-# Regenerate everything (≥5 epochs per star, literature included in fits)
-WEB_ROOT=/var/www/html/darkhunter/rv MIN_POINTS=5 FIT_FORCE=1 bash scripts/populate_website.sh
+Paths assume `REPO=/data2/darkhunter/dark-hunter_rv`, `WEB_ROOT=/var/www/html/darkhunter/rv`, `SPEC_ROOT=/data2/gaia_stars/apf_reductions`.
+
+### 1 — Hβ plots + website staging (fast; no pipeline, no refit)
+
+Rebuilds `Gaia_DR3_<id>_28_hbeta.png` (−300…+300 km/s, flux 1–99%), copies star trees to `WEB_ROOT`, rsyncs reports. Summaries must already be complete.
+
+```bash
+cd /data2/darkhunter/dark-hunter_rv && git pull
+bash scripts/update_hbeta_website.sh
+# optional: deploy script.js/style.css too
+DEPLOY_STATIC=1 bash scripts/update_hbeta_website.sh
 ```
 
-### Full overnight refresh (detached screen)
+### 2 — Full refit in detached screen (per-star pipeline → fit → Hβ → live website row)
 
-Refits every star with **≥5** valid epochs (pipeline + literature; drops −9999 / NaN / |RV|≥5000 km/s), **force**-rebuilds all Keplerian and Hβ plots, repairs `data.csv`, and stages to the website. Run after merging website fixes (#19+):
+Repairs `data.csv` columns, deploys static assets, then **`refit_all_per_object.sh`**: for each star, analyze all `Gaia_DR3_*_epoch_*.txt` spectra, run Keplerian fit, rebuild plots/Hβ, **stage that star and update its table row immediately**.
 
 ```bash
 screen -dmS darkhunter_full_refresh bash -lc '
   REPO=/data2/darkhunter/dark-hunter_rv
   cd "$REPO" && git pull && bash scripts/full_website_refresh.sh
 '
+```
+
+Log: `logs/full_website_refresh.log`, `logs/refit_all_per_object.log`
+
+### 3 — Per-object refit only (same star-by-star website updates; no CSV layout repair)
+
+Use when static site / `data.csv` columns are already correct. Cron now includes `Gaia_DR3_*_epoch_*.txt` in pipeline discovery (not only `*_ap1.*`).
+
+```bash
+screen -dmS darkhunter_per_object bash -lc '
+  REPO=/data2/darkhunter/dark-hunter_rv
+  cd "$REPO" && git pull && bash scripts/refit_all_per_object.sh
+'
+```
+
+Single-star test: `STAR_ID=1551542027851147904 bash scripts/refit_all_per_object.sh`
+
+**Bulk alternative** (website updates only at the end): `bash scripts/full_website_refresh_bulk.sh`
+
+### Populate from existing summaries only (no pipeline)
+
+```bash
+cd /data2/darkhunter/dark-hunter_rv
+WEB_ROOT=/var/www/html/darkhunter/rv MIN_POINTS=5 FIT_FORCE=1 bash scripts/populate_website.sh
 ```
 
 Attach: `screen -r darkhunter_full_refresh` — Detach: `Ctrl-a d`  
@@ -128,11 +160,9 @@ bash scripts/repair_website_table.sh
 
 Hard-refresh the browser (Cmd+Shift+R). This deploys `script.js`, fixes column alignment, clears stray plot HTML, and fills **DAYS SINCE LAST APF** / mass / **NEXT RV EVENT** from existing summaries and `rv_fit_reports` JSON if they are already on disk.
 
-### Step 2 — Full refresh when ready (long: refit + all plots + Hβ + staging)
+### Step 2 — Full refresh when ready
 
-```bash
-bash scripts/full_website_refresh.sh
-```
+Same as **command 2** above (`full_website_refresh.sh` → per-star `refit_all_per_object.sh`). Use when summaries are missing epochs (e.g. only four of nine `epoch_*.txt` in `[PIPELINE RESULTS]`).
 
 CSV-only normalize (no column value fill):
 
@@ -154,8 +184,10 @@ PYTHONPATH=. python3 scripts/build_hbeta_website_plots.py \
 
 `scripts/cron_update_rv_website.sh` runs:
 
-1. **Pipeline** `--update` on `SPEC_ROOT` (new/changed `.flm` / `.txt` / `.fits` only).
+1. **Pipeline** `--update` on `SPEC_ROOT` for `Gaia_DR3_*_epoch_*.txt`, `*_ap1.{flm,txt}`, and `*.fits` (skips spectra whose `*_diagnostics.csv` is newer than the input).
 2. **Populate**: Keplerian fits (≥`MIN_POINTS`, literature included, bad RVs filtered), RV/Hβ plots, `data.csv` mass columns, staging to `WEB_ROOT`. Skips refit when the JSON is newer than the summary (`FIT_FORCE=0`).
+
+**Missing epochs in summaries:** Cron used to match only `*_ap1.*` / `*.fits`, not `Gaia_DR3_*_epoch_*.txt`. Stars with only epoch `.txt` reductions (e.g. nine epochs on disk but four in `[PIPELINE RESULTS]`) need a one-time **`bash scripts/full_website_refresh.sh`** (`RUN_PIPELINE=1`, default), which runs the pipeline on all epoch files then refits. Incremental cron picks up new epoch `.txt` files after that.
 
 Install crontab: run **`crontab -e`** alone (do not put the schedule on the same shell line), then add:
 

--- a/scripts/build_hbeta_website_plots.py
+++ b/scripts/build_hbeta_website_plots.py
@@ -137,6 +137,19 @@ def build_overlay(
         color = cmap(frac)
         ax.plot(v, f, "-", lw=1.1, color=color, alpha=0.88, label=f"MJD {mjd:.1f}")
 
+    ax.set_xlim(-300.0, 300.0)
+    flux_in_win: list[np.ndarray] = []
+    for _mjd, v, f in curves:
+        m = np.isfinite(v) & np.isfinite(f) & (np.abs(v) <= 300.0)
+        if int(np.sum(m)) >= 3:
+            flux_in_win.append(f[m])
+    if flux_in_win:
+        pooled = np.concatenate(flux_in_win)
+        ylo, yhi = np.nanpercentile(pooled, [1.0, 99.0])
+        if np.isfinite(ylo) and np.isfinite(yhi) and yhi > ylo:
+            pad = 0.03 * (yhi - ylo)
+            ax.set_ylim(float(ylo - pad), float(yhi + pad))
+
     ax.set_xlabel("Velocity (km/s)")
     ax.set_ylabel("Normalized flux")
     sid = parse_object_id_from_summary(summary_path) or summary_path.stem

--- a/scripts/cron_update_rv_website.sh
+++ b/scripts/cron_update_rv_website.sh
@@ -24,6 +24,8 @@ RUN_PIPELINE="${RUN_PIPELINE:-1}"
 
 mkdir -p "$(dirname "$LOG")" "$OUT" "$REPO/logs"
 cd "$REPO"
+# shellcheck source=scripts/lib/spec_find_patterns.sh
+source "$REPO/scripts/lib/spec_find_patterns.sh"
 export PYTHONPATH="$REPO"
 export DARKHUNTER_OUTPUT_DIR="$OUT"
 export WEB_ROOT OUT SPEC_ROOT MIN_POINTS
@@ -36,7 +38,7 @@ echo "=== $(date -Is) cron_update_rv_website start (pid $$) ==="
 # 1) Pipeline: new/changed spectra (--update skips unchanged). Updates summaries in output/.
 if [[ "$RUN_PIPELINE" == "1" && -d "$SPEC_ROOT" ]]; then
   echo "=== Pipeline --update on $SPEC_ROOT ==="
-  find "$SPEC_ROOT" -type f \( -name '*_ap1.flm' -o -name '*_ap1.txt' -o -name '*.fits' \) -print0 2>/dev/null \
+  find_apf_spectra_print0 "$SPEC_ROOT" \
     | xargs -0 -r "$PY" -m darkhunter_rv.pipeline --instrument APF --update --plots --plots-focus 2>/dev/null \
     || echo "[WARN] pipeline pass had errors (continuing)"
 elif [[ "$RUN_PIPELINE" == "1" ]]; then

--- a/scripts/full_website_refresh.sh
+++ b/scripts/full_website_refresh.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
-# One-shot: deploy static site assets, repair data.csv, refit all stars (≥MIN_POINTS),
-# rebuild RV / Keplerian / Hβ plots, update mass columns, stage to WEB_ROOT.
-#
-# Fits use pipeline + literature epochs; invalid RVs (|RV|≥5000, NaN, -9999, etc.) are dropped
-# via darkhunter_rv.rv_point_filters.rv_value_is_valid.
+# Full refit with incremental website updates (per star: pipeline → fit → Hβ → stage).
 #
 # Usage (ziggy):
-#   cd /data2/darkhunter/dark-hunter_rv
-#   git pull   # merge website fixes (#19+) before first run
+#   cd /data2/darkhunter/dark-hunter_rv && git pull
 #   bash scripts/full_website_refresh.sh
 #
-# Detached:
+# Detached screen (command 2 — full refit, site updates star-by-star):
 #   screen -dmS darkhunter_full_refresh bash -lc '
 #     REPO=/data2/darkhunter/dark-hunter_rv
 #     cd "$REPO" && git pull && bash scripts/full_website_refresh.sh
@@ -18,25 +13,18 @@
 
 set -euo pipefail
 
-REPO="${REPO:-/data2/darkhunter/dark-hunter_rv}"
-OUT="${OUT:-$REPO/output}"
+REPO="${REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
 WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
-SPEC_ROOT="${SPEC_ROOT:-/data2/gaia_stars/apf_reductions}"
 PY="${PY:-/home/marley/anaconda2/envs/gaia-env/bin/python}"
-MIN_POINTS="${MIN_POINTS:-5}"
 LOG="${LOG:-$REPO/logs/full_website_refresh.log}"
 
 cd "$REPO"
-mkdir -p "$(dirname "$LOG")" "$OUT" "$REPO/logs"
+mkdir -p "$(dirname "$LOG")" "$REPO/logs"
 export PYTHONPATH="$REPO"
-export DARKHUNTER_OUTPUT_DIR="$OUT"
-export WEB_ROOT OUT SPEC_ROOT MIN_POINTS
-export RUN_FITS=1 RUN_RV_PLOTS=1 RUN_HBETA_PLOTS=1 FIT_FORCE=1 MIN_POINTS="${MIN_POINTS:-5}" QUERY_GAIA_ONLINE="${QUERY_GAIA_ONLINE:-0}"
-export LOG="$REPO/logs/batch_fits_plots_sync.log"
+export WEB_ROOT
 
 exec > >(tee -a "$LOG") 2>&1
 echo "=== $(date -Is) full_website_refresh start (pid $$) ==="
-echo "repo=$REPO out=$OUT web_root=$WEB_ROOT min_points=$MIN_POINTS"
 
 if [[ ! -f "$WEB_ROOT/tables/data.csv" ]]; then
   echo "[ERROR] $WEB_ROOT/tables/data.csv missing — run scripts/bootstrap_website_tables.sh first." >&2
@@ -47,15 +35,12 @@ echo "=== Deploy script.js / style.css / index.html ==="
 bash scripts/setup_website.sh
 
 if [[ -f "$REPO/scripts/fix_data_csv_column_order.py" ]]; then
-  echo "=== Repair tables/data.csv column alignment + stray plot HTML ==="
+  echo "=== Repair tables/data.csv column alignment ==="
   "$PY" scripts/fix_data_csv_column_order.py --data-csv "$WEB_ROOT/tables/data.csv"
-else
-  echo "[WARN] scripts/fix_data_csv_column_order.py not found (git pull #19+?); skipping CSV repair"
 fi
 
-echo "=== Keplerian fits (all stars, force) + plots + Hβ + website staging ==="
-bash scripts/populate_website.sh
+echo "=== Per-object pipeline + fit + website (see logs/refit_all_per_object.log) ==="
+bash scripts/refit_all_per_object.sh
 
 echo "=== $(date -Is) full_website_refresh done ==="
-echo "Log: $LOG"
-echo "Batch detail: $REPO/logs/batch_fits_plots_sync.log"
+echo "Logs: $LOG  $REPO/logs/refit_all_per_object.log"

--- a/scripts/full_website_refresh_bulk.sh
+++ b/scripts/full_website_refresh_bulk.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Bulk refit: pipeline all spectra, then Keplerian fits + plots + Hβ + website in one batch.
+# Website updates only at the end (not per star). Prefer refit_all_per_object.sh for incremental site updates.
+#
+# Detached:
+#   screen -dmS darkhunter_bulk_refresh bash -lc '
+#     REPO=/data2/darkhunter/dark-hunter_rv
+#     cd "$REPO" && git pull && bash scripts/full_website_refresh_bulk.sh
+#   '
+
+set -euo pipefail
+
+REPO="${REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
+OUT="${OUT:-$REPO/output}"
+WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
+SPEC_ROOT="${SPEC_ROOT:-/data2/gaia_stars/apf_reductions}"
+PY="${PY:-/home/marley/anaconda2/envs/gaia-env/bin/python}"
+MIN_POINTS="${MIN_POINTS:-5}"
+RUN_PIPELINE="${RUN_PIPELINE:-1}"
+LOG="${LOG:-$REPO/logs/full_website_refresh_bulk.log}"
+
+cd "$REPO"
+# shellcheck source=scripts/lib/spec_find_patterns.sh
+source "$REPO/scripts/lib/spec_find_patterns.sh"
+mkdir -p "$(dirname "$LOG")" "$OUT" "$REPO/logs"
+export PYTHONPATH="$REPO"
+export DARKHUNTER_OUTPUT_DIR="$OUT"
+export WEB_ROOT OUT SPEC_ROOT MIN_POINTS
+export RUN_FITS=1 RUN_RV_PLOTS=1 RUN_HBETA_PLOTS=1 FIT_FORCE=1 QUERY_GAIA_ONLINE="${QUERY_GAIA_ONLINE:-0}"
+export LOG="$REPO/logs/batch_fits_plots_sync.log"
+
+exec > >(tee -a "$LOG") 2>&1
+echo "=== $(date -Is) full_website_refresh_bulk start (pid $$) ==="
+
+if [[ ! -f "$WEB_ROOT/tables/data.csv" ]]; then
+  echo "[ERROR] $WEB_ROOT/tables/data.csv missing — run scripts/bootstrap_website_tables.sh first." >&2
+  exit 2
+fi
+
+if [[ "$RUN_PIPELINE" == "1" && -d "$SPEC_ROOT" ]]; then
+  echo "=== Pipeline on all spectra under $SPEC_ROOT ==="
+  find_apf_spectra_print0 "$SPEC_ROOT" \
+    | xargs -0 -r "$PY" -m darkhunter_rv.pipeline --instrument APF --plots --plots-focus 2>/dev/null \
+    || echo "[WARN] pipeline pass had errors (continuing)"
+fi
+
+bash scripts/setup_website.sh
+if [[ -f "$REPO/scripts/fix_data_csv_column_order.py" ]]; then
+  "$PY" scripts/fix_data_csv_column_order.py --data-csv "$WEB_ROOT/tables/data.csv"
+fi
+
+bash scripts/populate_website.sh
+echo "=== $(date -Is) full_website_refresh_bulk done ==="

--- a/scripts/lib/discover_gaia_star_ids.sh
+++ b/scripts/lib/discover_gaia_star_ids.sh
@@ -1,0 +1,29 @@
+# List unique Gaia DR3 source ids under a reduction tree (sorted).
+# Uses top-level Gaia_DR3_* directories and Gaia_DR3_*_epoch_*.txt basenames.
+
+discover_gaia_star_ids() {
+  local root="${1:?SPEC_ROOT required}"
+  local -a ids=()
+  local d base
+
+  if [[ ! -d "$root" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r d; do
+    base=$(basename "$d")
+    ids+=("${base#Gaia_DR3_}")
+  done < <(find "$root" -maxdepth 1 -type d -name 'Gaia_DR3_*' 2>/dev/null | sort)
+
+  while IFS= read -r base; do
+    base=$(basename "$base")
+    if [[ "$base" =~ ^Gaia_DR3_([0-9]+)_epoch_ ]]; then
+      ids+=("${BASH_REMATCH[1]}")
+    fi
+  done < <(find "$root" -type f -name 'Gaia_DR3_*_epoch_*.txt' 2>/dev/null | sort -u)
+
+  if [[ "${#ids[@]}" -eq 0 ]]; then
+    return 0
+  fi
+  printf '%s\n' "${ids[@]}" | awk '!seen[$0]++'
+}

--- a/scripts/lib/spec_find_patterns.sh
+++ b/scripts/lib/spec_find_patterns.sh
@@ -1,0 +1,12 @@
+# Shared find(1) for APF spectrum files under a reduction tree.
+# Gaia_DR3_*_epoch_*.txt are reduced spectra in star summaries; *_ap1.* / *.fits are APF products.
+
+find_apf_spectra_print0() {
+  local root="${1:?root directory required}"
+  find "$root" -type f \( \
+    -name 'Gaia_DR3_*_epoch_*.txt' -o \
+    -name '*_ap1.flm' -o \
+    -name '*_ap1.txt' -o \
+    -name '*.fits' \
+  \) -print0 2>/dev/null
+}

--- a/scripts/lib/website_sync_one_star.sh
+++ b/scripts/lib/website_sync_one_star.sh
@@ -1,0 +1,61 @@
+# Stage one star into WEB_ROOT and refresh its data.csv row.
+# Requires: REPO, WEB_ROOT, OUT, REPORTS_DIR, PY, WEBSITE_STARS_DIR, DATA_CSV, run_cmd (optional DRY_RUN).
+
+website_sync_one_star() {
+  local gid="${1:?gaia id required}"
+  local summ="$OUT/Gaia_DR3_${gid}_summary.txt"
+  local star_root="$WEBSITE_STARS_DIR/Gaia_DR3_${gid}/Gaia"
+  local star_plots="$star_root/Plots"
+  local star_fit="$star_root/RV_Fit"
+
+  if [[ ! -f "$summ" ]]; then
+    echo "[WARN] no summary for Gaia_DR3_${gid}; skip website sync" >&2
+    return 1
+  fi
+
+  run_cmd mkdir -p "$star_plots" "$star_fit"
+  run_cmd cp "$summ" "$star_root/${gid}_summary.txt"
+
+  local fit_png="$REPORTS_DIR/${gid}_keplerian_fit.png"
+  local fit_json="$REPORTS_DIR/${gid}_keplerian_fit.json"
+  if [[ -f "$fit_png" ]]; then
+    run_cmd cp "$fit_png" "$star_fit/${gid}_keplerian_fit.png"
+  elif [[ "${DRY_RUN:-0}" != "1" && -n "${MISSING_ASSETS_CSV:-}" ]]; then
+    echo "${gid},missing_fit_png,${fit_png}" >> "$MISSING_ASSETS_CSV"
+  fi
+  if [[ -f "$fit_json" ]]; then
+    run_cmd cp "$fit_json" "$star_fit/${gid}_keplerian_fit.json"
+  elif [[ "${DRY_RUN:-0}" != "1" && -n "${MISSING_ASSETS_CSV:-}" ]]; then
+    echo "${gid},missing_fit_json,${fit_json}" >> "$MISSING_ASSETS_CSV"
+  fi
+
+  local src_plot_dir="$OUT/Gaia_DR3_${gid}"
+  if [[ -d "$src_plot_dir" ]]; then
+    local p
+    while IFS= read -r -d '' p; do
+      run_cmd cp "$p" "$star_plots/$(basename "$p")"
+    done < <(find "$src_plot_dir" -maxdepth 1 -type f -name '*.png' -print0 2>/dev/null)
+  elif [[ "${DRY_RUN:-0}" != "1" && -n "${MISSING_ASSETS_CSV:-}" ]]; then
+    echo "${gid},missing_plot_dir,${src_plot_dir}" >> "$MISSING_ASSETS_CSV"
+  fi
+
+  if [[ "${DRY_RUN:-0}" != "1" ]]; then
+    run_cmd "$PY" scripts/update_website_table_columns.py \
+      --data-csv "$DATA_CSV" \
+      --output-dir "$OUT" \
+      --reports-dir "$REPORTS_DIR" \
+      --gaia-id "$gid"
+    if [[ -d "$WEBSITE_STARS_DIR/Gaia_DR3_${gid}" ]]; then
+      run_cmd rsync -rlptD --omit-dir-times \
+        "$WEBSITE_STARS_DIR/Gaia_DR3_${gid}/" \
+        "$WEB_ROOT/stars/Gaia_DR3_${gid}/"
+    fi
+    if [[ -f "$REPORTS_DIR/${gid}_keplerian_fit.json" ]]; then
+      run_cmd mkdir -p "$WEB_ROOT/rv_fit_reports"
+      run_cmd cp "$REPORTS_DIR/${gid}_keplerian_fit.json" "$WEB_ROOT/rv_fit_reports/"
+      [[ -f "$REPORTS_DIR/${gid}_keplerian_fit.png" ]] && \
+        run_cmd cp "$REPORTS_DIR/${gid}_keplerian_fit.png" "$WEB_ROOT/rv_fit_reports/"
+    fi
+  fi
+  return 0
+}

--- a/scripts/refit_all_per_object.sh
+++ b/scripts/refit_all_per_object.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Per-object backfill: for each Gaia star, run pipeline on all its spectra, Keplerian fit,
+# Hβ overlay, then stage that star to the website and update its data.csv row.
+#
+# Usage (ziggy):
+#   cd /data2/darkhunter/dark-hunter_rv && git pull
+#   bash scripts/refit_all_per_object.sh
+#
+#   STAR_ID=1551542027851147904 bash scripts/refit_all_per_object.sh
+#   MIN_POINTS=5 FIT_FORCE=1 bash scripts/refit_all_per_object.sh
+#
+# Detached (recommended for full catalog):
+#   screen -dmS darkhunter_per_object bash -lc '
+#     REPO=/data2/darkhunter/dark-hunter_rv
+#     cd "$REPO" && git pull && bash scripts/refit_all_per_object.sh
+#   '
+
+set -euo pipefail
+
+REPO="${REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
+OUT="${OUT:-$REPO/output}"
+WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
+SPEC_ROOT="${SPEC_ROOT:-/data2/gaia_stars/apf_reductions}"
+PY="${PY:-/home/marley/anaconda2/envs/gaia-env/bin/python}"
+REPORTS_DIR="${REPORTS_DIR:-$REPO/rv_fit_reports}"
+MIN_POINTS="${MIN_POINTS:-5}"
+FIT_FORCE="${FIT_FORCE:-1}"
+PIPELINE_UPDATE="${PIPELINE_UPDATE:-0}"
+RUN_HBETA="${RUN_HBETA:-1}"
+QUERY_GAIA_ONLINE="${QUERY_GAIA_ONLINE:-0}"
+STAR_ID="${STAR_ID:-}"
+LOG="${LOG:-$REPO/logs/refit_all_per_object.log}"
+
+cd "$REPO"
+# shellcheck source=scripts/lib/spec_find_patterns.sh
+source "$REPO/scripts/lib/spec_find_patterns.sh"
+# shellcheck source=scripts/lib/discover_gaia_star_ids.sh
+source "$REPO/scripts/lib/discover_gaia_star_ids.sh"
+# shellcheck source=scripts/lib/website_sync_one_star.sh
+source "$REPO/scripts/lib/website_sync_one_star.sh"
+
+mkdir -p "$(dirname "$LOG")" "$OUT" "$REPO/logs" "$REPORTS_DIR"
+export PYTHONPATH="$REPO"
+export DARKHUNTER_OUTPUT_DIR="$OUT"
+export WEB_ROOT OUT SPEC_ROOT REPORTS_DIR PY MIN_POINTS
+export WEBSITE_STARS_DIR="$WEB_ROOT/stars"
+export DATA_CSV="$WEB_ROOT/tables/data.csv"
+
+run_cmd() { "$@"; }
+
+if [[ ! -f "$DATA_CSV" ]]; then
+  echo "[ERROR] $DATA_CSV missing — run scripts/bootstrap_website_tables.sh first." >&2
+  exit 2
+fi
+
+exec > >(tee -a "$LOG") 2>&1
+echo "=== $(date -Is) refit_all_per_object start (pid $$) ==="
+echo "repo=$REPO spec_root=$SPEC_ROOT out=$OUT web_root=$WEB_ROOT min_points=$MIN_POINTS"
+
+mapfile -t STAR_IDS < <(
+  if [[ -n "$STAR_ID" ]]; then
+    echo "$STAR_ID"
+  else
+    discover_gaia_star_ids "$SPEC_ROOT"
+  fi
+)
+
+if [[ "${#STAR_IDS[@]}" -eq 0 ]]; then
+  echo "[ERROR] No Gaia_DR3_* stars under $SPEC_ROOT" >&2
+  exit 2
+fi
+echo "stars_to_process=${#STAR_IDS[@]}"
+
+pipeline_args=(--instrument APF --plots --plots-focus)
+if [[ "$PIPELINE_UPDATE" == "1" ]]; then
+  pipeline_args+=(--update)
+fi
+
+n_ok=0
+n_skip=0
+for gid in "${STAR_IDS[@]}"; do
+  echo ""
+  echo "=== Gaia_DR3_${gid} ($(date -Is)) ==="
+
+  mapfile -d '' -t SPEC_FILES < <(
+    find "$SPEC_ROOT" -type f \( \
+      -name "Gaia_DR3_${gid}_epoch_*.txt" -o \
+      -name "Gaia_DR3_${gid}_*_ap1.flm" -o \
+      -name "Gaia_DR3_${gid}_*_ap1.txt" \
+    \) -print0 2>/dev/null
+  )
+  if [[ "${#SPEC_FILES[@]}" -eq 0 ]]; then
+    echo "[WARN] no spectra files for Gaia_DR3_${gid}; skip"
+    n_skip=$((n_skip + 1))
+    continue
+  fi
+  echo "pipeline: ${#SPEC_FILES[@]} spectrum file(s)"
+  printf '%s\0' "${SPEC_FILES[@]}" | xargs -0 -r "$PY" -m darkhunter_rv.pipeline "${pipeline_args[@]}" \
+    || echo "[WARN] pipeline errors for Gaia_DR3_${gid} (continuing)"
+
+  summ="$OUT/Gaia_DR3_${gid}_summary.txt"
+  if [[ ! -f "$summ" ]]; then
+    echo "[WARN] no summary after pipeline; skip fit/website"
+    n_skip=$((n_skip + 1))
+    continue
+  fi
+
+  fit_args=(
+    fit_apf_rv_keplerian.py
+    --summary "$summ"
+    --output-dir "$OUT"
+    --reports-dir "$REPORTS_DIR"
+    --use-gaia-nss
+    --min-points "$MIN_POINTS"
+  )
+  if [[ "$FIT_FORCE" == "1" ]]; then
+    fit_args+=(--force)
+  fi
+  if [[ "$QUERY_GAIA_ONLINE" == "1" ]]; then
+    fit_args+=(--query-gaia-online)
+  fi
+  "$PY" "${fit_args[@]}" || echo "[WARN] fit failed for Gaia_DR3_${gid} (continuing)"
+
+  if [[ "$RUN_HBETA" == "1" ]]; then
+    "$PY" scripts/build_hbeta_website_plots.py \
+      --summary-dir "$OUT" \
+      --plots-root "$OUT" \
+      --spec-root "$SPEC_ROOT" \
+      --star-id "$gid" \
+      || echo "[WARN] Hβ plot failed for Gaia_DR3_${gid} (continuing)"
+  fi
+
+  if website_sync_one_star "$gid"; then
+    n_ok=$((n_ok + 1))
+    echo "[OK] website updated for Gaia_DR3_${gid}"
+  else
+    n_skip=$((n_skip + 1))
+  fi
+done
+
+echo ""
+echo "=== $(date -Is) refit_all_per_object done: website_ok=$n_ok skipped=$n_skip ==="
+echo "Log: $LOG"

--- a/scripts/repair_website_table.sh
+++ b/scripts/repair_website_table.sh
@@ -13,8 +13,10 @@
 #   git pull   # needs PR #22+ (website_table_csv.py, script.js)
 #   bash scripts/repair_website_table.sh
 #
-# Then later:
-#   bash scripts/full_website_refresh.sh
+# Three operational commands (see docs/website.md):
+#   bash scripts/update_hbeta_website.sh              # Hβ + stage only
+#   screen ... bash scripts/full_website_refresh.sh   # per-star pipeline+fit+site
+#   screen ... bash scripts/refit_all_per_object.sh   # same (no CSV repair preamble)
 
 set -euo pipefail
 

--- a/scripts/update_hbeta_website.sh
+++ b/scripts/update_hbeta_website.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Fast path: rebuild Hβ table thumbnails + stage stars to WEB_ROOT (no pipeline, no Keplerian refit).
+#
+# Usage (ziggy):
+#   cd /data2/darkhunter/dark-hunter_rv && git pull
+#   bash scripts/update_hbeta_website.sh
+#
+#   STAR_ID=1551542027851147904 bash scripts/update_hbeta_website.sh
+#   DEPLOY_STATIC=1 bash scripts/update_hbeta_website.sh   # also copy script.js / style.css
+
+set -euo pipefail
+
+REPO="${REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
+export WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
+export DEPLOY_STATIC="${DEPLOY_STATIC:-0}"
+
+cd "$REPO"
+if [[ "$DEPLOY_STATIC" == "1" ]]; then
+  bash scripts/setup_website.sh
+fi
+
+export RUN_FITS=0 RUN_RV_PLOTS=0 RUN_HBETA_PLOTS=1 FIT_FORCE=0
+exec bash scripts/batch_fits_plots_sync.sh

--- a/scripts/update_website_table_columns.py
+++ b/scripts/update_website_table_columns.py
@@ -24,6 +24,7 @@ def update_table_columns(
     *,
     out_dir: Path,
     reports_dir: Path,
+    gaia_id: str | None = None,
 ) -> dict[str, int]:
     rows: list[list[str]] = []
     with data_csv.open(newline="", encoding="utf-8") as fh:
@@ -54,12 +55,15 @@ def update_table_columns(
     n_apf_days = 0
     n_m2 = 0
     n_next = 0
+    target = (gaia_id or "").strip()
     for r in data_rows:
         if not r:
             continue
         gaia = (r[gaia_i] if gaia_i < len(r) else "").strip()
         sid = gaia_id_from_row(gaia)
         if not sid:
+            continue
+        if target and sid != target:
             continue
 
         summ = out_dir / f"Gaia_DR3_{sid}_summary.txt"
@@ -134,6 +138,11 @@ def main() -> int:
         default=None,
         help="Keplerian JSON reports (default: REPO/rv_fit_reports)",
     )
+    ap.add_argument(
+        "--gaia-id",
+        default=None,
+        help="Update only this Gaia DR3 source id row (default: all rows).",
+    )
     args = ap.parse_args()
     repo = Path(__file__).resolve().parents[1]
     out_dir = Path(args.output_dir) if args.output_dir else repo / "output"
@@ -142,6 +151,7 @@ def main() -> int:
         Path(args.data_csv),
         out_dir=out_dir,
         reports_dir=reports_dir,
+        gaia_id=args.gaia_id,
     )
     print(
         f"updated {args.data_csv}: {stats['data_rows']} rows, {stats['columns']} columns, "


### PR DESCRIPTION
## Summary
- **Hβ table overlays:** ±300 km/s, y-axis from 1–99% flux (`build_hbeta_website_plots.py`).
- **Missing epochs:** Cron/full refresh now discover `Gaia_DR3_*_epoch_*.txt` (not only `*_ap1.*`).
- **Per-object refit:** `refit_all_per_object.sh` runs pipeline on all spectra for each star, Keplerian fit, Hβ, then stages that star and updates its `data.csv` row (incremental website).
- **Three ziggy commands** documented in `docs/website.md`.

## Commands (after merge)

**1 — Hβ + website (fast)**
```bash
cd /data2/darkhunter/dark-hunter_rv && git pull
bash scripts/update_hbeta_website.sh
```

**2 — Full refit in screen (CSV repair + static deploy + per-object refit)**
```bash
screen -dmS darkhunter_full_refresh bash -lc '
  REPO=/data2/darkhunter/dark-hunter_rv
  cd "$REPO" && git pull && bash scripts/full_website_refresh.sh
'
```

**3 — Per-object refit only (incremental website; same inner loop)**
```bash
screen -dmS darkhunter_per_object bash -lc '
  REPO=/data2/darkhunter/dark-hunter_rv
  cd "$REPO" && git pull && bash scripts/refit_all_per_object.sh
'
```

Bulk alternative (website only at end): `bash scripts/full_website_refresh_bulk.sh`

## Test plan
- [x] `pytest tests/test_website_table_csv.py`
- [x] `bash -n` on new shell scripts


Made with [Cursor](https://cursor.com)