### PR TITLE
Fix M2 sin i and M2 at i population in data.csv

### DIFF
--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -126,21 +126,50 @@ def load_nss_priors_from_summary(path: Path) -> Optional[Dict[str, float]]:
     return out
 
 
+def load_mass_priors_from_summary(path: Path) -> Dict[str, float]:
+    """M1 / M2 / inclination from [GAIA METADATA] (no NSS period requirement)."""
+    meta = _parse_gaia_metadata(path)
+    if not meta:
+        return {}
+    out: Dict[str, float] = {}
+    m1 = _meta_float(meta, "M1", "m1", "m1_msun", "Mass_Primary", "mass_primary")
+    m2 = _meta_float(meta, "M2", "m2", "m2_msun", "Mass_Secondary", "mass_secondary")
+    incl = _meta_float(meta, "Inclination", "inclination", "Inclination_Deg")
+    if m1 is not None and m1 > 0:
+        out["m1_msun"] = float(m1)
+    if m2 is not None and m2 > 0:
+        out["m2_msun"] = float(m2)
+    if incl is not None and np.isfinite(incl):
+        out["inclination_deg"] = float(incl)
+    return out
+
+
 def parse_m1_from_summary(path: Path) -> Optional[float]:
-    for line in path.read_text().splitlines():
-        if not line.startswith("#"):
-            continue
-        if "M1" not in line.upper():
-            continue
-        m = re.search(r"=\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)", line)
-        if not m:
-            continue
-        try:
-            val = float(m.group(1))
-        except ValueError:
-            continue
-        if np.isfinite(val) and val > 0:
-            return val
+    m1 = load_mass_priors_from_summary(path).get("m1_msun")
+    return float(m1) if m1 is not None and m1 > 0 else None
+
+
+def _free_fit_variant_report(report: dict) -> Optional[dict]:
+    variants = report.get("fit_variants")
+    if isinstance(variants, dict):
+        free = variants.get("free")
+        if isinstance(free, dict) and free.get("P_days") is not None:
+            return free
+    if report.get("P_days") is not None and report.get("K_kms") is not None:
+        return report
+    return None
+
+
+def lookup_fit_report_by_gaia_id(reports: Dict[str, dict], gaia_id: str) -> Optional[dict]:
+    """Match fit JSON keyed by numeric id or ``Gaia_DR3_<id>`` stem."""
+    sid = (gaia_id or "").strip()
+    if not sid:
+        return None
+    if sid in reports:
+        return reports[sid]
+    prefixed = f"Gaia_DR3_{sid}"
+    if prefixed in reports:
+        return reports[prefixed]
     return None
 
 
@@ -856,7 +885,11 @@ def _finite_mass_value(value: Any) -> Optional[float]:
     return None
 
 
-def website_table_masses_from_report(report: dict) -> Dict[str, Optional[float]]:
+def website_table_masses_from_report(
+    report: dict,
+    *,
+    summary_path: Optional[Path] = None,
+) -> Dict[str, Optional[float]]:
     """
     Map a Keplerian fit JSON report to website ``data.csv`` mass columns.
 
@@ -864,10 +897,35 @@ def website_table_masses_from_report(report: dict) -> Dict[str, Optional[float]]
     - ``m2sin_i_msun``: M2 sin i from the RV-only (free) fit and assumed M1.
     - ``m2_at_i_msun``: M2 at i from the RV-only f(M), assumed M1, and astrometric i.
     """
+    m2sin = _finite_mass_value(report.get("m2sini_msun"))
+    m2_at_i = _finite_mass_value(report.get("m2_given_inclination_msun"))
+
+    m1 = _finite_mass_value(report.get("used_m1_msun"))
+    incl_raw = report.get("inclination_deg_used")
+    incl = float(incl_raw) if isinstance(incl_raw, (int, float)) and np.isfinite(incl_raw) else None
+
+    if summary_path is not None:
+        meta_mass = load_mass_priors_from_summary(summary_path)
+        if m1 is None:
+            m1 = _finite_mass_value(meta_mass.get("m1_msun"))
+        if incl is None:
+            incl_meta = meta_mass.get("inclination_deg")
+            if incl_meta is not None and np.isfinite(incl_meta):
+                incl = float(incl_meta)
+
+    if m2sin is None or m2_at_i is None:
+        rep_free = _free_fit_variant_report(report)
+        if rep_free is not None and m1 is not None:
+            calc_sini, calc_at_i = rv_only_mass_estimates(rep_free, m1, incl)
+            if m2sin is None:
+                m2sin = _finite_mass_value(calc_sini)
+            if m2_at_i is None:
+                m2_at_i = _finite_mass_value(calc_at_i)
+
     return {
         "m2_msun": _finite_mass_value(report.get("used_m2_msun")),
-        "m2sin_i_msun": _finite_mass_value(report.get("m2sini_msun")),
-        "m2_at_i_msun": _finite_mass_value(report.get("m2_given_inclination_msun")),
+        "m2sin_i_msun": m2sin,
+        "m2_at_i_msun": m2_at_i,
     }
 
 
