### PR TITLE
Website table improvements: inclination, luminous M1, P-fixed seeding, APF windows

### DIFF
--- a/darkhunter_rv/apf_observability.py
+++ b/darkhunter_rv/apf_observability.py
@@ -1,0 +1,208 @@
+"""APF observability windows from Lick Observatory site constraints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+from astropy import units as u
+from astropy.coordinates import AltAz, EarthLocation, SkyCoord
+from astropy.time import Time
+
+from fit_apf_rv_keplerian import _parse_gaia_metadata, parse_object_id_from_summary
+
+# APF at Lick Observatory (approximate IERS values).
+LICK_LOCATION = EarthLocation(lat=37.3413 * u.deg, lon=-121.6438 * u.deg, height=1280 * u.m)
+
+TWILIGHT_SUN_ALT_DEG = -18.0
+MAX_AIRMASS = 2.5
+MIN_OBS_MINUTES = 15
+STEP_MINUTES = 5
+HORIZON_DAYS = 90
+
+
+def _airmass_from_altitude_deg(alt_deg: float) -> float:
+    if not np.isfinite(alt_deg) or alt_deg <= 0:
+        return float("inf")
+    z_rad = np.deg2rad(90.0 - float(alt_deg))
+    return float(1.0 / np.cos(z_rad))
+
+
+def _target_coord_from_summary(summary_path: Path) -> Optional[SkyCoord]:
+    meta = _parse_gaia_metadata(summary_path)
+    if not meta:
+        return None
+    ra = meta.get("RA") or meta.get("ra")
+    dec = meta.get("Dec") or meta.get("dec") or meta.get("DEC")
+    try:
+        ra_f = float(ra)
+        dec_f = float(dec)
+    except (TypeError, ValueError):
+        return None
+    if not np.isfinite(ra_f) or not np.isfinite(dec_f):
+        return None
+    return SkyCoord(ra=ra_f * u.deg, dec=dec_f * u.deg, frame="icrs")
+
+
+def _sun_alt_deg(time: Time, location: EarthLocation) -> float:
+    """Sun altitude (deg) at Lick; ERFA-based to avoid ephemeris download."""
+    import erfa
+
+    jd = time.utc.jd
+    d1 = np.floor(jd)
+    d2 = jd - d1
+    earth_pv, earth_heliocentric = erfa.epv00(d1, d2)
+    del earth_pv
+    if hasattr(earth_heliocentric, "dtype") and earth_heliocentric.dtype.names:
+        eh = np.asarray(earth_heliocentric["p"], dtype=float)
+    else:
+        eh = np.asarray(earth_heliocentric, dtype=float).reshape(-1)[:3]
+    sun_vec = -eh
+    sun_dist = float(np.sqrt(np.sum(np.square(sun_vec))))
+    if sun_dist <= 0:
+        return -90.0
+    sun_vec /= sun_dist
+    ra_deg = float(np.rad2deg(np.arctan2(sun_vec[1], sun_vec[0]))) % 360.0
+    dec_deg = float(np.rad2deg(np.arcsin(np.clip(sun_vec[2], -1.0, 1.0))))
+    sun = SkyCoord(ra=ra_deg * u.deg, dec=dec_deg * u.deg, frame="icrs")
+    sun_aa = sun.transform_to(AltAz(obstime=time, location=location))
+    return float(sun_aa.alt.deg)
+
+
+def _is_circumpolar_at_lick(coord: SkyCoord) -> bool:
+    """Northern circumpolar at Lick: dec > 90 - lat."""
+    return float(coord.dec.deg) > (90.0 - float(LICK_LOCATION.lat.deg) - 0.05)
+
+
+@dataclass
+class ObsWindow:
+    start_mjd: float
+    end_mjd: float
+    start_date: str
+    end_date: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "start_mjd": float(self.start_mjd),
+            "end_mjd": float(self.end_mjd),
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+        }
+
+
+def _mjd_to_iso_date(mjd: float) -> str:
+    return Time(float(mjd), format="mjd", scale="utc").datetime.strftime("%Y-%m-%d")
+
+
+def _merge_windows(windows: List[ObsWindow], *, gap_days: float = 1.5) -> List[ObsWindow]:
+    if not windows:
+        return []
+    ordered = sorted(windows, key=lambda w: w.start_mjd)
+    merged: List[ObsWindow] = [ordered[0]]
+    for w in ordered[1:]:
+        prev = merged[-1]
+        if w.start_mjd - prev.end_mjd <= gap_days:
+            merged[-1] = ObsWindow(
+                start_mjd=prev.start_mjd,
+                end_mjd=max(prev.end_mjd, w.end_mjd),
+                start_date=prev.start_date,
+                end_date=w.end_date,
+            )
+        else:
+            merged.append(w)
+    return merged
+
+
+def compute_apf_observability(
+    coord: SkyCoord,
+    *,
+    start_mjd: Optional[float] = None,
+    horizon_days: int = HORIZON_DAYS,
+) -> Dict[str, Any]:
+    """
+    Find APF-visible intervals within horizon_days of start_mjd.
+
+    Observable when target airmass <= 2.5 for >= 15 minutes after astronomical twilight (-18°).
+    """
+    now_mjd = float(Time.now().mjd) if start_mjd is None else float(start_mjd)
+    end_mjd = now_mjd + float(horizon_days)
+
+    if _is_circumpolar_at_lick(coord):
+        start_date = _mjd_to_iso_date(now_mjd)
+        end_date = _mjd_to_iso_date(end_mjd)
+        win = ObsWindow(now_mjd, end_mjd, start_date, end_date)
+        return {
+            "circumpolar": True,
+            "windows": [win.to_dict()],
+            "next_window_start_date": start_date,
+            "next_window_end_date": end_date,
+        }
+
+    step_days = STEP_MINUTES / (24.0 * 60.0)
+    min_steps = max(1, int(round(MIN_OBS_MINUTES / STEP_MINUTES)))
+    windows: List[ObsWindow] = []
+    t = now_mjd
+    run_start: Optional[float] = None
+    run_end: Optional[float] = None
+    streak = 0
+    night_active = False
+
+    while t <= end_mjd + step_days:
+        time = Time(t, format="mjd", scale="utc")
+        sun_alt = _sun_alt_deg(time, LICK_LOCATION)
+        in_night = sun_alt <= TWILIGHT_SUN_ALT_DEG
+
+        observable = False
+        if in_night:
+            target_aa = coord.transform_to(AltAz(obstime=time, location=LICK_LOCATION))
+            am = _airmass_from_altitude_deg(float(target_aa.alt.deg))
+            observable = np.isfinite(am) and am <= MAX_AIRMASS
+
+        if in_night and observable:
+            if run_start is None:
+                run_start = t
+            streak += 1
+            run_end = t
+            night_active = True
+        else:
+            if night_active and run_start is not None and run_end is not None and streak >= min_steps:
+                windows.append(
+                    ObsWindow(
+                        start_mjd=run_start,
+                        end_mjd=run_end + step_days,
+                        start_date=_mjd_to_iso_date(run_start),
+                        end_date=_mjd_to_iso_date(run_end),
+                    )
+                )
+            run_start = None
+            run_end = None
+            streak = 0
+            night_active = False
+        t += step_days
+
+    merged = _merge_windows(windows)
+    if not merged:
+        return {"circumpolar": False, "windows": []}
+
+    first = merged[0]
+    last = merged[-1]
+    return {
+        "circumpolar": False,
+        "windows": [w.to_dict() for w in merged],
+        "next_window_start_date": first.start_date,
+        "next_window_end_date": last.end_date,
+    }
+
+
+def observability_for_summary(summary_path: Path) -> Optional[Dict[str, Any]]:
+    sid = parse_object_id_from_summary(summary_path)
+    coord = _target_coord_from_summary(summary_path)
+    if sid is None or coord is None:
+        return None
+    result = compute_apf_observability(coord)
+    if not result.get("windows"):
+        return None
+    result["gaia_source_id"] = sid
+    return result

--- a/darkhunter_rv/rv_keplerian_plots.py
+++ b/darkhunter_rv/rv_keplerian_plots.py
@@ -100,16 +100,36 @@ def _xlim_from_data(t: np.ndarray, report: dict) -> Tuple[float, float]:
     return t_lo, t_hi
 
 
+def _observability_windows(report: dict) -> List[dict]:
+    obs_win = report.get("observability_window")
+    if not isinstance(obs_win, dict):
+        return []
+    windows = obs_win.get("windows")
+    if isinstance(windows, list) and windows:
+        return [w for w in windows if isinstance(w, dict) and w.get("start_date") and w.get("end_date")]
+    if obs_win.get("start_date") and obs_win.get("end_date"):
+        return [obs_win]
+    return []
+
+
 def _observability_span(report: dict) -> Tuple[Optional[float], Optional[float], Optional[dict]]:
     obs_win = report.get("observability_window")
     if not isinstance(obs_win, dict):
         return None, None, None
-    try:
-        obs_start = float(Time(obs_win["start_date"], format="iso", scale="utc").mjd)
-        obs_end = float(Time(obs_win["end_date"], format="iso", scale="utc").mjd) + 1.0
-        return obs_start, obs_end, obs_win
-    except Exception:
+    windows = _observability_windows(report)
+    if not windows:
         return None, None, None
+    starts: List[float] = []
+    ends: List[float] = []
+    for w in windows:
+        try:
+            starts.append(float(Time(w["start_date"], format="iso", scale="utc").mjd))
+            ends.append(float(Time(w["end_date"], format="iso", scale="utc").mjd) + 1.0)
+        except Exception:
+            continue
+    if not starts or not ends:
+        return None, None, None
+    return float(min(starts)), float(max(ends)), obs_win
 
 
 def _shade_apf_window(
@@ -120,19 +140,34 @@ def _shade_apf_window(
     *,
     annotate: bool = True,
 ) -> None:
-    obs_start, obs_end, obs_win = _observability_span(report)
-    if obs_start is None or obs_end is None or obs_win is None:
+    obs_win = report.get("observability_window")
+    if not isinstance(obs_win, dict):
         return
-    left = max(t_start, obs_start)
-    right = min(t_end, obs_end)
-    if right <= left:
+    windows = _observability_windows(report)
+    if not windows:
         return
-    ax.axvspan(left, right, color="tab:blue", alpha=0.12, zorder=0)
-    if annotate:
+    label_parts: List[str] = []
+    for w in windows:
+        try:
+            obs_start = float(Time(w["start_date"], format="iso", scale="utc").mjd)
+            obs_end = float(Time(w["end_date"], format="iso", scale="utc").mjd) + 1.0
+        except Exception:
+            continue
+        left = max(t_start, obs_start)
+        right = min(t_end, obs_end)
+        if right <= left:
+            continue
+        ax.axvspan(left, right, color="tab:blue", alpha=0.12, zorder=0)
+        label_parts.append(f"{w['start_date']} to {w['end_date']}")
+    if annotate and label_parts:
+        if obs_win.get("circumpolar"):
+            msg = "Circumpolar (airmass ≤ 2.5): " + "; ".join(label_parts[:2])
+        else:
+            msg = "APF window " + "; ".join(label_parts[:3])
         ax.text(
             0.985,
             0.02,
-            f"APF window {obs_win['start_date']} to {obs_win['end_date']}",
+            msg,
             transform=ax.transAxes,
             fontsize=8.5,
             color="tab:blue",

--- a/darkhunter_rv/website_table_csv.py
+++ b/darkhunter_rv/website_table_csv.py
@@ -12,14 +12,17 @@ from astropy.time import Time
 MEDIA_COLUMNS = frozenset({"RV PLOT", "RV FIT", "FLUX PLOT", "SOURCE IMAGE"})
 
 MASS_COLUMNS = ("M2sin i (Msun)", "(M2sin i)/(sin i) (Msun)")
+INCLINATION_COLUMN = "INCLINATION (deg)"
+MASS_BLOCK_COLUMNS = MASS_COLUMNS + (INCLINATION_COLUMN,)
 
 GAIA_DATA_COLUMN = "GAIA DATA"
 SCHEDULE_COLUMNS = ("DAYS SINCE LAST APF", "NEXT RV EVENT (DATE)")
-LEGACY_COLUMN_RENAMES = {"NEXT RV EVENT (MJD)": "NEXT RV EVENT (DATE)"}
+LEGACY_NEXT_RV_MJD = "NEXT RV EVENT (MJD)"
+LEGACY_COLUMN_RENAMES = {LEGACY_NEXT_RV_MJD: "NEXT RV EVENT (DATE)"}
 
 # Inserted immediately after these anchors when rebuilding header order.
 _INSERT_AFTER: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
-    ("M2 (Msun)", MASS_COLUMNS),
+    ("M2 (Msun)", MASS_BLOCK_COLUMNS),
     ("DATA PRODUCTS", (GAIA_DATA_COLUMN,)),
     (GAIA_DATA_COLUMN, SCHEDULE_COLUMNS),
 )
@@ -43,7 +46,12 @@ def row_dict(hdr: List[str], row: List[str]) -> Dict[str, str]:
         if not key:
             continue
         key = LEGACY_COLUMN_RENAMES.get(key, key)
-        out[key] = row[i] if i < len(row) else ""
+        val = row[i] if i < len(row) else ""
+        if key in out:
+            if not (out[key] or "").strip() and (val or "").strip():
+                out[key] = val
+        else:
+            out[key] = val
     return out
 
 
@@ -106,11 +114,13 @@ def build_canonical_header(hdr: List[str]) -> List[str]:
     inserted_mass = False
     inserted_sched = False
     for h in base:
-        if h in MASS_COLUMNS or h in SCHEDULE_COLUMNS or h == GAIA_DATA_COLUMN:
+        if h in MASS_BLOCK_COLUMNS or h in SCHEDULE_COLUMNS or h == GAIA_DATA_COLUMN:
+            continue
+        if h == LEGACY_NEXT_RV_MJD:
             continue
         out.append(h)
         if h == "M2 (Msun)" and not inserted_mass:
-            for c in MASS_COLUMNS:
+            for c in MASS_BLOCK_COLUMNS:
                 if c in base:
                     out.append(c)
             inserted_mass = True
@@ -124,7 +134,7 @@ def build_canonical_header(hdr: List[str]) -> List[str]:
                 inserted_sched = True
 
     if not inserted_mass:
-        for c in MASS_COLUMNS:
+        for c in MASS_BLOCK_COLUMNS:
             if c in base and c not in out:
                 out.append(c)
     if not inserted_sched:
@@ -133,7 +143,7 @@ def build_canonical_header(hdr: List[str]) -> List[str]:
                 out.append(c)
 
     for h in base:
-        if h not in out:
+        if h not in out and h != LEGACY_NEXT_RV_MJD:
             out.append(h)
     return out
 
@@ -143,8 +153,19 @@ def normalize_data_csv(hdr: List[str], data_rows: List[List[str]]) -> Tuple[List
     Rebuild rows keyed by column name (fixes off-by-one from header-only edits).
     Clears media / stray <img> cells. Returns (new_hdr, n_stray_cleared).
     """
