### PR TITLE
Fix identical M2 sin i and M2 at i table columns

### DIFF
--- a/docs/website.md
+++ b/docs/website.md
@@ -91,9 +91,9 @@ Rebuilds `Gaia_DR3_<id>_28_hbeta.png` (−300…+300 km/s, flux 1–99%), copies
 ```bash
 cd /data2/darkhunter/dark-hunter_rv && git pull
 bash scripts/update_hbeta_website.sh
-# optional: deploy script.js/style.css too
-DEPLOY_STATIC=1 bash scripts/update_hbeta_website.sh
 ```
+
+Deploys `script.js` (table H-beta links always point at `Gaia_DR3_<id>_28_hbeta.png`, not legacy CSV URLs) and prunes old `*_h_beta_rv.png` files from `Plots/`.
 
 ### 2 — Full refit in detached screen (per-star pipeline → fit → Hβ → live website row)
 

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -988,6 +988,21 @@ def _valid_inclination_deg(value: Any) -> Optional[float]:
     return incl
 
 
+def _json_inclination_is_stale_sin_i_fallback(report: dict) -> bool:
+    """
+    Detect fit JSON from the old i=90° table-fill era: inclination_deg_used=90 with
+    m2_given_inclination_msun copied from m2sini_msun.
+    """
+    incl = _valid_inclination_deg(report.get("inclination_deg_used"))
+    if incl is None or abs(incl - 90.0) > 0.05:
+        return False
+    stored_at = _finite_mass_value(report.get("m2_given_inclination_msun"))
+    stored_sin = _finite_mass_value(report.get("m2sini_msun"))
+    if stored_at is None or stored_sin is None:
+        return False
+    return abs(stored_at - stored_sin) <= max(1e-6, 1e-4 * stored_sin)
+
+
 def resolve_inclination_deg_for_rv_mass(
     report: dict,
     *,
@@ -995,10 +1010,6 @@ def resolve_inclination_deg_for_rv_mass(
     gaia_cache: Optional[Dict[str, Any]] = None,
 ) -> Optional[float]:
     """Astrometric inclination (deg) for M2 at i = (M2 sin i) / sin(i)."""
-    incl = _valid_inclination_deg(report.get("inclination_deg_used"))
-    if incl is not None:
-        return incl
-
     gnss = _gaia_nss_dict_from_report(report)
     incl = _valid_inclination_deg(gnss.get("inclination_deg"))
     if incl is not None:
@@ -1024,6 +1035,11 @@ def resolve_inclination_deg_for_rv_mass(
             )
             if incl is not None:
                 return incl
+
+    if not _json_inclination_is_stale_sin_i_fallback(report):
+        incl = _valid_inclination_deg(report.get("inclination_deg_used"))
+        if incl is not None:
+            return incl
     return None
 
 
@@ -1065,6 +1081,17 @@ def enrich_gaia_cache_from_summaries(
         if patched:
             n += 1
     return n
+
+
+def m2_msun_at_inclination(m2sin_msun: float, inclination_deg: float) -> Optional[float]:
+    """M2 at inclination i (Msun) from M2 sin i and astrometric i (degrees)."""
+    incl = _valid_inclination_deg(inclination_deg)
+    if incl is None or not np.isfinite(m2sin_msun) or float(m2sin_msun) <= 0:
+        return None
+    sin_i = float(np.sin(np.deg2rad(incl)))
+    if sin_i < 1e-6:
+        return None
+    return float(m2sin_msun / sin_i)
 
 
 def resolve_m2_astrometric_msun(
@@ -1123,24 +1150,23 @@ def website_table_masses_from_report(
     if rep_free is not None and m1 is not None:
         calc_sini, calc_at_i = rv_only_mass_estimates(rep_free, m1, incl)
         m2sin = _finite_mass_value(calc_sini)
-        if incl is not None:
+        if incl is not None and m2sin is not None:
             m2_at_i = _finite_mass_value(calc_at_i)
+            if m2_at_i is None:
+                m2_at_i = m2_msun_at_inclination(m2sin, incl)
     if m2sin is None:
         m2sin = _finite_mass_value(report.get("m2sini_msun"))
+    if m2_at_i is None and m2sin is not None and incl is not None:
+        m2_at_i = m2_msun_at_inclination(m2sin, incl)
     if m2_at_i is None:
         stored_at_i = _finite_mass_value(report.get("m2_given_inclination_msun"))
         stored_sin_json = _finite_mass_value(report.get("m2sini_msun"))
-        if stored_at_i is not None:
-            incl_used = report.get("inclination_deg_used")
-            has_fit_incl = isinstance(incl_used, (int, float)) and np.isfinite(incl_used)
-            if incl is not None or has_fit_incl:
-                m2_at_i = stored_at_i
-            elif (
-                stored_sin_json is not None
-                and abs(stored_at_i - stored_sin_json) > max(1e-6, 1e-4 * stored_sin_json)
-            ):
-                # Trust fit JSON when M2 at i was computed with real i (not a sin-i copy).
-                m2_at_i = stored_at_i
+        if (
+            stored_at_i is not None
+            and stored_sin_json is not None
+            and abs(stored_at_i - stored_sin_json) > max(1e-6, 1e-4 * stored_sin_json)
+        ):
+            m2_at_i = stored_at_i
 
     return {
         "m2_msun": resolve_m2_astrometric_msun(

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -304,14 +304,18 @@ for r in data_rows:
                 r.append("")
             r[m2_i] = f"{m2_astro:.5f}"
             updated += 1
+        while len(r) <= m2sini_i:
+            r.append("")
         if m2s is not None:
-            while len(r) <= m2sini_i:
-                r.append("")
             r[m2sini_i] = f"{m2s:.5f}"
+        else:
+            r[m2sini_i] = ""
+        while len(r) <= m2over_i:
+            r.append("")
         if m2i is not None:
-            while len(r) <= m2over_i:
-                r.append("")
             r[m2over_i] = f"{m2i:.5f}"
+        else:
+            r[m2over_i] = ""
         nxt = next_rv_event_from_fit_report(rep)
         if nxt is not None:
             while len(r) <= next_rv_i:

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -18,6 +18,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/website_plot_sync.sh
+source "$SCRIPT_DIR/lib/website_plot_sync.sh"
+
 REPO="${REPO:-/data2/darkhunter/dark-hunter_rv}"
 OUT="${OUT:-$REPO/output}"
 WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
@@ -193,13 +197,9 @@ for summ in "${SUMMARY_FILES[@]}"; do
 
   src_plot_dir="$OUT/Gaia_DR3_${gid}"
   if [[ -d "$src_plot_dir" ]]; then
-    mapfile -t pngs < <(find "$src_plot_dir" -maxdepth 1 -type f -name '*.png' | sort)
-    if [[ "${#pngs[@]}" -gt 0 ]]; then
-      for p in "${pngs[@]}"; do
-        run_cmd cp "$p" "$star_plots/$(basename "$p")"
-        staged_plots=$((staged_plots + 1))
-      done
-    elif [[ "$DRY_RUN" != "1" ]]; then
+    n_plots=$(website_stage_gaia_plots "$gid" "$src_plot_dir" "$star_plots")
+    staged_plots=$((staged_plots + n_plots))
+    if [[ "$n_plots" -eq 0 && "$DRY_RUN" != "1" ]]; then
       echo "${gid},missing_plot_pngs,${src_plot_dir}" >> "$MISSING_ASSETS_CSV"
     fi
   elif [[ "$DRY_RUN" != "1" ]]; then

--- a/scripts/lib/website_plot_sync.sh
+++ b/scripts/lib/website_plot_sync.sh
@@ -1,0 +1,39 @@
+# Copy only website-contract Gaia plot PNGs; remove legacy pipeline Hβ diagnostics.
+# Requires: run_cmd (optional DRY_RUN).
+
+website_stage_gaia_plots() {
+  local gid="${1:?gaia id}"
+  local src_dir="${2:?source plot dir}"
+  local dest_dir="${3:?dest Plots dir}"
+  local n=0
+
+  run_cmd mkdir -p "$dest_dir"
+  local name
+  for name in \
+    "Gaia_DR3_${gid}_28_hbeta.png" \
+    "Gaia_DR3_${gid}_rv_plot.png" \
+    "Gaia_DR3_${gid}_keplerian_residuals.png"
+  do
+    if [[ -f "$src_dir/$name" ]]; then
+      run_cmd cp "$src_dir/$name" "$dest_dir/$name"
+      n=$((n + 1))
+    fi
+  done
+  website_prune_legacy_gaia_plots "$dest_dir"
+  echo "$n"
+}
+
+website_prune_legacy_gaia_plots() {
+  local plot_dir="${1:?Plots directory}"
+  [[ -d "$plot_dir" ]] || return 0
+  local f
+  while IFS= read -r -d '' f; do
+    run_cmd rm -f "$f"
+  done < <(
+    find "$plot_dir" -maxdepth 1 -type f \( \
+      -name '*_h_beta_rv.png' -o \
+      -name '*_h_beta_order*.png' -o \
+      -name '*_h_beta_three*.png' \
+    \) -print0 2>/dev/null
+  )
+}

--- a/scripts/lib/website_sync_one_star.sh
+++ b/scripts/lib/website_sync_one_star.sh
@@ -1,6 +1,9 @@
 # Stage one star into WEB_ROOT and refresh its data.csv row.
 # Requires: REPO, WEB_ROOT, OUT, REPORTS_DIR, PY, WEBSITE_STARS_DIR, DATA_CSV, run_cmd (optional DRY_RUN).
 
+# shellcheck source=scripts/lib/website_plot_sync.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/website_plot_sync.sh"
+
 website_sync_one_star() {
   local gid="${1:?gaia id required}"
   local summ="$OUT/Gaia_DR3_${gid}_summary.txt"
@@ -31,10 +34,7 @@ website_sync_one_star() {
 
   local src_plot_dir="$OUT/Gaia_DR3_${gid}"
   if [[ -d "$src_plot_dir" ]]; then
-    local p
-    while IFS= read -r -d '' p; do
-      run_cmd cp "$p" "$star_plots/$(basename "$p")"
-    done < <(find "$src_plot_dir" -maxdepth 1 -type f -name '*.png' -print0 2>/dev/null)
+    website_stage_gaia_plots "$gid" "$src_plot_dir" "$star_plots"
   elif [[ "${DRY_RUN:-0}" != "1" && -n "${MISSING_ASSETS_CSV:-}" ]]; then
     echo "${gid},missing_plot_dir,${src_plot_dir}" >> "$MISSING_ASSETS_CSV"
   fi

--- a/scripts/prune_legacy_website_plots.sh
+++ b/scripts/prune_legacy_website_plots.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Remove legacy pipeline Hβ PNGs from deployed website Plots/ (keeps _28_hbeta, rv, residuals).
+#
+# Usage (ziggy):
+#   cd /data2/darkhunter/dark-hunter_rv && git pull
+#   bash scripts/prune_legacy_website_plots.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/website_plot_sync.sh
+source "$SCRIPT_DIR/lib/website_plot_sync.sh"
+
+WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
+STARS="$WEB_ROOT/stars"
+
+run_cmd() {
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    echo "[DRY_RUN] $*"
+  else
+    "$@"
+  fi
+}
+
+if [[ ! -d "$STARS" ]]; then
+  echo "[ERROR] missing $STARS" >&2
+  exit 2
+fi
+
+n=0
+for plot_dir in "$STARS"/Gaia_DR3_*/Gaia/Plots; do
+  [[ -d "$plot_dir" ]] || continue
+  before=$(find "$plot_dir" -maxdepth 1 -type f \( \
+    -name '*_h_beta_rv.png' -o \
+    -name '*_h_beta_order*.png' -o \
+    -name '*_h_beta_three*.png' \
+  \) 2>/dev/null | wc -l | tr -d ' ')
+  website_prune_legacy_gaia_plots "$plot_dir"
+  n=$((n + before))
+done
+
+echo "Pruned legacy Hβ plot files under $STARS (removed $n files)."

--- a/scripts/update_hbeta_website.sh
+++ b/scripts/update_hbeta_website.sh
@@ -6,16 +6,17 @@
 #   bash scripts/update_hbeta_website.sh
 #
 #   STAR_ID=1551542027851147904 bash scripts/update_hbeta_website.sh
-#   DEPLOY_STATIC=1 bash scripts/update_hbeta_website.sh   # also copy script.js / style.css
+#   DEPLOY_STATIC=0 bash scripts/update_hbeta_website.sh   # skip script.js deploy (not recommended)
 
 set -euo pipefail
 
 REPO="${REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
 export WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
-export DEPLOY_STATIC="${DEPLOY_STATIC:-0}"
+export DEPLOY_STATIC="${DEPLOY_STATIC:-1}"
 
 cd "$REPO"
 if [[ "$DEPLOY_STATIC" == "1" ]]; then
+  echo "=== Deploy website/rv (script.js builds H-beta links by Gaia id) ==="
   bash scripts/setup_website.sh
 fi
 

--- a/scripts/update_website_table_columns.py
+++ b/scripts/update_website_table_columns.py
@@ -84,6 +84,7 @@ def update_table_columns(
     n_m2 = 0
     n_m2sini = 0
     n_m2_at_i = 0
+    n_m2_at_i_eq_sin = 0
     n_next = 0
     target = (gaia_id or "").strip()
     for r in data_rows:
@@ -118,16 +119,25 @@ def update_table_columns(
                 r.append("")
             r[m2_i] = f"{masses['m2_msun']:.5f}"
             n_m2 += 1
+        while len(r) <= m2sini_i:
+            r.append("")
         if masses["m2sin_i_msun"] is not None:
-            while len(r) <= m2sini_i:
-                r.append("")
             r[m2sini_i] = f"{masses['m2sin_i_msun']:.5f}"
             n_m2sini += 1
+        else:
+            r[m2sini_i] = ""
+        while len(r) <= m2over_i:
+            r.append("")
         if masses["m2_at_i_msun"] is not None:
-            while len(r) <= m2over_i:
-                r.append("")
             r[m2over_i] = f"{masses['m2_at_i_msun']:.5f}"
             n_m2_at_i += 1
+            if masses["m2sin_i_msun"] is not None:
+                if abs(masses["m2_at_i_msun"] - masses["m2sin_i_msun"]) <= max(
+                    1e-6, 1e-4 * masses["m2sin_i_msun"]
+                ):
+                    n_m2_at_i_eq_sin += 1
+        else:
+            r[m2over_i] = ""
         nxt = next_rv_event_from_fit_report(rep)
         if nxt is not None:
             while len(r) <= next_rv_i:
@@ -153,6 +163,7 @@ def update_table_columns(
         "m2_filled": n_m2,
         "m2sin_i_filled": n_m2sini,
         "m2_at_i_filled": n_m2_at_i,
+        "m2_at_i_equals_m2sin_i": n_m2_at_i_eq_sin,
         "next_rv_filled": n_next,
         "reports_loaded": len(reports),
         "cache_enriched_from_summaries": n_cache_summ,
@@ -205,7 +216,8 @@ def main() -> int:
         f"updated {args.data_csv}: {stats['data_rows']} rows, {stats['columns']} columns, "
         f"cleared {stats['stray_img_cleared']} stray <img>, "
         f"apf_days={stats['apf_days_filled']}, m2={stats['m2_filled']}, "
-        f"m2sin_i={stats['m2sin_i_filled']}, m2_at_i={stats['m2_at_i_filled']}, "
+        f"m2sin_i={stats['m2sin_i_filled']}, m2_at_i={stats['m2_at_i_filled']} "
+        f"(m2_at_i=m2sin_i for {stats['m2_at_i_equals_m2sin_i']}, often i≈90°), "
         f"next_rv={stats['next_rv_filled']} (from {stats['reports_loaded']} reports, "
         f"cache+summary incl patches={stats['cache_enriched_from_summaries']})"
     )

--- a/tests/test_fit_apf_rv_keplerian.py
+++ b/tests/test_fit_apf_rv_keplerian.py
@@ -296,6 +296,26 @@ def test_resolve_m1_defaults_when_free_fit_present() -> None:
     assert fitmod.resolve_m1_msun_for_rv_mass(rep) == pytest.approx(1.0)
 
 
+def test_resolve_inclination_ignores_stale_json_90_fallback(tmp_path: Path) -> None:
+    summ = tmp_path / "Gaia_DR3_99_summary.txt"
+    summ.write_text(
+        "[GAIA METADATA]\n"
+        "Source_ID: 99\n"
+        "RA: 1.0\n"
+        "Dec: 2.0\n"
+        "Inclination: 60.0\n"
+        "\n[PIPELINE RESULTS]\n"
+        "ep_1.txt 60000 -1 0.1 0.2 False\n"
+    )
+    rep = {
+        "gaia_source_id": "99",
+        "inclination_deg_used": 90.0,
+        "m2sini_msun": 0.42,
+        "m2_given_inclination_msun": 0.42,
+    }
+    assert fitmod.resolve_inclination_deg_for_rv_mass(rep, summary_path=summ) == pytest.approx(60.0)
+
+
 def test_resolve_inclination_from_summary_metadata(tmp_path: Path) -> None:
     summ = tmp_path / "Gaia_DR3_99_summary.txt"
     summ.write_text(
@@ -335,11 +355,32 @@ def test_website_table_masses_m2_at_i_from_inclination(tmp_path: Path) -> None:
     assert cols["m2_at_i_msun"] > cols["m2sin_i_msun"]
 
 
+def test_m2_msun_at_inclination_from_m2sin() -> None:
+    m2 = fitmod.m2_msun_at_inclination(0.5, 60.0)
+    assert m2 is not None
+    assert m2 == pytest.approx(0.5 / np.sin(np.deg2rad(60.0)))
+
+
+def test_website_table_masses_uses_json_inclination_for_m2_at_i() -> None:
+    rep = {
+        "gaia_source_id": "99",
+        "inclination_deg_used": 60.0,
+        "fit_variants": {
+            "free": {"P_days": 10.0, "K_kms": 40.0, "e": 0.1, "mass_function_msun": 0.05},
+        },
+    }
+    cols = fitmod.website_table_masses_from_report(rep, summary_path=None)
+    assert cols["m2sin_i_msun"] is not None
+    assert cols["m2_at_i_msun"] is not None
+    assert cols["m2_at_i_msun"] > cols["m2sin_i_msun"]
+
+
 def test_website_table_masses_m2_at_i_empty_without_inclination() -> None:
     rep = {
         "gaia_source_id": "99",
         "m2sini_msun": 0.4,
         "m2_given_inclination_msun": 0.4,
+        "inclination_deg_used": 90.0,
         "fit_variants": {
             "free": {"P_days": 10.0, "K_kms": 40.0, "e": 0.1, "mass_function_msun": 0.05},
         },
@@ -347,6 +388,33 @@ def test_website_table_masses_m2_at_i_empty_without_inclination() -> None:
     cols = fitmod.website_table_masses_from_report(rep, summary_path=None)
     assert cols["m2sin_i_msun"] is not None
     assert cols["m2_at_i_msun"] is None
+
+
+def test_website_table_masses_overrides_stale_json_90_with_summary(tmp_path: Path) -> None:
+    summ = tmp_path / "Gaia_DR3_99_summary.txt"
+    summ.write_text(
+        "[GAIA METADATA]\n"
+        "Source_ID: 99\n"
+        "RA: 1.0\n"
+        "Dec: 2.0\n"
+        "M1: 1.0\n"
+        "Inclination: 60.0\n"
+        "\n[PIPELINE RESULTS]\n"
+        "ep_1.txt 60000 -1 0.1 0.2 False\n"
+    )
+    rep = {
+        "gaia_source_id": "99",
+        "inclination_deg_used": 90.0,
+        "m2sini_msun": 0.42,
+        "m2_given_inclination_msun": 0.42,
+        "fit_variants": {
+            "free": {"P_days": 10.0, "K_kms": 40.0, "e": 0.1, "mass_function_msun": 0.05},
+        },
+    }
+    cols = fitmod.website_table_masses_from_report(rep, summary_path=summ)
+    assert cols["m2sin_i_msun"] is not None
+    assert cols["m2_at_i_msun"] is not None
+    assert cols["m2_at_i_msun"] > cols["m2sin_i_msun"]
 
 
 def test_website_table_masses_with_teff_fallback(tmp_path: Path) -> None:

--- a/website/rv/script.js
+++ b/website/rv/script.js
@@ -291,6 +291,8 @@ async function refreshLastUpdatedFromWebsiteFiles() {
     renderLastUpdated();
 }
 
+const PLOT_HEADERS_FROM_GAIA_ID = new Set(["RV PLOT", "RV FIT", "FLUX PLOT"]);
+
 function buildMediaCellHtml(text) {
     if (typeof text !== "string") {
         return text;
@@ -301,9 +303,16 @@ function buildMediaCellHtml(text) {
         return text;
     }
 
-    const srcMatch = trimmed.match(/src=['"]([^'"]+)['"]/i);
+    let inner = trimmed;
+    const anchorMatch = trimmed.match(/<a\b[^>]*>([\s\S]*)<\/a>/i);
+    if (anchorMatch && anchorMatch[1]) {
+        inner = anchorMatch[1];
+    }
+    const srcMatch = inner.match(/src=['"]([^'"]+)['"]/i);
     if (srcMatch && srcMatch[1]) {
-        return `<a href="${srcMatch[1]}" target="_blank" rel="noopener noreferrer">${trimmed}</a>`;
+        const href = srcMatch[1];
+        const imgOnly = inner.match(/<img\b/i) ? inner : `<img src="${href}" alt="plot">`;
+        return `<a href="${href}" target="_blank" rel="noopener noreferrer">${imgOnly}</a>`;
     }
 
     if (/^https?:\/\/\S+$/i.test(trimmed) && /\.(png|jpg|jpeg|gif|webp)(\?.*)?$/i.test(trimmed)) {
@@ -511,8 +520,9 @@ function isMediaHeader(headerName) {
 }
 
 function buildPlotImgCell(thumbSrc, detailSrc, altText) {
+    const base = detailSrc || thumbSrc;
     const thumb = `${thumbSrc}?v=${ASSET_CACHE_BUST}`;
-    const href = detailSrc || thumbSrc;
+    const href = `${base}?v=${ASSET_CACHE_BUST}`;
     return `<a href="${href}" target="_blank" rel="noopener noreferrer"><img src="${thumb}" alt="${altText}" onerror="this.closest('a').outerHTML='N/A';"></a>`;
 }
 
@@ -1449,7 +1459,12 @@ function arrayToTable(tableData) {
             ) {
                 text = Number(text).toFixed(5);
             }
-            if (i > 0 && isMediaHeader(headerName) && hasNonNAContent(text)) {
+            if (
+                i > 0
+                && isMediaHeader(headerName)
+                && hasNonNAContent(text)
+                && !PLOT_HEADERS_FROM_GAIA_ID.has(headerName)
+            ) {
                 text = buildMediaCellHtml(text);
             }
             const rvPlotCol = colIndex("RV PLOT");


### PR DESCRIPTION
## Summary
- Resolve astrometric inclination from Gaia NSS/cache/summary **before** fit JSON, so legacy `inclination_deg_used=90` rows no longer force M2 at i = M2 sin i.
- Ignore stale JSON when i=90° and `m2_given_inclination_msun` equals `m2sini_msun` (old table-fill era).
- Recompute M2 at i as M₂ sin i / sin(i); clear empty mass cells in `data.csv` on repair; log how many rows still match at i≈90°.

## Test plan
- [x] `pytest tests/test_fit_apf_rv_keplerian.py`
- [ ] On ziggy: `git pull`, merge this branch, `PREFETCH_GAIA_NSS=1 bash scripts/repair_website_table.sh`, hard-refresh browser
- [ ] Repair log: `m2_at_i` filled > 0 and `m2_at_i=m2sin_i` only for true edge-on systems


Made with [Cursor](https://cursor.com)