### PR TITLE
M2 at i only with real Gaia inclination (not M2 sin i copy)

### DIFF
--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -1127,8 +1127,20 @@ def website_table_masses_from_report(
             m2_at_i = _finite_mass_value(calc_at_i)
     if m2sin is None:
         m2sin = _finite_mass_value(report.get("m2sini_msun"))
-    if m2_at_i is None and incl is not None:
-        m2_at_i = _finite_mass_value(report.get("m2_given_inclination_msun"))
+    if m2_at_i is None:
+        stored_at_i = _finite_mass_value(report.get("m2_given_inclination_msun"))
+        stored_sin_json = _finite_mass_value(report.get("m2sini_msun"))
+        if stored_at_i is not None:
+            incl_used = report.get("inclination_deg_used")
+            has_fit_incl = isinstance(incl_used, (int, float)) and np.isfinite(incl_used)
+            if incl is not None or has_fit_incl:
+                m2_at_i = stored_at_i
+            elif (
+                stored_sin_json is not None
+                and abs(stored_at_i - stored_sin_json) > max(1e-6, 1e-4 * stored_sin_json)
+            ):
+                # Trust fit JSON when M2 at i was computed with real i (not a sin-i copy).
+                m2_at_i = stored_at_i
 
     return {
         "m2_msun": resolve_m2_astrometric_msun(

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -1027,6 +1027,46 @@ def resolve_inclination_deg_for_rv_mass(
     return None
 
 
+def enrich_gaia_cache_from_summaries(
+    gaia_cache: Dict[str, Any],
+    out_dir: Path,
+    *,
+    gaia_ids: Optional[List[str]] = None,
+) -> int:
+    """Merge [GAIA METADATA] masses/inclination from star summaries into the NSS cache dict."""
+    n = 0
+    if gaia_ids is None:
+        paths = sorted(out_dir.glob("Gaia_DR3_*_summary.txt"))
+    else:
+        paths = [out_dir / f"Gaia_DR3_{gid}_summary.txt" for gid in gaia_ids]
+    for summ in paths:
+        if not summ.is_file():
+            continue
+        sid_m = re.search(r"Gaia_DR3_(\d{18,19})", summ.name)
+        if not sid_m:
+            continue
+        sid = sid_m.group(1)
+        priors = load_mass_priors_from_summary(summ)
+        if not priors:
+            continue
+        entry = gaia_cache.get(sid)
+        if not isinstance(entry, dict) or entry.get("_none"):
+            entry = {}
+            gaia_cache[sid] = entry
+        patched = False
+        for key in ("m1_msun", "m2_msun", "inclination_deg"):
+            val = priors.get(key)
+            if val is None or not np.isfinite(val):
+                continue
+            if key == "inclination_deg" and _valid_inclination_deg(val) is None:
+                continue
+            entry[key] = float(val)
+            patched = True
+        if patched:
+            n += 1
+    return n
+
+
 def resolve_m2_astrometric_msun(
     report: dict,
     *,
@@ -1070,28 +1110,25 @@ def website_table_masses_from_report(
     - ``m2sin_i_msun``: M2 sin i from the RV-only (free) fit and assumed M1.
     - ``m2_at_i_msun``: M2 at i from the RV-only f(M), assumed M1, and astrometric i.
     """
-    m2sin = _finite_mass_value(report.get("m2sini_msun"))
-    m2_at_i = _finite_mass_value(report.get("m2_given_inclination_msun"))
-
     incl = resolve_inclination_deg_for_rv_mass(
         report, summary_path=summary_path, gaia_cache=gaia_cache
     )
-
     m1 = resolve_m1_msun_for_rv_mass(
         report, summary_path=summary_path, gaia_cache=gaia_cache
     )
 
-    if m2sin is None or m2_at_i is None:
-        rep_free = _free_fit_variant_report(report)
-        if rep_free is not None and m1 is not None:
-            calc_sini, calc_at_i = rv_only_mass_estimates(rep_free, m1, incl)
-            if m2sin is None:
-                m2sin = _finite_mass_value(calc_sini)
-            if m2_at_i is None:
-                m2_at_i = _finite_mass_value(calc_at_i)
-            # If M2 sin i is known but Gaia i is not, use i = 90° (M2 at i = M2 sin i).
-            if m2_at_i is None and m2sin is not None and incl is None:
-                m2_at_i = float(m2sin)
+    m2sin: Optional[float] = None
+    m2_at_i: Optional[float] = None
+    rep_free = _free_fit_variant_report(report)
+    if rep_free is not None and m1 is not None:
+        calc_sini, calc_at_i = rv_only_mass_estimates(rep_free, m1, incl)
+        m2sin = _finite_mass_value(calc_sini)
+        if incl is not None:
+            m2_at_i = _finite_mass_value(calc_at_i)
+    if m2sin is None:
+        m2sin = _finite_mass_value(report.get("m2sini_msun"))
+    if m2_at_i is None and incl is not None:
+        m2_at_i = _finite_mass_value(report.get("m2_given_inclination_msun"))
 
     return {
         "m2_msun": resolve_m2_astrometric_msun(

--- a/scripts/prefetch_gaia_nss_for_table.py
+++ b/scripts/prefetch_gaia_nss_for_table.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Query Gaia NSS (period, e, inclination, binary masses) for stars in tables/data.csv."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+from darkhunter_rv.website_table_csv import gaia_id_from_row
+from fit_apf_rv_keplerian import prefetch_gaia_nss_bulk
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Prefetch Gaia NSS into gaia_nss_cache.json for table stars.")
+    ap.add_argument("--data-csv", required=True)
+    ap.add_argument("--reports-dir", required=True)
+    args = ap.parse_args()
+
+    reports_dir = Path(args.reports_dir)
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = reports_dir / "gaia_nss_cache.json"
+
+    ids: list[str] = []
+    with Path(args.data_csv).open(newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+    if not rows:
+        return 1
+    hdr = rows[0]
+    gaia_i = hdr.index("GAIA NAME")
+    for r in rows[1:]:
+        if not r:
+            continue
+        sid = gaia_id_from_row(r[gaia_i] if gaia_i < len(r) else "")
+        if sid:
+            ids.append(sid)
+
+    prefetch_gaia_nss_bulk(sorted(set(ids)), cache_path)
+    print(f"prefetched Gaia NSS for {len(set(ids))} sources → {cache_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repair_website_table.sh
+++ b/scripts/repair_website_table.sh
@@ -50,8 +50,15 @@ if [[ ! -f "$REPO/scripts/update_website_table_columns.py" ]]; then
   exit 2
 fi
 
+if [[ "${PREFETCH_GAIA_NSS:-0}" == "1" ]]; then
+  echo "=== Prefetch Gaia NSS (inclination, binary masses) for table stars ==="
+  PYTHONPATH=. "$PY" scripts/prefetch_gaia_nss_for_table.py \
+    --data-csv "$WEB_ROOT/tables/data.csv" \
+    --reports-dir "$REPORTS_DIR"
+fi
+
 echo "=== Normalize data.csv + fill columns from existing summaries/reports ==="
-echo "M2 sin i / M2 at i need M1 (gaia_nss_cache.json, Teff estimate, or 1 Msun default)."
+echo "M2 at i requires Gaia Inclination (summary [GAIA METADATA] or PREFETCH_GAIA_NSS=1); not copied from M2 sin i."
 "$PY" scripts/update_website_table_columns.py \
   --data-csv "$WEB_ROOT/tables/data.csv" \
   --output-dir "$OUT" \

--- a/scripts/update_website_table_columns.py
+++ b/scripts/update_website_table_columns.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from fit_apf_rv_keplerian import (
     _load_json_cache,
+    enrich_gaia_cache_from_summaries,
     lookup_fit_report_by_gaia_id,
     website_table_masses_from_report,
 )
@@ -61,6 +62,14 @@ def update_table_columns(
 
     if gaia_cache is None:
         gaia_cache = load_gaia_nss_cache(reports_dir)
+
+    gaia_ids = [
+        gaia_id_from_row((r[hdr.index("GAIA NAME")] if hdr.index("GAIA NAME") < len(r) else ""))
+        for r in data_rows
+        if r
+    ]
+    gaia_ids = [g for g in gaia_ids if g]
+    n_cache_summ = enrich_gaia_cache_from_summaries(gaia_cache, out_dir, gaia_ids=gaia_ids)
 
     reports: dict[str, dict] = {}
     if reports_dir.is_dir():
@@ -146,6 +155,7 @@ def update_table_columns(
         "m2_at_i_filled": n_m2_at_i,
         "next_rv_filled": n_next,
         "reports_loaded": len(reports),
+        "cache_enriched_from_summaries": n_cache_summ,
     }
 
 
@@ -196,7 +206,8 @@ def main() -> int:
         f"cleared {stats['stray_img_cleared']} stray <img>, "
         f"apf_days={stats['apf_days_filled']}, m2={stats['m2_filled']}, "
         f"m2sin_i={stats['m2sin_i_filled']}, m2_at_i={stats['m2_at_i_filled']}, "
-        f"next_rv={stats['next_rv_filled']} (from {stats['reports_loaded']} reports)"
+        f"next_rv={stats['next_rv_filled']} (from {stats['reports_loaded']} reports, "
+        f"cache+summary incl patches={stats['cache_enriched_from_summaries']})"
     )
     return 0
 

--- a/tests/test_fit_apf_rv_keplerian.py
+++ b/tests/test_fit_apf_rv_keplerian.py
@@ -319,7 +319,7 @@ def test_website_table_masses_m2_at_i_from_inclination(tmp_path: Path) -> None:
         "RA: 1.0\n"
         "Dec: 2.0\n"
         "M1: 1.0\n"
-        "Inclination: 90.0\n"
+        "Inclination: 60.0\n"
         "\n[PIPELINE RESULTS]\n"
         "ep_1.txt 60000 -1 0.1 0.2 False\n"
     )
@@ -332,19 +332,21 @@ def test_website_table_masses_m2_at_i_from_inclination(tmp_path: Path) -> None:
     cols = fitmod.website_table_masses_from_report(rep, summary_path=summ)
     assert cols["m2sin_i_msun"] is not None
     assert cols["m2_at_i_msun"] is not None
-    assert cols["m2_at_i_msun"] == pytest.approx(cols["m2sin_i_msun"], rel=1e-4)
+    assert cols["m2_at_i_msun"] > cols["m2sin_i_msun"]
 
 
-def test_website_table_masses_m2_at_i_fallback_equals_m2sin(tmp_path: Path) -> None:
+def test_website_table_masses_m2_at_i_empty_without_inclination() -> None:
     rep = {
         "gaia_source_id": "99",
+        "m2sini_msun": 0.4,
+        "m2_given_inclination_msun": 0.4,
         "fit_variants": {
             "free": {"P_days": 10.0, "K_kms": 40.0, "e": 0.1, "mass_function_msun": 0.05},
         },
     }
     cols = fitmod.website_table_masses_from_report(rep, summary_path=None)
     assert cols["m2sin_i_msun"] is not None
-    assert cols["m2_at_i_msun"] == pytest.approx(cols["m2sin_i_msun"])
+    assert cols["m2_at_i_msun"] is None
 
 
 def test_website_table_masses_with_teff_fallback(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem
PR #28 used an i = 90° fallback when Gaia inclination was missing, setting **M2 at i = M2 sin i** for every star — the two columns looked identical.

## Fix
- Remove the 90° fallback entirely.
- Recompute **M2 sin i** and **M2 at i** from the free RV fit; **M2 at i** is filled only when `Inclination` is available (summary, fit JSON, or `gaia_nss_cache.json`).
- Merge summary `[GAIA METADATA]` inclinations into the NSS cache before table fill.
- Optional: `PREFETCH_GAIA_NSS=1 bash scripts/repair_website_table.sh` queries Gaia for inclination + binary masses.

## On ziggy after merge
```bash
cd /data2/darkhunter/dark-hunter_rv && git pull
PREFETCH_GAIA_NSS=1 bash scripts/repair_website_table.sh
# or without network if summaries already have Inclination:
bash scripts/repair_website_table.sh
```

Stars without Gaia **Inclination** will show **M2 sin i** only; **M2 at i** stays blank (correct).

## Test plan
- [x] `pytest` — M2 at i > M2 sin i at i=60°; M2 at i empty without inclination


Made with [Cursor](https://cursor.com)