-    _ensure_columns_present(hdr, MASS_COLUMNS + (GAIA_DATA_COLUMN,) + SCHEDULE_COLUMNS)
+    _ensure_columns_present(hdr, MASS_BLOCK_COLUMNS + (GAIA_DATA_COLUMN,) + SCHEDULE_COLUMNS)
     align_rows_to_header(hdr, data_rows)
+
+    if LEGACY_NEXT_RV_MJD in hdr and "NEXT RV EVENT (DATE)" in hdr:
+        date_i = hdr.index("NEXT RV EVENT (DATE)")
+        mjd_i = hdr.index(LEGACY_NEXT_RV_MJD)
+        for r in data_rows:
+            while len(r) <= max(date_i, mjd_i):
+                r.append("")
+            if not (r[date_i] or "").strip() and (r[mjd_i] or "").strip():
+                mjd = parse_next_rv_cell_to_mjd(r[mjd_i])
+                if mjd is not None:
+                    r[date_i] = format_next_rv_event_cell(mjd)
 
     old_hdr = list(hdr)
     maps = [row_dict(old_hdr, r) for r in data_rows]
@@ -255,3 +276,21 @@ def parse_next_rv_cell_to_mjd(value: str) -> Optional[float]:
 def gaia_id_from_row(gaia_cell: str) -> str:
     m = re.search(r"(\d{8,})", gaia_cell or "")
     return m.group(1) if m else ""