@@ -1338,6 +1396,12 @@ def run_one(
         fit_inclination_deg = gaia_nss.get("inclination_deg")
     if fit_m1_msun is None:
         fit_m1_msun = parse_m1_from_summary(summary_path)
+
+    mass_meta = load_mass_priors_from_summary(summary_path)
+    if fit_m1_msun is None:
+        fit_m1_msun = mass_meta.get("m1_msun")
+    if fit_inclination_deg is None:
+        fit_inclination_deg = mass_meta.get("inclination_deg")
 
     fit_variants = fit_all_variants(
         t,

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -215,7 +215,7 @@ import json
 import os
 from pathlib import Path
 
-from fit_apf_rv_keplerian import website_table_masses_from_report
+from fit_apf_rv_keplerian import lookup_fit_report_by_gaia_id, website_table_masses_from_report
 from darkhunter_rv.website_table_csv import (
     days_since_last_apf_from_summary,
     format_next_rv_event_cell,
@@ -283,9 +283,12 @@ for r in data_rows:
                 r.append("")
             r[apf_days_i] = f"{age:.2f}"
 
-    if sid in reports:
-        rep = reports[sid]
-        masses = website_table_masses_from_report(rep)
+    rep = lookup_fit_report_by_gaia_id(reports, sid)
+    if rep is not None:
+        masses = website_table_masses_from_report(
+            rep,
+            summary_path=summ if summ.is_file() else None,
+        )
         m2_astro = masses["m2_msun"]
         m2s = masses["m2sin_i_msun"]
         m2i = masses["m2_at_i_msun"]

--- a/scripts/update_website_table_columns.py
+++ b/scripts/update_website_table_columns.py
@@ -8,7 +8,7 @@ import csv
 import json
 from pathlib import Path
 
-from fit_apf_rv_keplerian import website_table_masses_from_report
+from fit_apf_rv_keplerian import lookup_fit_report_by_gaia_id, website_table_masses_from_report
 from darkhunter_rv.website_table_csv import (
     days_since_last_apf_from_summary,
     format_next_rv_event_cell,
@@ -54,6 +54,8 @@ def update_table_columns(
 
     n_apf_days = 0
     n_m2 = 0
+    n_m2sini = 0
+    n_m2_at_i = 0
     n_next = 0
     target = (gaia_id or "").strip()
     for r in data_rows:
@@ -75,10 +77,10 @@ def update_table_columns(
                 r[apf_days_i] = f"{age:.2f}"
                 n_apf_days += 1
 
-        if sid not in reports:
+        rep = lookup_fit_report_by_gaia_id(reports, sid)
+        if rep is None:
             continue
-        rep = reports[sid]
-        masses = website_table_masses_from_report(rep)
+        masses = website_table_masses_from_report(rep, summary_path=summ if summ.is_file() else None)
         if masses["m2_msun"] is not None:
             while len(r) <= m2_i:
                 r.append("")
@@ -88,10 +90,12 @@ def update_table_columns(
             while len(r) <= m2sini_i:
                 r.append("")
             r[m2sini_i] = f"{masses['m2sin_i_msun']:.5f}"
+            n_m2sini += 1
         if masses["m2_at_i_msun"] is not None:
             while len(r) <= m2over_i:
                 r.append("")
             r[m2over_i] = f"{masses['m2_at_i_msun']:.5f}"
+            n_m2_at_i += 1
         nxt = next_rv_event_from_fit_report(rep)
         if nxt is not None:
             while len(r) <= next_rv_i:
@@ -115,6 +119,8 @@ def update_table_columns(
         "stray_img_cleared": n_stray,
         "apf_days_filled": n_apf_days,
         "m2_filled": n_m2,
+        "m2sin_i_filled": n_m2sini,
+        "m2_at_i_filled": n_m2_at_i,
         "next_rv_filled": n_next,
         "reports_loaded": len(reports),
     }
@@ -157,6 +163,7 @@ def main() -> int:
         f"updated {args.data_csv}: {stats['data_rows']} rows, {stats['columns']} columns, "
         f"cleared {stats['stray_img_cleared']} stray <img>, "
         f"apf_days={stats['apf_days_filled']}, m2={stats['m2_filled']}, "
+        f"m2sin_i={stats['m2sin_i_filled']}, m2_at_i={stats['m2_at_i_filled']}, "
         f"next_rv={stats['next_rv_filled']} (from {stats['reports_loaded']} reports)"
     )
     return 0

--- a/tests/test_fit_apf_rv_keplerian.py
+++ b/tests/test_fit_apf_rv_keplerian.py
@@ -268,6 +268,53 @@ def test_load_nss_priors_includes_inclination(tmp_path: Path) -> None:
     assert priors["inclination_deg"] == pytest.approx(74.5)
 
 
+def test_parse_m1_from_gaia_metadata_block(tmp_path: Path) -> None:
+    summ = tmp_path / "Gaia_DR3_99_summary.txt"
+    summ.write_text(
+        "[GAIA METADATA]\n"
+        "Source_ID: 99\n"
+        "RA: 1.0\n"
+        "Dec: 2.0\n"
+        "M1: 1.25\n"
+        "Inclination: 60.0\n"
+        "\n[PIPELINE RESULTS]\n"
+        "ep_1.txt 60000 -1 0.1 0.2 False\n"
+    )
+    assert fitmod.parse_m1_from_summary(summ) == pytest.approx(1.25)
+    priors = fitmod.load_mass_priors_from_summary(summ)
+    assert priors["m1_msun"] == pytest.approx(1.25)
+    assert priors["inclination_deg"] == pytest.approx(60.0)
+
+
+def test_website_table_masses_recompute_from_free_fit(tmp_path: Path) -> None:
+    summ = tmp_path / "Gaia_DR3_99_summary.txt"
+    summ.write_text(
+        "[GAIA METADATA]\n"
+        "Source_ID: 99\n"
+        "RA: 1.0\n"
+        "Dec: 2.0\n"
+        "M1: 1.0\n"
+        "Inclination: 90.0\n"
+        "\n[PIPELINE RESULTS]\n"
+        "ep_1.txt 60000 -1 0.1 0.2 False\n"
+    )
+    rep = {
+        "used_m2_msun": 0.55,
+        "fit_variants": {
+            "free": {"P_days": 10.0, "K_kms": 40.0, "e": 0.1, "mass_function_msun": 0.05},
+        },
+    }
+    cols = fitmod.website_table_masses_from_report(rep, summary_path=summ)
+    assert cols["m2sin_i_msun"] is not None
+    assert cols["m2_at_i_msun"] is not None
+    assert cols["m2sin_i_msun"] == pytest.approx(cols["m2_at_i_msun"], rel=1e-5)
+
+
+def test_lookup_fit_report_by_gaia_id() -> None:
+    reports = {"Gaia_DR3_123": {"P_days": 1.0}}
+    assert fitmod.lookup_fit_report_by_gaia_id(reports, "123") == reports["Gaia_DR3_123"]
+
+
 def test_website_table_masses_from_report_separates_sources() -> None:
     rep = {
         "used_m2_msun": 0.55,


### PR DESCRIPTION
## Summary
PR #25 merged without the follow-up mass-column fix. This PR restores it:

- Parse **M1** and **inclination** from `[GAIA METADATA]` `Key: value` lines (the old parser only read `#` comments, so RV masses were never computed).
- Store **M2 sin i** / **M2 at i** in fit JSON when M1 is available.
- When filling `tables/data.csv`, recompute RV masses from `fit_variants.free` if JSON fields are empty, using M1 from the report or summary.
- Match fit JSON files keyed as numeric id or `Gaia_DR3_<id>`.

## On ziggy after merge

```bash
cd /data2/darkhunter/dark-hunter_rv && git pull
bash scripts/repair_website_table.sh
```

Or only refill mass columns:

```bash
PYTHONPATH=. python3 scripts/update_website_table_columns.py \
  --data-csv /var/www/html/darkhunter/rv/tables/data.csv \
  --output-dir /data2/darkhunter/dark-hunter_rv/output \
  --reports-dir /data2/darkhunter/dark-hunter_rv/rv_fit_reports
```

Stars without **M1** in summary metadata still need a refit: `STAR_ID=<id> bash scripts/refit_all_per_object.sh`

## Test plan
- [x] `pytest tests/test_fit_apf_rv_keplerian.py` (M1 metadata + recompute + lookup tests)


Made with [Cursor](https://cursor.com)