### PR TITLE
Fix empty M2 sin i / M2 at i: resolve M1 for RV mass columns

### DIFF
--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -885,10 +885,127 @@ def _finite_mass_value(value: Any) -> Optional[float]:
     return None
 
 
+def _gaia_nss_dict_from_report(report: dict) -> Dict[str, Any]:
+    gnss = report.get("gaia_nss")
+    return gnss if isinstance(gnss, dict) else {}
+
+
+def _gaia_cache_entry(gaia_cache: Optional[Dict[str, Any]], gaia_source_id: Optional[str]) -> Optional[dict]:
+    if not gaia_cache or not gaia_source_id:
+        return None
+    sid = str(gaia_source_id).strip()
+    for key in (sid, f"Gaia_DR3_{sid}"):
+        val = gaia_cache.get(key)
+        if isinstance(val, dict) and not val.get("_none"):
+            return val
+    return None
+
+
+def estimate_m1_msun_from_hrd(meta: Dict[str, Any]) -> Optional[float]:
+    """Rough main-sequence M1 (Msun) from Gaia GSP-PHOT Teff/logg when NSS masses are absent."""
+    teff = _meta_float(meta, "Teff", "teff")
+    if teff is None or not (3200.0 <= teff <= 9000.0):
+        return None
+    logg = _meta_float(meta, "logg", "Logg")
+    if logg is not None and logg < 3.5:
+        return None
+    m1 = float((teff / 5772.0) ** 1.8)
+    return float(np.clip(m1, 0.5, 2.0))
+
+
+def resolve_m1_msun_for_rv_mass(
+    report: dict,
+    *,
+    summary_path: Optional[Path] = None,
+    gaia_cache: Optional[Dict[str, Any]] = None,
+) -> Optional[float]:
+    """
+    Primary mass for converting RV f(M) to M2 sin i / M2 at i.
+
+    Order: fit report → embedded gaia_nss → gaia_nss_cache.json → summary metadata →
+    M2/Mass_Ratio → Teff/logg estimate → 1 Msun if a free RV fit exists.
+    """
+    m1 = _finite_mass_value(report.get("used_m1_msun"))
+    if m1 is not None:
+        return m1
+
+    gnss = _gaia_nss_dict_from_report(report)
+    m1 = _finite_mass_value(gnss.get("m1_msun"))
+    if m1 is not None:
+        return m1
+
+    sid = report.get("gaia_source_id")
+    cached = _gaia_cache_entry(gaia_cache, str(sid) if sid is not None else None)
+    if cached is not None:
+        m1 = _finite_mass_value(cached.get("m1_msun"))
+        if m1 is not None:
+            return m1
+
+    meta_mass: Dict[str, float] = {}
+    meta_raw: Optional[Dict[str, Any]] = None
+    if summary_path is not None and summary_path.is_file():
+        meta_mass = load_mass_priors_from_summary(summary_path)
+        m1 = _finite_mass_value(meta_mass.get("m1_msun"))
+        if m1 is not None:
+            return m1
+        meta_raw = _parse_gaia_metadata(summary_path)
+
+    m2 = _finite_mass_value(report.get("used_m2_msun"))
+    if m2 is None:
+        m2 = _finite_mass_value(gnss.get("m2_msun"))
+    if m2 is None and cached is not None:
+        m2 = _finite_mass_value(cached.get("m2_msun"))
+    if m2 is None:
+        m2 = _finite_mass_value(meta_mass.get("m2_msun"))
+    q = _meta_float(meta_raw, "Mass_Ratio", "mass_ratio") if meta_raw else None
+    if m2 is not None and q is not None and q > 0:
+        return float(m2 / q)
+
+    if meta_raw:
+        est = estimate_m1_msun_from_hrd(meta_raw)
+        if est is not None:
+            return est
+
+    if _free_fit_variant_report(report) is not None:
+        return 1.0
+    return None
+
+
+def resolve_m2_astrometric_msun(
+    report: dict,
+    *,
+    summary_path: Optional[Path] = None,
+    gaia_cache: Optional[Dict[str, Any]] = None,
+) -> Optional[float]:
+    """Gaia NSS astrometric secondary mass (not from the RV-only fit)."""
+    m2 = _finite_mass_value(report.get("used_m2_msun"))
+    if m2 is not None:
+        return m2
+    m2 = _finite_mass_value(report.get("m2_astrometric_msun"))
+    if m2 is not None:
+        return m2
+    gnss = _gaia_nss_dict_from_report(report)
+    m2 = _finite_mass_value(gnss.get("m2_msun"))
+    if m2 is not None:
+        return m2
+    sid = report.get("gaia_source_id")
+    cached = _gaia_cache_entry(gaia_cache, str(sid) if sid is not None else None)
+    if cached is not None:
+        m2 = _finite_mass_value(cached.get("m2_msun"))
+        if m2 is not None:
+            return m2
+    if summary_path is not None and summary_path.is_file():
+        m2 = _finite_mass_value(load_mass_priors_from_summary(summary_path).get("m2_msun"))
+        if m2 is not None:
+            return m2
+    return None
+
+
 def website_table_masses_from_report(
     report: dict,
     *,
     summary_path: Optional[Path] = None,
+    gaia_cache: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Optional[float]]:
     """
     Map a Keplerian fit JSON report to website ``data.csv`` mass columns.
@@ -900,18 +1017,19 @@ def website_table_masses_from_report(
     m2sin = _finite_mass_value(report.get("m2sini_msun"))
     m2_at_i = _finite_mass_value(report.get("m2_given_inclination_msun"))
 
-    m1 = _finite_mass_value(report.get("used_m1_msun"))
     incl_raw = report.get("inclination_deg_used")
     incl = float(incl_raw) if isinstance(incl_raw, (int, float)) and np.isfinite(incl_raw) else None
 
-    if summary_path is not None:
+    if summary_path is not None and summary_path.is_file():
         meta_mass = load_mass_priors_from_summary(summary_path)
-        if m1 is None:
-            m1 = _finite_mass_value(meta_mass.get("m1_msun"))
         if incl is None:
             incl_meta = meta_mass.get("inclination_deg")
             if incl_meta is not None and np.isfinite(incl_meta):
                 incl = float(incl_meta)
+
+    m1 = resolve_m1_msun_for_rv_mass(
+        report, summary_path=summary_path, gaia_cache=gaia_cache
+    )
 
     if m2sin is None or m2_at_i is None:
         rep_free = _free_fit_variant_report(report)
@@ -919,11 +1037,13 @@ def website_table_masses_from_report(
             calc_sini, calc_at_i = rv_only_mass_estimates(rep_free, m1, incl)
             if m2sin is None:
                 m2sin = _finite_mass_value(calc_sini)
-            if m2_at_i is None:
+            if m2_at_i is None and incl is not None:
                 m2_at_i = _finite_mass_value(calc_at_i)
 
     return {
-        "m2_msun": _finite_mass_value(report.get("used_m2_msun")),
+        "m2_msun": resolve_m2_astrometric_msun(
+            report, summary_path=summary_path, gaia_cache=gaia_cache
+        ),
         "m2sin_i_msun": m2sin,
         "m2_at_i_msun": m2_at_i,
     }

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -215,7 +215,11 @@ import json
 import os
 from pathlib import Path
 
-from fit_apf_rv_keplerian import lookup_fit_report_by_gaia_id, website_table_masses_from_report
+from fit_apf_rv_keplerian import (
+    _load_json_cache,
+    lookup_fit_report_by_gaia_id,
+    website_table_masses_from_report,
+)
 from darkhunter_rv.website_table_csv import (
     days_since_last_apf_from_summary,
     format_next_rv_event_cell,
@@ -227,6 +231,8 @@ from darkhunter_rv.website_table_csv import (
 
 report_dir = Path(os.environ["REPORTS_DIR"])
 out_dir = Path(os.environ.get("OUT", report_dir.parent / "output"))
+gaia_cache_path = report_dir / "gaia_nss_cache.json"
+gaia_cache = _load_json_cache(gaia_cache_path) if gaia_cache_path.is_file() else {}
 data_csv = Path(os.environ["DATA_CSV"])
 missing_csv = Path(os.environ["MISSING_ASSETS_CSV"])
 summary_json = Path(os.environ["STAGED_SUMMARY"])
@@ -288,6 +294,7 @@ for r in data_rows:
         masses = website_table_masses_from_report(
             rep,
             summary_path=summ if summ.is_file() else None,
+            gaia_cache=gaia_cache,
         )
         m2_astro = masses["m2_msun"]
         m2s = masses["m2sin_i_msun"]

--- a/scripts/repair_website_table.sh
+++ b/scripts/repair_website_table.sh
@@ -51,6 +51,7 @@ if [[ ! -f "$REPO/scripts/update_website_table_columns.py" ]]; then
 fi
 
 echo "=== Normalize data.csv + fill columns from existing summaries/reports ==="
+echo "M2 sin i / M2 at i need M1 (gaia_nss_cache.json, Teff estimate, or 1 Msun default)."
 "$PY" scripts/update_website_table_columns.py \
   --data-csv "$WEB_ROOT/tables/data.csv" \
   --output-dir "$OUT" \

--- a/scripts/update_website_table_columns.py
+++ b/scripts/update_website_table_columns.py
@@ -6,9 +6,14 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import warnings
 from pathlib import Path
 
-from fit_apf_rv_keplerian import lookup_fit_report_by_gaia_id, website_table_masses_from_report
+from fit_apf_rv_keplerian import (
+    _load_json_cache,
+    lookup_fit_report_by_gaia_id,
+    website_table_masses_from_report,
+)
 from darkhunter_rv.website_table_csv import (
     days_since_last_apf_from_summary,
     format_next_rv_event_cell,
@@ -19,12 +24,23 @@ from darkhunter_rv.website_table_csv import (
 )
 
 
+def load_gaia_nss_cache(reports_dir: Path) -> dict:
+    for path in (
+        reports_dir / "gaia_nss_cache.json",
+        reports_dir.parent / "rv_fit_reports" / "gaia_nss_cache.json",
+    ):
+        if path.is_file():
+            return _load_json_cache(path)
+    return {}
+
+
 def update_table_columns(
     data_csv: Path,
     *,
     out_dir: Path,
     reports_dir: Path,
     gaia_id: str | None = None,
+    gaia_cache: dict | None = None,
 ) -> dict[str, int]:
     rows: list[list[str]] = []
     with data_csv.open(newline="", encoding="utf-8") as fh:
@@ -42,6 +58,9 @@ def update_table_columns(
     m2over_i = hdr.index("(M2sin i)/(sin i) (Msun)")
     apf_days_i = hdr.index("DAYS SINCE LAST APF")
     next_rv_i = hdr.index("NEXT RV EVENT (DATE)")
+
+    if gaia_cache is None:
+        gaia_cache = load_gaia_nss_cache(reports_dir)
 
     reports: dict[str, dict] = {}
     if reports_dir.is_dir():
@@ -80,7 +99,11 @@ def update_table_columns(
         rep = lookup_fit_report_by_gaia_id(reports, sid)
         if rep is None:
             continue
-        masses = website_table_masses_from_report(rep, summary_path=summ if summ.is_file() else None)
+        masses = website_table_masses_from_report(
+            rep,
+            summary_path=summ if summ.is_file() else None,
+            gaia_cache=gaia_cache,
+        )
         if masses["m2_msun"] is not None:
             while len(r) <= m2_i:
                 r.append("")
@@ -127,6 +150,13 @@ def update_table_columns(
 
 
 def main() -> int:
+    try:
+        from erfa import ErfaWarning  # type: ignore
+
+        warnings.filterwarnings("ignore", category=ErfaWarning)
+    except Exception:
+        pass
+
     ap = argparse.ArgumentParser(
         description="Normalize data.csv and fill schedule/mass columns from existing assets (no refit)."
     )
@@ -153,11 +183,13 @@ def main() -> int:
     repo = Path(__file__).resolve().parents[1]
     out_dir = Path(args.output_dir) if args.output_dir else repo / "output"
     reports_dir = Path(args.reports_dir) if args.reports_dir else repo / "rv_fit_reports"
+    gaia_cache = load_gaia_nss_cache(reports_dir)
     stats = update_table_columns(
         Path(args.data_csv),
         out_dir=out_dir,
         reports_dir=reports_dir,
         gaia_id=args.gaia_id,
+        gaia_cache=gaia_cache,
     )
     print(
         f"updated {args.data_csv}: {stats['data_rows']} rows, {stats['columns']} columns, "

--- a/tests/test_fit_apf_rv_keplerian.py
+++ b/tests/test_fit_apf_rv_keplerian.py
@@ -286,6 +286,38 @@ def test_parse_m1_from_gaia_metadata_block(tmp_path: Path) -> None:
     assert priors["inclination_deg"] == pytest.approx(60.0)
 
 
+def test_resolve_m1_defaults_when_free_fit_present() -> None:
+    rep = {
+        "gaia_source_id": "99",
+        "fit_variants": {
+            "free": {"P_days": 10.0, "K_kms": 40.0, "e": 0.1, "mass_function_msun": 0.05},
+        },
+    }
+    assert fitmod.resolve_m1_msun_for_rv_mass(rep) == pytest.approx(1.0)
+
+
+def test_website_table_masses_with_teff_fallback(tmp_path: Path) -> None:
+    summ = tmp_path / "Gaia_DR3_99_summary.txt"
+    summ.write_text(
+        "[GAIA METADATA]\n"
+        "Source_ID: 99\n"
+        "RA: 1.0\n"
+        "Dec: 2.0\n"
+        "Teff: 5772.0\n"
+        "logg: 4.44\n"
+        "\n[PIPELINE RESULTS]\n"
+        "ep_1.txt 60000 -1 0.1 0.2 False\n"
+    )
+    rep = {
+        "gaia_source_id": "99",
+        "fit_variants": {
+            "free": {"P_days": 10.0, "K_kms": 40.0, "e": 0.1, "mass_function_msun": 0.05},
+        },
+    }
+    cols = fitmod.website_table_masses_from_report(rep, summary_path=summ)
+    assert cols["m2sin_i_msun"] is not None
+
+
 def test_website_table_masses_recompute_from_free_fit(tmp_path: Path) -> None:
     summ = tmp_path / "Gaia_DR3_99_summary.txt"
     summ.write_text(


### PR DESCRIPTION
## Problem
`repair_website_table.sh` reported `m2=0, m2sin_i=0, m2_at_i=0` with 69 fit reports loaded. Next-RV filled (67) proves report lookup works; masses failed because **M1 is not written** into star summaries (Gaia pipeline metadata has Teff/Period/Inclination but not `binary_masses` M1/M2 unless queried online).

## Fix
- `resolve_m1_msun_for_rv_mass`: report → `gaia_nss` in JSON → `gaia_nss_cache.json` → summary → **M2/Mass_Ratio** → **Teff/logg MS estimate** → **1 Msun** when a free RV fit exists.
- `resolve_m2_astrometric_msun`: same cache/report chain for the **M2 (Msun)** column.
- Table update loads `rv_fit_reports/gaia_nss_cache.json` and ignores ERFA dubious-year warnings.

**M2 at i** still requires inclination in summary or fit JSON (many NSS stars have `Inclination` in metadata).

## On ziggy after merge
```bash
cd /data2/darkhunter/dark-hunter_rv && git pull
bash scripts/repair_website_table.sh
```

For Gaia DR3 `binary_masses` M1/M2 in JSON (best astrometric values), refit with online NSS once:
```bash
QUERY_GAIA_ONLINE=1 STAR_ID=<id> bash scripts/refit_all_per_object.sh
```

## Test plan
- [x] New/updated tests for M1 resolution and Teff fallback


Made with [Cursor](https://cursor.com)