+
+
+def parse_table_m1_msun(row: List[str], hdr: List[str]) -> Optional[float]:
+    """Luminous M1 from the website table column (Msun)."""
+    col = "M1 (Msun)"
+    if col not in hdr:
+        return None
+    idx = hdr.index(col)
+    if idx >= len(row):
+        return None
+    raw = (row[idx] or "").strip()
+    if not raw or raw.upper() == "N/A":
+        return None
+    try:
+        val = float(raw)
+    except ValueError:
+        return None
+    return float(val) if np.isfinite(val) and val > 0 else None

--- a/docs/website.md
+++ b/docs/website.md
@@ -70,15 +70,19 @@ Ensure Apache serves `/var/www/html/darkhunter/rv/` (existing `Alias` or symlink
 | **GAIA DATA** | Link to `stars/Gaia_DR3_<id>/Gaia/` (star file directory) |
 | **SOURCE IMAGE** | UV image from legacy CSV (restored; not hidden) |
 | **DAYS SINCE LAST APF** | Days since latest APF pipeline epoch (sortable; drives &lt;7d / &lt;30d filters) |
-| **NEXT RV EVENT (DATE)** | Sooner of next max/min RV from **P & e fixed** fit, as `YYYY/MM/DD` |
+| **NEXT RV EVENT (DATE)** | Sooner of next max/min RV from **P & e fixed** fit, as `YYYY/MM/DD` (legacy `NEXT RV EVENT (MJD)` column is merged away on repair) |
 
 **Mass columns:**
 
 | Column | Meaning |
 |--------|---------|
+| **M1 (Msun)** | Luminous primary mass (catalog); **used first** for RV-derived M2 sin i / M2 at i |
 | **M2 (Msun)** | Gaia NSS astrometric secondary mass (`used_m2_msun`), not from the RV fit |
-| **M2sin i (Msun)** | RV-only Keplerian fit, with assumed M1 |
-| **(M2sin i)/(sin i) (Msun)** | Same RV-only f(M) and M1, with Gaia astrometric inclination |
+| **M2sin i (Msun)** | RV-only Keplerian fit f(M) with table M1 |
+| **(M2sin i)/(sin i) (Msun)** | Same f(M) and M1 with Gaia astrometric inclination |
+| **INCLINATION (deg)** | Astrometric i used for M2 at i (empty if unknown or edge-on) |
+
+**RV fit plots:** blue shaded regions mark APF visibility at Lick (airmass ≤ 2.5 for ≥15 min after −18° twilight, out to 3 months). Built via `scripts/build_apf_observability_cache.py` and stored in `rv_fit_reports/observability_windows_cache.json`. Circumpolar targets are annotated on the plot.
 
 ## Three commands (ziggy)
 
@@ -155,10 +159,13 @@ WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 RUN_RV_PLOTS=1 MIN_POINTS=5 \
 ```bash
 cd /data2/darkhunter/dark-hunter_rv
 git pull
-bash scripts/repair_website_table.sh
+PREFETCH_GAIA_NSS=1 bash scripts/repair_website_table.sh
+PYTHONPATH=. python3 scripts/build_apf_observability_cache.py \
+  --data-csv /var/www/html/darkhunter/rv/tables/data.csv \
+  --output-dir /data2/darkhunter/dark-hunter_rv/output
 ```
 
-Hard-refresh the browser (Cmd+Shift+R). This deploys `script.js`, fixes column alignment, clears stray plot HTML, and fills **DAYS SINCE LAST APF** / mass / **NEXT RV EVENT** from existing summaries and `rv_fit_reports` JSON if they are already on disk.
+Hard-refresh the browser. After a code update that changes Keplerian fit logic or observability shading, rerun per-object refit (command 3) or full refresh (command 2).
 
 ### Step 2 — Full refresh when ready
 

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -183,7 +183,7 @@ def _load_json_cache(path: Path) -> Dict[str, Any]:
         return {}
 
 
-def load_observability_window(source_id: Optional[str], cache_path: Optional[Path]) -> Optional[Dict[str, str]]:
+def load_observability_window(source_id: Optional[str], cache_path: Optional[Path]) -> Optional[Dict[str, Any]]:
     if source_id is None or cache_path is None or (not cache_path.exists()):
         return None
     data = _load_json_cache(cache_path)
@@ -192,9 +192,30 @@ def load_observability_window(source_id: Optional[str], cache_path: Optional[Pat
         return None
     s = row.get("next_window_start_date")
     e = row.get("next_window_end_date")
+    windows = row.get("windows")
+    circumpolar = bool(row.get("circumpolar", False))
+    if isinstance(windows, list) and windows:
+        out: Dict[str, Any] = {
+            "windows": windows,
+            "circumpolar": circumpolar,
+        }
+        if isinstance(s, str) and s and isinstance(e, str) and e:
+            out["start_date"] = s
+            out["end_date"] = e
+        else:
+            w0 = windows[0]
+            if isinstance(w0, dict):
+                out["start_date"] = w0.get("start_date", "")
+                out["end_date"] = windows[-1].get("end_date", "") if isinstance(windows[-1], dict) else ""
+        return out if out.get("start_date") and out.get("end_date") else None
     if not isinstance(s, str) or not isinstance(e, str) or (not s) or (not e):
         return None
-    return {"start_date": s, "end_date": e}
+    return {
+        "start_date": s,
+        "end_date": e,
+        "circumpolar": circumpolar,
+        "windows": [{"start_date": s, "end_date": e}],
+    }
 
 
 def _save_json_cache(path: Path, data: Dict[str, Any]) -> None:
@@ -635,6 +656,7 @@ def fit_keplerian(
     period_prior_sigma: float = 0.15,
     fix_period: Optional[float] = None,
     fix_e: Optional[float] = None,
+    initial_params: Optional[np.ndarray] = None,
 ) -> Tuple[np.ndarray, dict]:
     t = np.asarray(t, dtype=float)
     y = np.asarray(y, dtype=float)
@@ -729,6 +751,13 @@ def fit_keplerian(
     if not np.isfinite(f_scale) or f_scale <= 0:
         f_scale = 1.0
 
+    x0_candidates: List[np.ndarray] = []
+    if initial_params is not None:
+        seed = _clip_initial_guess(np.asarray(initial_params, dtype=float), lower, upper)
+        if fix_period is not None:
+            seed[0] = np.log(float(np.clip(fix_period, min_period, max_period)))
+        x0_candidates.append(seed)
+
     for p0 in uniq_periods:
         log_p = np.log(np.clip(p0, min_period, max_period))
         if not np.isfinite(log_p):
@@ -745,6 +774,14 @@ def fit_keplerian(
             lower,
             upper,
         )
+        x0_candidates.append(x0)
+
+    seen_x0: set = set()
+    for x0 in x0_candidates:
+        key = tuple(np.round(x0, 5))
+        if key in seen_x0:
+            continue
+        seen_x0.add(key)
         try:
             res = least_squares(
                 resid,
@@ -925,13 +962,18 @@ def resolve_m1_msun_for_rv_mass(
     *,
     summary_path: Optional[Path] = None,
     gaia_cache: Optional[Dict[str, Any]] = None,
+    table_m1_msun: Optional[float] = None,
 ) -> Optional[float]:
     """
     Primary mass for converting RV f(M) to M2 sin i / M2 at i.
 
-    Order: fit report → embedded gaia_nss → gaia_nss_cache.json → summary metadata →
-    M2/Mass_Ratio → Teff/logg estimate → 1 Msun if a free RV fit exists.
+    Order: website table M1 (luminous) → fit report → embedded gaia_nss → cache →
+    summary metadata → M2/Mass_Ratio → Teff/logg estimate → 1 Msun if free fit exists.
     """
+    m1 = _finite_mass_value(table_m1_msun)
+    if m1 is not None:
+        return m1
+
     m1 = _finite_mass_value(report.get("used_m1_msun"))
     if m1 is not None:
         return m1
@@ -1052,16 +1094,19 @@ def enrich_gaia_cache_from_summaries(
     """Merge [GAIA METADATA] masses/inclination from star summaries into the NSS cache dict."""
     n = 0
     if gaia_ids is None:
-        paths = sorted(out_dir.glob("Gaia_DR3_*_summary.txt"))
+        paths = discover_summary_files(out_dir)
     else:
-        paths = [out_dir / f"Gaia_DR3_{gid}_summary.txt" for gid in gaia_ids]
+        paths = []
+        for gid in gaia_ids:
+            p = discover_summary_path(out_dir, gid)
+            if p is not None:
+                paths.append(p)
     for summ in paths:
         if not summ.is_file():
             continue
-        sid_m = re.search(r"Gaia_DR3_(\d{18,19})", summ.name)
-        if not sid_m:
+        sid = parse_object_id_from_summary(summ)
+        if not sid:
             continue
-        sid = sid_m.group(1)
         priors = load_mass_priors_from_summary(summ)
         if not priors:
             continue
@@ -1124,11 +1169,24 @@ def resolve_m2_astrometric_msun(
     return None
 
 
+def inclination_deg_for_website_table(
+    report: dict,
+    *,
+    summary_path: Optional[Path] = None,
+    gaia_cache: Optional[Dict[str, Any]] = None,
+) -> Optional[float]:
+    """Astrometric inclination (deg) for the website table column."""
+    return resolve_inclination_deg_for_rv_mass(
+        report, summary_path=summary_path, gaia_cache=gaia_cache
+    )
+
+
 def website_table_masses_from_report(
     report: dict,
     *,
     summary_path: Optional[Path] = None,
     gaia_cache: Optional[Dict[str, Any]] = None,
+    table_m1_msun: Optional[float] = None,
 ) -> Dict[str, Optional[float]]:
     """
     Map a Keplerian fit JSON report to website ``data.csv`` mass columns.
@@ -1141,7 +1199,10 @@ def website_table_masses_from_report(
         report, summary_path=summary_path, gaia_cache=gaia_cache
     )
     m1 = resolve_m1_msun_for_rv_mass(
-        report, summary_path=summary_path, gaia_cache=gaia_cache
+        report,
+        summary_path=summary_path,
+        gaia_cache=gaia_cache,
+        table_m1_msun=table_m1_msun,
     )
 
     m2sin: Optional[float] = None
@@ -1216,11 +1277,26 @@ def fit_all_variants(
         nss_p = gaia_nss.get("period_days")
         nss_e = gaia_nss.get("eccentricity")
 
-    specs: List[Tuple[str, Optional[float], Optional[float]]] = [
-        ("free", None, None),
-    ]
+    try:
+        free_params, free_rep = fit_keplerian(
+            t,
+            y,
+            yerr,
+            period_min=period_min,
+            period_max=period_max,
+            period_prior=None,
+            period_prior_sigma=period_prior_sigma,
+        )
+    except (ValueError, RuntimeError):
+        return out
+    free_rep["fit_variant"] = "free"
+    fm = mass_function_msun(free_rep["P_days"], free_rep["K_kms"], free_rep["e"])
+    free_rep["mass_function_msun"] = None if not np.isfinite(fm) else float(fm)
+    out["free"] = (free_params, free_rep)
+
+    constrained: List[Tuple[str, Optional[float], Optional[float]]] = []
     if nss_p is not None and nss_e is not None and nss_p > 0 and 0 <= nss_e < 1:
-        specs.extend(
+        constrained.extend(
             [
                 ("fix_period", float(nss_p), None),
                 ("fix_ecc", None, float(nss_e)),
@@ -1228,7 +1304,7 @@ def fit_all_variants(
             ]
         )
 
-    for key, fix_p, fix_e in specs:
+    for key, fix_p, fix_e in constrained:
         try:
             params, rep = fit_keplerian(
                 t,
@@ -1240,9 +1316,43 @@ def fit_all_variants(
                 period_prior_sigma=period_prior_sigma,
                 fix_period=fix_p,
                 fix_e=fix_e,
+                initial_params=free_params,
             )
         except (ValueError, RuntimeError):
             continue
+        if key == "fix_period":
+            chi_free = free_rep.get("chi2_red")
+            chi_fp = rep.get("chi2_red")
+            e_free = free_rep.get("e")
+            e_fp = rep.get("e")
+            if (
+                isinstance(chi_free, (int, float))
+                and isinstance(chi_fp, (int, float))
+                and chi_free > 0
+                and chi_fp > 2.0 * chi_free
+                and isinstance(e_free, (int, float))
+                and isinstance(e_fp, (int, float))
+                and abs(float(e_fp) - float(e_free)) > 0.15
+            ):
+                try:
+                    params_retry, rep_retry = fit_keplerian(
+                        t,
+                        y,
+                        yerr,
+                        period_min=period_min,
+                        period_max=period_max,
+                        period_prior=None,
+                        period_prior_sigma=period_prior_sigma,
+                        fix_period=fix_p,
+                        fix_e=float(e_free),
+                        initial_params=free_params,
+                    )
+                    chi_retry = rep_retry.get("chi2_red")
+                    if isinstance(chi_retry, (int, float)) and chi_retry < chi_fp:
+                        params, rep = params_retry, rep_retry
+                        rep["fix_period_e_seed_retry"] = True
+                except (ValueError, RuntimeError):
+                    pass
         rep["fit_variant"] = key
         fm = mass_function_msun(rep["P_days"], rep["K_kms"], rep["e"])
         rep["mass_function_msun"] = None if not np.isfinite(fm) else float(fm)
@@ -1542,6 +1652,17 @@ def discover_summary_files(output_dir: Path) -> List[Path]:
     return sorted(by_sid.values())
 
 
+def discover_summary_path(output_dir: Path, gaia_source_id: str) -> Optional[Path]:
+    """Best summary path for one Gaia source (flat or nested under output/)."""
+    sid = str(gaia_source_id).strip()
+    if not sid:
+        return None
+    for p in discover_summary_files(output_dir):
+        if parse_object_id_from_summary(p) == sid:
+            return p
+    return None
+
+
 def newest_summary(output_dir: Path) -> Optional[Path]:
     files = discover_summary_files(output_dir)
     if not files:
@@ -1566,6 +1687,33 @@ def report_stem(summary_path: Path, gaia_source_id: Optional[str]) -> str:
     return m.group(1) if m else stem
 
 
+def load_table_m1_map_from_csv(data_csv: Path) -> Dict[str, float]:
+    """Gaia source id → luminous M1 (Msun) from website tables/data.csv."""
+    if not data_csv.is_file():
+        return {}
+    import csv
+
+    from darkhunter_rv.website_table_csv import gaia_id_from_row, parse_table_m1_msun
+
+    out: Dict[str, float] = {}
+    with data_csv.open(newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+    if len(rows) < 2:
+        return out
+    hdr = rows[0]
+    if "GAIA NAME" not in hdr:
+        return out
+    gaia_i = hdr.index("GAIA NAME")
+    for r in rows[1:]:
+        sid = gaia_id_from_row(r[gaia_i] if gaia_i < len(r) else "")
+        if not sid:
+            continue
+        m1 = parse_table_m1_msun(r, hdr)
+        if m1 is not None:
+            out[sid] = m1
+    return out
+
+
 def run_one(
     summary_path: Path,
     out_dir: Path,
@@ -1583,6 +1731,7 @@ def run_one(
     observability_cache_path: Optional[Path],
     query_gaia_online: bool,
     plots_root: Optional[Path] = None,
+    table_m1_msun: Optional[float] = None,
 ) -> Optional[dict]:
     from darkhunter_rv.rv_keplerian_plots import (
         our_telescope_points,
@@ -1634,7 +1783,9 @@ def run_one(
             if gaia_nss is not None:
                 nss_source = "online"
 
-    fit_m1_msun = m1_msun
+    fit_m1_msun = _finite_mass_value(table_m1_msun)
+    if fit_m1_msun is None:
+        fit_m1_msun = m1_msun
     fit_m2_msun = None
     fit_inclination_deg = None
     if gaia_nss is not None:
@@ -1689,21 +1840,27 @@ def run_one(
     resid_png = out_dir / f"{stem}_keplerian_residuals.png"
     out_json = out_dir / f"{stem}_keplerian_fit.json"
 
-    report["used_m1_msun"] = None if fit_m1_msun is None else float(fit_m1_msun)
+    report["used_m1_msun"] = resolve_m1_msun_for_rv_mass(
+        report,
+        summary_path=summary_path,
+        table_m1_msun=table_m1_msun,
+    )
+    report["table_m1_msun"] = None if table_m1_msun is None else float(table_m1_msun)
     report["used_m2_msun"] = None if fit_m2_msun is None else float(fit_m2_msun)
     report["inclination_deg_used"] = (
         None if fit_inclination_deg is None else float(fit_inclination_deg)
     )
 
     _, rep_free = fit_variants["free"]
-    m2sini, m2_at_i = rv_only_mass_estimates(rep_free, fit_m1_msun, fit_inclination_deg)
+    m1_for_masses = report["used_m1_msun"]
+    m2sini, m2_at_i = rv_only_mass_estimates(rep_free, m1_for_masses, fit_inclination_deg)
     report["m2sini_msun"] = m2sini
     report["m2_given_inclination_msun"] = m2_at_i
     report["m2_astrometric_msun"] = report["used_m2_msun"]
 
-    plot_multi_fit(summary_path, points_fit, fit_variants, report, out_png, m1_msun=fit_m1_msun)
+    plot_multi_fit(summary_path, points_fit, fit_variants, report, out_png, m1_msun=m1_for_masses)
     plot_fit_residuals(
-        summary_path, points_fit, fit_variants, report, resid_png, m1_msun=fit_m1_msun
+        summary_path, points_fit, fit_variants, report, resid_png, m1_msun=m1_for_masses
     )
     ours = our_telescope_points(points_fit)
     if len(ours) >= 2:
@@ -1778,6 +1935,11 @@ def main() -> None:
         default=None,
         help="Optional observability cache JSON path. Default: <reports-dir>/observability_windows_cache.json",
     )
+    parser.add_argument(
+        "--data-csv",
+        default=None,
+        help="Website tables/data.csv for luminous M1 (Msun) per Gaia id (default: none).",
+    )
     parser.add_argument("--force", action="store_true", help="Recompute even if report JSON is newer than summary.")
     args = parser.parse_args()
 
@@ -1796,6 +1958,12 @@ def main() -> None:
     if not targets:
         print("No summary files found.")
         return
+
+    table_m1_map: Dict[str, float] = {}
+    if args.data_csv:
+        table_m1_map = load_table_m1_map_from_csv(Path(args.data_csv))
+        if table_m1_map:
+            print(f"Loaded luminous M1 for {len(table_m1_map)} stars from {args.data_csv}")
 
     if args.use_gaia_nss and args.query_gaia_online:
         ids: List[str] = []
@@ -1841,8 +2009,9 @@ def main() -> None:
             args.use_gaia_nss,
             gaia_cache_path,
             observability_cache_path,
-            args.            query_gaia_online,
+            args.query_gaia_online,
             plots_root=output_dir,
+            table_m1_msun=table_m1_map.get(str(sid)) if sid else None,
         )
         if report is None:
             skipped += 1

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -108,6 +108,18 @@ for summ in "${SUMMARY_FILES[@]}"; do
 done
 echo "summaries=${#SUMMARY_FILES[@]} with_epochs>=${MIN_POINTS}: $n_ge_min"
 
+echo "=== APF observability windows cache ==="
+obs_args=(
+  scripts/build_apf_observability_cache.py
+  --data-csv "$DATA_CSV"
+  --output-dir "$OUT"
+  --cache "$REPORTS_DIR/observability_windows_cache.json"
+)
+if [[ -n "$STAR_ID" ]]; then
+  obs_args+=(--gaia-id "$STAR_ID")
+fi
+run_cmd "$PY" "${obs_args[@]}"
+
 if [[ "$RUN_FITS" == "1" ]]; then
   echo "=== Keplerian fits ==="
   fit_args=(
@@ -117,6 +129,7 @@ if [[ "$RUN_FITS" == "1" ]]; then
     --use-gaia-nss
     --min-points "$MIN_POINTS"
     --reports-dir "$REPORTS_DIR"
+    --data-csv "$DATA_CSV"
   )
   if [[ "$FIT_FORCE" == "1" ]]; then
     fit_args+=(--force)
@@ -125,7 +138,7 @@ if [[ "$RUN_FITS" == "1" ]]; then
     fit_args+=(--query-gaia-online)
   fi
   if [[ -n "$STAR_ID" ]]; then
-    fit_args=(fit_apf_rv_keplerian.py --summary "$OUT/Gaia_DR3_${STAR_ID}_summary.txt" --output-dir "$OUT" --use-gaia-nss --min-points "$MIN_POINTS" --reports-dir "$REPORTS_DIR")
+    fit_args=(fit_apf_rv_keplerian.py --summary "$OUT/Gaia_DR3_${STAR_ID}_summary.txt" --output-dir "$OUT" --use-gaia-nss --min-points "$MIN_POINTS" --reports-dir "$REPORTS_DIR" --data-csv "$DATA_CSV")
     if [[ "$FIT_FORCE" == "1" ]]; then
       fit_args+=(--force)
     fi
@@ -210,121 +223,25 @@ done
 if [[ "$DRY_RUN" != "1" ]]; then
   export REPORTS_DIR DATA_CSV MISSING_ASSETS_CSV STAGED_SUMMARY OUT
   "$PY" - <<'PY'
-import csv
 import json
 import os
 from pathlib import Path
 
-from fit_apf_rv_keplerian import (
-    _load_json_cache,
-    lookup_fit_report_by_gaia_id,
-    website_table_masses_from_report,
-)
-from darkhunter_rv.website_table_csv import (
-    days_since_last_apf_from_summary,
-    format_next_rv_event_cell,
-    gaia_id_from_row,
-    next_rv_event_from_fit_report,
-    normalize_data_csv,
-    parse_next_rv_cell_to_mjd,
-)
+from scripts.update_website_table_columns import load_gaia_nss_cache, update_table_columns
 
 report_dir = Path(os.environ["REPORTS_DIR"])
 out_dir = Path(os.environ.get("OUT", report_dir.parent / "output"))
-gaia_cache_path = report_dir / "gaia_nss_cache.json"
-gaia_cache = _load_json_cache(gaia_cache_path) if gaia_cache_path.is_file() else {}
 data_csv = Path(os.environ["DATA_CSV"])
 missing_csv = Path(os.environ["MISSING_ASSETS_CSV"])
 summary_json = Path(os.environ["STAGED_SUMMARY"])
 
-reports = {}
-for p in sorted(report_dir.glob("*_keplerian_fit.json")):
-    sid = p.stem.replace("_keplerian_fit", "")
-    try:
-        reports[sid] = json.loads(p.read_text())
-    except Exception:
-        continue
-
-rows = []
-with data_csv.open(newline="", encoding="utf-8") as fh:
-    reader = csv.reader(fh)
-    rows = list(reader)
-
-if not rows:
-    raise SystemExit("tables/data.csv is empty")
-
-hdr = rows[0]
-try:
-    gaia_i = hdr.index("GAIA NAME")
-    m2_i = hdr.index("M2 (Msun)")
-except ValueError as exc:
-    raise SystemExit(f"Required data.csv column missing: {exc}")
-
-data_rows = rows[1:]
-normalize_data_csv(hdr, data_rows)
-
-col_m2sini = "M2sin i (Msun)"
-col_m2over = "(M2sin i)/(sin i) (Msun)"
-col_apf_days = "DAYS SINCE LAST APF"
-col_next_rv = "NEXT RV EVENT (DATE)"
-m2sini_i = hdr.index(col_m2sini)
-m2over_i = hdr.index(col_m2over)
-apf_days_i = hdr.index(col_apf_days)
-next_rv_i = hdr.index(col_next_rv)
-
-updated = 0
-for r in data_rows:
-    if not r:
-        continue
-    gaia = (r[gaia_i] if gaia_i < len(r) else "").strip()
-    sid = gaia_id_from_row(gaia)
-    if not sid:
-        continue
-
-    summ = out_dir / f"Gaia_DR3_{sid}_summary.txt"
-    if summ.is_file():
-        age = days_since_last_apf_from_summary(summ)
-        if age is not None:
-            while len(r) <= apf_days_i:
-                r.append("")
-            r[apf_days_i] = f"{age:.2f}"
-
-    rep = lookup_fit_report_by_gaia_id(reports, sid)
-    if rep is not None:
-        masses = website_table_masses_from_report(
-            rep,
-            summary_path=summ if summ.is_file() else None,
-            gaia_cache=gaia_cache,
-        )
-        m2_astro = masses["m2_msun"]
-        m2s = masses["m2sin_i_msun"]
-        m2i = masses["m2_at_i_msun"]
-        if m2_astro is not None:
-            while len(r) <= m2_i:
-                r.append("")
-            r[m2_i] = f"{m2_astro:.5f}"
-            updated += 1
-        while len(r) <= m2sini_i:
-            r.append("")
-        if m2s is not None:
-            r[m2sini_i] = f"{m2s:.5f}"
-        else:
-            r[m2sini_i] = ""
-        while len(r) <= m2over_i:
-            r.append("")
-        if m2i is not None:
-            r[m2over_i] = f"{m2i:.5f}"
-        else:
-            r[m2over_i] = ""
-        nxt = next_rv_event_from_fit_report(rep)
-        if nxt is not None:
-            while len(r) <= next_rv_i:
-                r.append("")
-            r[next_rv_i] = format_next_rv_event_cell(nxt)
-
-with data_csv.open("w", newline="", encoding="utf-8") as fh:
-    writer = csv.writer(fh)
-    writer.writerows(rows)
+gaia_cache = load_gaia_nss_cache(report_dir)
+stats = update_table_columns(
+    data_csv,
+    out_dir=out_dir,
+    reports_dir=report_dir,
+    gaia_cache=gaia_cache,
+)
 
 missing = 0
 if missing_csv.exists():
@@ -332,12 +249,17 @@ if missing_csv.exists():
         missing = max(0, sum(1 for _ in fh) - 1)
 
 summary = {
-    "reports_found": len(reports),
-    "table_rows_updated_m2": updated,
+    "reports_found": stats["reports_loaded"],
+    "table_rows_updated_m2": stats["m2_filled"],
+    "inclination_filled": stats["inclination_filled"],
+    "m2_at_i_filled": stats["m2_at_i_filled"],
     "missing_assets_records": missing,
 }
 summary_json.write_text(json.dumps(summary, indent=2))
-print(f"table_update: m2_rows_updated={updated}, reports_found={len(reports)}, missing_assets={missing}")
+print(
+    f"table_update: m2_rows={stats['m2_filled']}, incl={stats['inclination_filled']}, "
+    f"m2_at_i={stats['m2_at_i_filled']}, reports={stats['reports_loaded']}, missing_assets={missing}"
+)
 PY
 fi
 

--- a/scripts/bootstrap_website_tables.sh
+++ b/scripts/bootstrap_website_tables.sh
@@ -59,6 +59,7 @@ hdr = rows[0]
 for col in (
     "M2sin i (Msun)",
     "(M2sin i)/(sin i) (Msun)",
+    "INCLINATION (deg)",
     "GAIA DATA",
     "DAYS SINCE LAST APF",
     "NEXT RV EVENT (DATE)",

--- a/scripts/build_apf_observability_cache.py
+++ b/scripts/build_apf_observability_cache.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Build rv_fit_reports/observability_windows_cache.json for APF visibility shading."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import warnings
+from pathlib import Path
+
+from darkhunter_rv.apf_observability import observability_for_summary
+from darkhunter_rv.website_table_csv import gaia_id_from_row
+from fit_apf_rv_keplerian import discover_summary_path
+
+
+def main() -> int:
+    try:
+        from erfa import ErfaWarning  # type: ignore
+
+        warnings.filterwarnings("ignore", category=ErfaWarning)
+    except Exception:
+        pass
+
+    ap = argparse.ArgumentParser(description="Build APF observability windows cache from summaries.")
+    ap.add_argument(
+        "--data-csv",
+        default="/var/www/html/darkhunter/rv/tables/data.csv",
+    )
+    ap.add_argument(
+        "--output-dir",
+        default=None,
+        help="Pipeline summaries directory (default: REPO/output)",
+    )
+    ap.add_argument(
+        "--cache",
+        default=None,
+        help="Output JSON path (default: REPO/rv_fit_reports/observability_windows_cache.json)",
+    )
+    ap.add_argument("--gaia-id", default=None, help="Single Gaia DR3 source id (default: all table rows).")
+    args = ap.parse_args()
+
+    repo = Path(__file__).resolve().parents[1]
+    out_dir = Path(args.output_dir) if args.output_dir else repo / "output"
+    cache_path = Path(args.cache) if args.cache else repo / "rv_fit_reports" / "observability_windows_cache.json"
+    data_csv = Path(args.data_csv)
+
+    gaia_ids: list[str] = []
+    if args.gaia_id:
+        gaia_ids = [str(args.gaia_id).strip()]
+    elif data_csv.is_file():
+        with data_csv.open(newline="", encoding="utf-8") as fh:
+            rows = list(csv.reader(fh))
+        if rows:
+            hdr = rows[0]
+            if "GAIA NAME" in hdr:
+                gaia_i = hdr.index("GAIA NAME")
+                for r in rows[1:]:
+                    sid = gaia_id_from_row(r[gaia_i] if gaia_i < len(r) else "")
+                    if sid:
+                        gaia_ids.append(sid)
+
+    cache: dict = {}
+    if cache_path.is_file():
+        try:
+            loaded = json.loads(cache_path.read_text())
+            if isinstance(loaded, dict):
+                cache = loaded
+        except Exception:
+            cache = {}
+
+    built = 0
+    skipped = 0
+    for sid in gaia_ids:
+        summ = discover_summary_path(out_dir, sid)
+        if summ is None:
+            skipped += 1
+            continue
+        row = observability_for_summary(summ)
+        if row is None:
+            skipped += 1
+            continue
+        entry = {k: v for k, v in row.items() if k != "gaia_source_id"}
+        cache[sid] = entry
+        built += 1
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps(cache, indent=2, sort_keys=True))
+    print(f"Wrote {built} observability entries to {cache_path} (skipped {skipped}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/full_website_refresh.sh
+++ b/scripts/full_website_refresh.sh
@@ -39,6 +39,12 @@ if [[ -f "$REPO/scripts/fix_data_csv_column_order.py" ]]; then
   "$PY" scripts/fix_data_csv_column_order.py --data-csv "$WEB_ROOT/tables/data.csv"
 fi
 
+echo "=== APF observability windows cache ==="
+"$PY" scripts/build_apf_observability_cache.py \
+  --data-csv "$WEB_ROOT/tables/data.csv" \
+  --output-dir "$REPO/output" \
+  --cache "$REPO/rv_fit_reports/observability_windows_cache.json"
+
 echo "=== Per-object pipeline + fit + website (see logs/refit_all_per_object.log) ==="
 bash scripts/refit_all_per_object.sh
 

--- a/scripts/plot_rv_from_summaries.py
+++ b/scripts/plot_rv_from_summaries.py
@@ -58,15 +58,22 @@ def parse_points(summary_path: Path) -> list[RVPoint]:
     return points
 
 
-def minimal_report(points: list[RVPoint]) -> dict:
+def minimal_report(points: list[RVPoint], *, summary_path: Path | None = None) -> dict:
     t = np.array([p.mjd for p in points], dtype=float)
     t_ref = float(np.median(t)) if t.size else float(Time.now().mjd)
+    obs = None
+    if summary_path is not None:
+        from darkhunter_rv.apf_observability import observability_for_summary
+
+        obs_row = observability_for_summary(summary_path)
+        if obs_row is not None:
+            obs = {k: v for k, v in obs_row.items() if k != "gaia_source_id"}
     return {
         "t_ref_mjd": t_ref,
         "now_mjd": float(Time.now().mjd),
         "next_rv_max_mjd": t_ref,
         "next_rv_min_mjd": t_ref,
-        "observability_window": None,
+        "observability_window": obs,
     }
 
 
@@ -74,7 +81,7 @@ def build_plot(summary_path: Path, out_png: Path) -> bool:
     points = our_telescope_points(parse_points(summary_path))
     if len(points) < 2:
         return False
-    plot_rv_data_only(summary_path, points, minimal_report(points), out_png)
+    plot_rv_data_only(summary_path, points, minimal_report(points, summary_path=summary_path), out_png)
     return True
 
 

--- a/scripts/refit_all_per_object.sh
+++ b/scripts/refit_all_per_object.sh
@@ -112,6 +112,7 @@ for gid in "${STAR_IDS[@]}"; do
     --reports-dir "$REPORTS_DIR"
     --use-gaia-nss
     --min-points "$MIN_POINTS"
+    --data-csv "$DATA_CSV"
   )
   if [[ "$FIT_FORCE" == "1" ]]; then
     fit_args+=(--force)

--- a/scripts/update_website_table_columns.py
+++ b/scripts/update_website_table_columns.py
@@ -11,17 +11,21 @@ from pathlib import Path
 
 from fit_apf_rv_keplerian import (
     _load_json_cache,
+    discover_summary_path,
     enrich_gaia_cache_from_summaries,
+    inclination_deg_for_website_table,
     lookup_fit_report_by_gaia_id,
     website_table_masses_from_report,
 )
 from darkhunter_rv.website_table_csv import (
+    INCLINATION_COLUMN,
     days_since_last_apf_from_summary,
     format_next_rv_event_cell,
     gaia_id_from_row,
     next_rv_event_from_fit_report,
     normalize_data_csv,
     parse_next_rv_cell_to_mjd,
+    parse_table_m1_msun,
 )
 
 
@@ -57,6 +61,7 @@ def update_table_columns(
     m2_i = hdr.index("M2 (Msun)")
     m2sini_i = hdr.index("M2sin i (Msun)")
     m2over_i = hdr.index("(M2sin i)/(sin i) (Msun)")
+    incl_i = hdr.index(INCLINATION_COLUMN)
     apf_days_i = hdr.index("DAYS SINCE LAST APF")
     next_rv_i = hdr.index("NEXT RV EVENT (DATE)")
 
@@ -85,6 +90,7 @@ def update_table_columns(
     n_m2sini = 0
     n_m2_at_i = 0
     n_m2_at_i_eq_sin = 0
+    n_incl = 0
     n_next = 0
     target = (gaia_id or "").strip()
     for r in data_rows:
@@ -97,8 +103,9 @@ def update_table_columns(
         if target and sid != target:
             continue
 
-        summ = out_dir / f"Gaia_DR3_{sid}_summary.txt"
-        if summ.is_file():
+        table_m1 = parse_table_m1_msun(r, hdr)
+        summ = discover_summary_path(out_dir, sid)
+        if summ is not None and summ.is_file():
             age = days_since_last_apf_from_summary(summ)
             if age is not None:
                 while len(r) <= apf_days_i:
@@ -109,10 +116,24 @@ def update_table_columns(
         rep = lookup_fit_report_by_gaia_id(reports, sid)
         if rep is None:
             continue
+        incl_deg = inclination_deg_for_website_table(
+            rep,
+            summary_path=summ if summ is not None else None,
+            gaia_cache=gaia_cache,
+        )
+        while len(r) <= incl_i:
+            r.append("")
+        if incl_deg is not None:
+            r[incl_i] = f"{incl_deg:.2f}"
+            n_incl += 1
+        else:
+            r[incl_i] = ""
+
         masses = website_table_masses_from_report(
             rep,
-            summary_path=summ if summ.is_file() else None,
+            summary_path=summ if summ is not None else None,
             gaia_cache=gaia_cache,
+            table_m1_msun=table_m1,
         )
         if masses["m2_msun"] is not None:
             while len(r) <= m2_i:
@@ -164,6 +185,7 @@ def update_table_columns(
         "m2sin_i_filled": n_m2sini,
         "m2_at_i_filled": n_m2_at_i,
         "m2_at_i_equals_m2sin_i": n_m2_at_i_eq_sin,
+        "inclination_filled": n_incl,
         "next_rv_filled": n_next,
         "reports_loaded": len(reports),
         "cache_enriched_from_summaries": n_cache_summ,
@@ -216,6 +238,7 @@ def main() -> int:
         f"updated {args.data_csv}: {stats['data_rows']} rows, {stats['columns']} columns, "
         f"cleared {stats['stray_img_cleared']} stray <img>, "
         f"apf_days={stats['apf_days_filled']}, m2={stats['m2_filled']}, "
+        f"incl={stats['inclination_filled']}, "
         f"m2sin_i={stats['m2sin_i_filled']}, m2_at_i={stats['m2_at_i_filled']} "
         f"(m2_at_i=m2sin_i for {stats['m2_at_i_equals_m2sin_i']}, often i≈90°), "
         f"next_rv={stats['next_rv_filled']} (from {stats['reports_loaded']} reports, "

--- a/tests/test_apf_observability.py
+++ b/tests/test_apf_observability.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+
+from darkhunter_rv.apf_observability import compute_apf_observability
+
+
+def test_circumpolar_target_has_flag_and_window() -> None:
+    # Dec well above Lick latitude → circumpolar at APF.
+    coord = SkyCoord(ra=180.0 * u.deg, dec=70.0 * u.deg, frame="icrs")
+    out = compute_apf_observability(coord, start_mjd=60000.0, horizon_days=30)
+    assert out["circumpolar"] is True
+    assert out["windows"]
+    assert out["next_window_start_date"]
+    assert out["next_window_end_date"]
+
+
+def test_mid_latitude_can_yield_windows_or_empty() -> None:
+    coord = SkyCoord(ra=120.0 * u.deg, dec=20.0 * u.deg, frame="icrs")
+    out = compute_apf_observability(coord, start_mjd=60000.0, horizon_days=90)
+    assert out["circumpolar"] is False
+    assert "windows" in out

--- a/tests/test_fit_apf_rv_keplerian.py
+++ b/tests/test_fit_apf_rv_keplerian.py
@@ -480,6 +480,39 @@ def test_website_table_masses_from_report_separates_sources() -> None:
     assert cols["m2_at_i_msun"] == pytest.approx(0.48)
 
 
+def test_table_m1_overrides_default_and_nss() -> None:
+    rep = {
+        "gaia_source_id": "99",
+        "used_m1_msun": 0.8,
+        "gaia_nss": {"m1_msun": 0.9},
+        "fit_variants": {
+            "free": {"P_days": 10.0, "K_kms": 40.0, "e": 0.1, "mass_function_msun": 0.05},
+        },
+    }
+    cols_default = fitmod.website_table_masses_from_report(rep)
+    cols_table = fitmod.website_table_masses_from_report(rep, table_m1_msun=1.5)
+    assert cols_default["m2sin_i_msun"] is not None
+    assert cols_table["m2sin_i_msun"] is not None
+    assert cols_table["m2sin_i_msun"] != cols_default["m2sin_i_msun"]
+
+
+def test_fix_period_seeded_from_free_fit() -> None:
+    rng = np.random.default_rng(42)
+    p_true = 12.0
+    t = np.sort(rng.uniform(60000, 60120, 18))
+    y = 30.0 * np.sin(2 * np.pi * t / p_true) + rng.normal(0, 2.0, size=t.size)
+    yerr = np.full_like(y, 2.0)
+    gaia_nss = {"period_days": p_true, "eccentricity": 0.05}
+    variants = fitmod.fit_all_variants(t, y, yerr, gaia_nss, period_min=1.0, period_max=100.0, period_prior_sigma=0.15)
+    assert "free" in variants
+    assert "fix_period" in variants
+    assert "fix_period_ecc" in variants
+    free_rep = variants["free"][1]
+    fp_rep = variants["fix_period"][1]
+    assert fp_rep["chi2_red"] <= 2.5 * free_rep["chi2_red"] + 0.05
+    assert abs(fp_rep["e"] - free_rep["e"]) < 0.25
+
+
 def test_rv_only_mass_estimates_use_free_fit() -> None:
     rep_free = {"P_days": 10.0, "K_kms": 40.0, "e": 0.1, "mass_function_msun": 0.05}
     m2s, m2i = fitmod.rv_only_mass_estimates(rep_free, m1_msun=1.0, inclination_deg=90.0)

--- a/tests/test_website_table_csv_normalize.py
+++ b/tests/test_website_table_csv_normalize.py
@@ -1,0 +1,22 @@
+from darkhunter_rv.website_table_csv import LEGACY_NEXT_RV_MJD, normalize_data_csv
+
+
+def test_normalize_drops_legacy_next_rv_mjd_column() -> None:
+    hdr = [
+        "GAIA NAME",
+        "M2 (Msun)",
+        "NEXT RV EVENT (DATE)",
+        LEGACY_NEXT_RV_MJD,
+    ]
+    rows = [["Gaia DR3 123", "0.5", "2024/01/01", "60000"]]
+    normalize_data_csv(hdr, rows)
+    assert LEGACY_NEXT_RV_MJD not in hdr
+    assert "NEXT RV EVENT (DATE)" in hdr
+    assert rows[0][hdr.index("NEXT RV EVENT (DATE)")] == "2024/01/01"
+
+
+def test_normalize_adds_inclination_column() -> None:
+    hdr = ["GAIA NAME", "M2 (Msun)", "M2sin i (Msun)", "(M2sin i)/(sin i) (Msun)"]
+    rows = [["id", "1", "0.2", "0.3"]]
+    normalize_data_csv(hdr, rows)
+    assert "INCLINATION (deg)" in hdr

--- a/website/rv/script.js
+++ b/website/rv/script.js
@@ -50,6 +50,7 @@ const headerDisplayMap = {
     "M2 (Msun)": "Dark M2<br>(M<sub>⊙</sub>)",
     "M2sin i (Msun)": "M2 sin i<br>(M<sub>⊙</sub>)",
     "(M2sin i)/(sin i) (Msun)": "M2 at i<br>(M<sub>⊙</sub>)",
+    "INCLINATION (deg)": "Inclination<br>(deg)",
     "RV PLOT": "RV Curve",
     "RV FIT": "RV Fit",
     "FLUX PLOT": "H-beta",
@@ -419,7 +420,7 @@ function colIndex(headerName) {
     return Object.prototype.hasOwnProperty.call(colByHeader, headerName) ? colByHeader[headerName] : -1;
 }
 
-const NUMERIC_TABLE_HEADERS = new Set(["DAYS SINCE LAST APF"]);
+const NUMERIC_TABLE_HEADERS = new Set(["DAYS SINCE LAST APF", "INCLINATION (deg)"]);
 const DATE_TABLE_HEADERS = new Set(["NEXT RV EVENT (DATE)", "NEXT RV EVENT (MJD)"]);
 
 function cellAtColumn(row, headerName) {


### PR DESCRIPTION
## Summary

- Add **`INCLINATION (deg)`** column to the RV table; dedupe legacy **`NEXT RV EVENT (MJD)`** into **`NEXT RV EVENT (DATE)`** during CSV normalize.
- Fix **M2 at i** fill: discover flat and nested summaries, enrich Gaia NSS cache in repair/batch, clear stale zero cells, and log inclination vs M2-at-i stats.
- Use table **`M1 (Msun)`** (Luminous) as the first choice for **M2 sin i** and **M2 at i** (astrometric M2 unchanged); wire through table updater and fit-time `--data-csv` map.
- **Seed constrained Keplerian fits** from the free fit (P fixed inherits free e/phase; optional e-fixed retry when chi² diverges).
- **APF observability**: new Lick airmass calculator, `observability_windows_cache.json` builder, and blue multi-window shading on fit/residual/data-only plots (circumpolar note when applicable).
- Update **`docs/website.md`** with column definitions and ziggy verification steps.

Also includes prior branch fixes: distinct M2 at i from M2 sin i (no stale i=90° JSON), H-beta plot URL correction.

## Test plan

- [x] `pytest tests/test_fit_apf_rv_keplerian.py tests/test_website_table_csv_normalize.py tests/test_apf_observability.py tests/test_fix_data_csv_column_order.py` (42 passed)
- [ ] On ziggy: `PREFETCH_GAIA_NSS=1 bash scripts/repair_website_table.sh` — inclination and M2 at i populated where Gaia i exists
- [ ] Build observability cache and confirm blue APF window shading on keplerian fit/residual plots
- [ ] Refit Gaia DR3 3378588057203660160 — orange P-fixed curve tracks RV-only after seeding
- [ ] Confirm single “Next RV min/max” column in `data.csv` header

## Ziggy deploy (after merge)

```bash
cd /data2/darkhunter/dark-hunter_rv && git pull

# Fast table repair (inclination, masses, Next RV, dedupe MJD column)
PREFETCH_GAIA_NSS=1 bash scripts/repair_website_table.sh

# APF visibility cache for plot shading
PYTHONPATH=. python3 scripts/build_apf_observability_cache.py \
  --data-csv /var/www/html/darkhunter/rv/tables/data.csv \
  --output-dir /data2/darkhunter/dark-hunter_rv/output

# Optional: refit for P-fixed seeding + observability embedded in fit JSON/plots
screen -dmS darkhunter_per_object bash -lc '
  REPO=/data2/darkhunter/dark-hunter_rv
  cd "$REPO" && git pull && bash scripts/refit_all_per_object.sh
'
```


Made with [Cursor](https://cursor.com)