### PR TITLE
Derive inclination from Thiele-Innes when Gaia NSS field is empty

### DIFF
--- a/darkhunter_rv/gaia_utils.py
+++ b/darkhunter_rv/gaia_utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 from astropy.time import Time
 from . import config
+from .thiele_innes_inclination import fill_inclination_in_metadata
 
 def _gaia_class():
     """Lazy import: avoids astroquery's noisy archive banner when only reading summaries from disk."""
@@ -259,6 +260,8 @@ def process_query_results(main_rows, unified_external_rows):
         "G_Thiele_Innes": get_val(base, "g_thiele_innes"),
         "G_Thiele_Innes_Error": get_val(base, "g_thiele_innes_error"),
     }
+
+    fill_inclination_in_metadata(metadata)
 
     external_rvs = _external_rvs_from_unified_rows(unified_external_rows)
     return {"metadata": metadata, "external_rvs": external_rvs}

--- a/darkhunter_rv/thiele_innes_inclination.py
+++ b/darkhunter_rv/thiele_innes_inclination.py
@@ -1,0 +1,218 @@
+"""Derive orbital inclination from Gaia Thiele-Innes elements (Halbwachs et al. 2023, App. A)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+import numpy as np
+
+# Gaia DR3: inclination is not published for astrometric binaries; derive from A,B,F,G.
+_TI_META_KEYS = (
+    ("A", ("A_Thiele_Innes", "a_thiele_innes")),
+    ("A_err", ("A_Thiele_Innes_Error", "a_thiele_innes_error")),
+    ("B", ("B_Thiele_Innes", "b_thiele_innes")),
+    ("B_err", ("B_Thiele_Innes_Error", "b_thiele_innes_error")),
+    ("F", ("F_Thiele_Innes", "f_thiele_innes")),
+    ("F_err", ("F_Thiele_Innes_Error", "f_thiele_innes_error")),
+    ("G", ("G_Thiele_Innes", "g_thiele_innes")),
+    ("G_err", ("G_Thiele_Innes_Error", "g_thiele_innes_error")),
+)
+
+
+@dataclass(frozen=True)
+class ThieleInnesElements:
+    A: float
+    B: float
+    F: float
+    G: float
+    A_err: float = np.nan
+    B_err: float = np.nan
+    F_err: float = np.nan
+    G_err: float = np.nan
+
+    def has_errors(self) -> bool:
+        errs = (self.A_err, self.B_err, self.F_err, self.G_err)
+        return any(np.isfinite(e) and e > 0 for e in errs)
+
+
+def _meta_float(meta: Mapping[str, Any], *keys: str) -> Optional[float]:
+    for key in keys:
+        if key not in meta:
+            continue
+        try:
+            val = float(meta[key])
+        except (TypeError, ValueError):
+            continue
+        if np.isfinite(val):
+            return val
+    return None
+
+
+def campbell_to_thiele_innes(
+    a_mas: float,
+    i_deg: float,
+    omega_deg: float,
+    Omega_deg: float,
+) -> tuple[float, float, float, float]:
+    """Forward Binnendijk/Halbwachs A.1 (mas); used for validation and tests."""
+    i = np.deg2rad(i_deg)
+    omega = np.deg2rad(omega_deg)
+    Omega = np.deg2rad(Omega_deg)
+    A = a_mas * (np.cos(omega) * np.cos(Omega) - np.sin(omega) * np.sin(Omega) * np.cos(i))
+    B = a_mas * (np.cos(omega) * np.sin(Omega) + np.sin(omega) * np.cos(Omega) * np.cos(i))
+    F = -a_mas * (np.sin(omega) * np.cos(Omega) + np.cos(omega) * np.sin(Omega) * np.cos(i))
+    G = -a_mas * (np.sin(omega) * np.sin(Omega) - np.cos(omega) * np.cos(Omega) * np.cos(i))
+    return float(A), float(B), float(F), float(G)
+
+
+def thiele_innes_from_metadata(meta: Mapping[str, Any]) -> Optional[ThieleInnesElements]:
+    """Parse A,B,F,G (+ errors) from Gaia metadata or ADQL row dict."""
+    vals: dict[str, Optional[float]] = {}
+    for slot, keys in _TI_META_KEYS:
+        vals[slot] = _meta_float(meta, *keys)
+    if any(vals[k] is None for k in ("A", "B", "F", "G")):
+        return None
+    return ThieleInnesElements(
+        A=float(vals["A"]),  # type: ignore[arg-type]
+        B=float(vals["B"]),  # type: ignore[arg-type]
+        F=float(vals["F"]),  # type: ignore[arg-type]
+        G=float(vals["G"]),  # type: ignore[arg-type]
+        A_err=float(vals["A_err"]) if vals["A_err"] is not None else np.nan,
+        B_err=float(vals["B_err"]) if vals["B_err"] is not None else np.nan,
+        F_err=float(vals["F_err"]) if vals["F_err"] is not None else np.nan,
+        G_err=float(vals["G_err"]) if vals["G_err"] is not None else np.nan,
+    )
+
+
+def inclination_rad_from_thiele_innes(A: float, B: float, F: float, G: float) -> Optional[float]:
+    """
+    Orbital inclination (rad) from Thiele-Innes elements.
+
+    Uses the Binnendijk/Halbwachs inversion (same arccos branch as ``rv_fits.astrometric_orbit``).
+    """
+    u = (A * A + B * B + F * F + G * G) / 2.0
+    v = A * G - B * F
+    disc = u * u - v * v
+    if disc < 0:
+        if disc > -1e-18 * max(1.0, u * u):
+            disc = 0.0
+        else:
+            return None
+    a0 = np.sqrt(u + np.sqrt(disc))
+    if a0 <= 0 or not np.isfinite(a0):
+        return None
+
+    o_minus_O = np.arctan2(B + F, G - A)
+    o_plus_O = np.arctan2(B - F, A + G)
+    omega = 0.5 * (o_minus_O + o_plus_O)
+    Omega = o_plus_O - omega
+
+    if (-B - F) * np.sin(omega - Omega) < 0:
+        o_minus_O += np.pi
+        omega = 0.5 * (o_minus_O + o_plus_O)
+        Omega = o_plus_O - omega
+
+    cos_wpO = np.cos(omega + Omega)
+    if abs(cos_wpO) < 1e-15:
+        return None
+    arg = ((A + G) / a0) / cos_wpO - 1.0
+    if not np.isfinite(arg):
+        return None
+    arg = float(np.clip(arg, -1.0, 1.0))
+    i_rad = float(np.arccos(arg))
+    if not np.isfinite(i_rad) or i_rad <= 0 or i_rad >= np.pi:
+        return None
+    return i_rad
+
+
+def inclination_deg_from_thiele_innes(A: float, B: float, F: float, G: float) -> Optional[float]:
+    i_rad = inclination_rad_from_thiele_innes(A, B, F, G)
+    if i_rad is None:
+        return None
+    return float(np.rad2deg(i_rad))
+
+
+def _mc_inclination_error_deg(
+    ti: ThieleInnesElements,
+    i_point_deg: float,
+    *,
+    n_samples: int,
+    seed: int,
+) -> Optional[float]:
+    sigmas = (
+        ti.A_err if np.isfinite(ti.A_err) and ti.A_err > 0 else 0.0,
+        ti.B_err if np.isfinite(ti.B_err) and ti.B_err > 0 else 0.0,
+        ti.F_err if np.isfinite(ti.F_err) and ti.F_err > 0 else 0.0,
+        ti.G_err if np.isfinite(ti.G_err) and ti.G_err > 0 else 0.0,
+    )
+    if not any(s > 0 for s in sigmas):
+        return None
+
+    rng = np.random.default_rng(seed)
+    draws: list[float] = []
+    for _ in range(n_samples):
+        a = rng.normal(ti.A, sigmas[0] or 0.0)
+        b = rng.normal(ti.B, sigmas[1] or 0.0)
+        f = rng.normal(ti.F, sigmas[2] or 0.0)
+        g = rng.normal(ti.G, sigmas[3] or 0.0)
+        inc = inclination_deg_from_thiele_innes(a, b, f, g)
+        if inc is not None and 0.0 < inc < 180.0:
+            draws.append(inc)
+    if len(draws) < max(50, n_samples // 20):
+        return None
+    return float(np.std(np.asarray(draws)))
+
+
+def inclination_from_thiele_innes(
+    ti: ThieleInnesElements,
+    *,
+    mc_samples: int = 4096,
+    seed: int = 0,
+) -> tuple[Optional[float], Optional[float]]:
+    """
+    Return (inclination_deg, inclination_error_deg).
+
+    Point estimate from Thiele-Innes inversion; σ_i from Monte Carlo over Gaussian TI
+    uncertainties (uncorrelated when covariances are unavailable).
+    """
+    i_deg = inclination_deg_from_thiele_innes(ti.A, ti.B, ti.F, ti.G)
+    if i_deg is None:
+        return None, None
+    i_err = _mc_inclination_error_deg(ti, i_deg, n_samples=mc_samples, seed=seed)
+    return i_deg, i_err
+
+
+def metadata_inclination_is_missing(meta: Mapping[str, Any]) -> bool:
+    incl = _meta_float(meta, "Inclination", "inclination", "Inclination_Deg")
+    if incl is None:
+        return True
+    return incl <= 0.05 or incl >= 179.95
+
+
+def fill_inclination_in_metadata(meta: dict[str, Any]) -> bool:
+    """
+    If Inclination is missing/invalid, derive from Thiele-Innes and update *meta* in place.
+
+    Returns True when inclination (and optional error) were written.
+    """
+    if not metadata_inclination_is_missing(meta):
+        return False
+    ti = thiele_innes_from_metadata(meta)
+    if ti is None:
+        return False
+    i_deg, i_err = inclination_from_thiele_innes(ti)
+    if i_deg is None or i_deg <= 0.05 or i_deg >= 179.95:
+        return False
+    meta["Inclination"] = float(i_deg)
+    if i_err is not None and np.isfinite(i_err) and i_err > 0:
+        meta["Inclination_Error"] = float(i_err)
+    return True
+
+
+def inclination_from_row_dict(row: Mapping[str, Any]) -> tuple[Optional[float], Optional[float]]:
+    """Convenience for ADQL / cache rows with lowercase nss column names."""
+    ti = thiele_innes_from_metadata(row)
+    if ti is None:
+        return None, None
+    return inclination_from_thiele_innes(ti)

--- a/docs/website.md
+++ b/docs/website.md
@@ -80,7 +80,7 @@ Ensure Apache serves `/var/www/html/darkhunter/rv/` (existing `Alias` or symlink
 | **M2 (Msun)** | Gaia NSS astrometric secondary mass (`used_m2_msun`), not from the RV fit |
 | **M2sin i (Msun)** | RV-only Keplerian fit f(M) with table M1 |
 | **(M2sin i)/(sin i) (Msun)** | Same f(M) and M1 with Gaia astrometric inclination |
-| **INCLINATION (deg)** | Astrometric i used for M2 at i (empty if unknown or edge-on) |
+| **INCLINATION (deg)** | Astrometric i used for M2 at i (from Gaia NSS or derived from Thiele-Innes A,B,F,G when the database field is empty; empty if unknown or edge-on) |
 
 **RV fit plots:** blue shaded regions mark APF visibility at Lick (airmass ≤ 2.5 for ≥15 min after −18° twilight, out to 3 months). Built via `scripts/build_apf_observability_cache.py` and stored in `rv_fit_reports/observability_windows_cache.json`. Circumpolar targets are annotated on the plot.
 
@@ -166,6 +166,17 @@ PYTHONPATH=. python3 scripts/build_apf_observability_cache.py \
 ```
 
 Hard-refresh the browser. After a code update that changes Keplerian fit logic or observability shading, rerun per-object refit (command 3) or full refresh (command 2).
+
+**Inclination from Thiele-Innes** (Gaia DR3 astrometric binaries often have empty `inclination` in `nss_two_body_orbit`; derive from A,B,F,G in summaries):
+
+```bash
+cd /data2/darkhunter/dark-hunter_rv
+PYTHONPATH=. python3 scripts/patch_summary_inclination_from_thiele_innes.py \
+  --output-dir /data2/darkhunter/dark-hunter_rv/output
+PREFETCH_GAIA_NSS=1 bash scripts/repair_website_table.sh
+```
+
+New Gaia queries and summary reads apply the same derivation automatically when TI elements are present.
 
 ### Step 2 — Full refresh when ready
 

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -33,6 +33,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 from astropy.timeseries import LombScargle
 from astropy.time import Time
+
+from darkhunter_rv.thiele_innes_inclination import fill_inclination_in_metadata, inclination_from_row_dict
 from scipy.optimize import least_squares
 import matplotlib.pyplot as plt
 from matplotlib.ticker import AutoMinorLocator
@@ -131,6 +133,7 @@ def load_mass_priors_from_summary(path: Path) -> Dict[str, float]:
     meta = _parse_gaia_metadata(path)
     if not meta:
         return {}
+    fill_inclination_in_metadata(meta)
     out: Dict[str, float] = {}
     m1 = _meta_float(meta, "M1", "m1", "m1_msun", "Mass_Primary", "mass_primary")
     m2 = _meta_float(meta, "M2", "m2", "m2_msun", "Mass_Secondary", "mass_secondary")
@@ -279,6 +282,27 @@ def _extract_m1_from_nss_row(row: Any) -> Optional[float]:
     return None
 
 
+def _gaia_table_row_as_dict(row: Any) -> Dict[str, Any]:
+    try:
+        names = list(getattr(row, "colnames", []) or [])
+        return {str(n): row[n] for n in names}
+    except Exception:
+        pass
+    if isinstance(row, dict):
+        return dict(row)
+    return {}
+
+
+def _resolve_orbit_inclination_deg(row: Any, cached_incl: Optional[float] = None) -> tuple[Optional[float], Optional[float]]:
+    """Database inclination when present; otherwise derive from Thiele-Innes (Halbwachs App. A)."""
+    incl_o = cached_incl
+    if incl_o is None:
+        incl_o = _first_finite(row, ["inclination", "incl"])
+    if incl_o is not None and np.isfinite(incl_o) and 0.05 < float(incl_o) < 179.95:
+        return float(incl_o), None
+    return inclination_from_row_dict(_gaia_table_row_as_dict(row))
+
+
 def fetch_gaia_nss_orbit(source_id: str, cache_path: Optional[Path] = None) -> Optional[Dict[str, float]]:
     cache: Dict[str, Any] = {}
     if cache_path is not None:
@@ -299,7 +323,11 @@ def fetch_gaia_nss_orbit(source_id: str, cache_path: Optional[Path] = None) -> O
 
     try:
         orbit_query = f"""
-        SELECT source_id, nss_solution_type, period, eccentricity, inclination
+        SELECT source_id, nss_solution_type, period, eccentricity, inclination,
+               a_thiele_innes, a_thiele_innes_error,
+               b_thiele_innes, b_thiele_innes_error,
+               f_thiele_innes, f_thiele_innes_error,
+               g_thiele_innes, g_thiele_innes_error
         FROM gaiadr3.nss_two_body_orbit
         WHERE source_id = '{source_id}'
         """
@@ -335,9 +363,11 @@ def fetch_gaia_nss_orbit(source_id: str, cache_path: Optional[Path] = None) -> O
             if p <= 0 or e < 0 or e >= 1:
                 continue
             out = {"period_days": float(p), "eccentricity": float(e)}
-            incl_o = _first_finite(row, ["inclination", "incl"])
+            incl_o, incl_err = _resolve_orbit_inclination_deg(row)
             if incl_o is not None and np.isfinite(incl_o):
                 out["inclination_deg"] = float(incl_o)
+            if incl_err is not None and np.isfinite(incl_err) and incl_err > 0:
+                out["inclination_deg_error"] = float(incl_err)
             if m1 is not None:
                 out["m1_msun"] = m1
             if m2 is not None:
@@ -384,7 +414,11 @@ def prefetch_gaia_nss_bulk(source_ids: List[str], cache_path: Path, chunk_size: 
     for ids in _chunk(to_fetch, chunk_size):
         id_clause = ",".join(ids)
         orbit_q = (
-            "SELECT source_id, period, eccentricity, inclination "
+            "SELECT source_id, period, eccentricity, inclination, "
+            "a_thiele_innes, a_thiele_innes_error, "
+            "b_thiele_innes, b_thiele_innes_error, "
+            "f_thiele_innes, f_thiele_innes_error, "
+            "g_thiele_innes, g_thiele_innes_error "
             "FROM gaiadr3.nss_two_body_orbit "
             f"WHERE source_id IN ({id_clause})"
         )
@@ -414,9 +448,11 @@ def prefetch_gaia_nss_bulk(source_ids: List[str], cache_path: Path, chunk_size: 
             if not np.isfinite(p) or not np.isfinite(e) or p <= 0 or e < 0 or e >= 1:
                 continue
             entry: Dict[str, float] = {"period_days": float(p), "eccentricity": float(e)}
-            incl_o = _first_finite(row, ["inclination", "incl"])
+            incl_o, incl_err = _resolve_orbit_inclination_deg(row)
             if incl_o is not None and np.isfinite(incl_o):
                 entry["inclination_deg"] = float(incl_o)
+            if incl_err is not None and np.isfinite(incl_err) and incl_err > 0:
+                entry["inclination_deg_error"] = float(incl_err)
             orbit_by[sid] = entry
 
         mass_by: Dict[str, Dict[str, float]] = {}

--- a/scripts/patch_summary_inclination_from_thiele_innes.py
+++ b/scripts/patch_summary_inclination_from_thiele_innes.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Derive Inclination from Thiele-Innes elements in star summary [GAIA METADATA] blocks."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from darkhunter_rv.thiele_innes_inclination import (
+    fill_inclination_in_metadata,
+    metadata_inclination_is_missing,
+    thiele_innes_from_metadata,
+)
+from fit_apf_rv_keplerian import discover_summary_files, parse_object_id_from_summary
+from darkhunter_rv.gaia_utils import parse_gaia_metadata_from_star_summary
+
+
+def _format_meta_value(key: str, val: float) -> str:
+    if key.endswith("_Error") or key.endswith("Error"):
+        return f"{val:.8f}"
+    return f"{val:.8f}"
+
+
+def _upsert_gaia_metadata_fields(text: str, updates: dict[str, float]) -> str:
+    """Insert or replace Key: value lines inside [GAIA METADATA]."""
+    lines = text.splitlines(keepends=True)
+    start = None
+    end = None
+    for i, line in enumerate(lines):
+        if line.strip() == "[GAIA METADATA]":
+            start = i + 1
+            continue
+        if start is not None and line.strip().startswith("[") and line.strip().endswith("]"):
+            end = i
+            break
+    if start is None:
+        return text
+
+    block_end = end if end is not None else len(lines)
+    key_re = {k: re.compile(rf"^{re.escape(k)}\s*:") for k in updates}
+
+    present: set[str] = set()
+    for i in range(start, block_end):
+        raw = lines[i]
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        for key, rx in key_re.items():
+            if rx.match(stripped):
+                lines[i] = f"{key}: {_format_meta_value(key, updates[key])}\n"
+                present.add(key)
+                break
+
+    missing = [k for k in updates if k not in present]
+    if missing:
+        insert_at = block_end
+        new_lines = [f"{k}: {_format_meta_value(k, updates[k])}\n" for k in missing]
+        lines[insert_at:block_end] = new_lines + lines[insert_at:block_end]
+
+    return "".join(lines)
+
+
+def patch_summary_path(path: Path, *, dry_run: bool) -> str:
+    meta = parse_gaia_metadata_from_star_summary(path)
+    if not meta:
+        return "no_metadata"
+    if thiele_innes_from_metadata(meta) is None:
+        return "no_thiele_innes"
+    if not metadata_inclination_is_missing(meta):
+        return "has_inclination"
+
+    working = dict(meta)
+    if not fill_inclination_in_metadata(working):
+        return "derive_failed"
+
+    updates: dict[str, float] = {"Inclination": float(working["Inclination"])}
+    if "Inclination_Error" in working:
+        updates["Inclination_Error"] = float(working["Inclination_Error"])
+
+    if dry_run:
+        return "would_patch"
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    path.write_text(_upsert_gaia_metadata_fields(text, updates), encoding="utf-8")
+    return "patched"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Fill Inclination in summary.txt from Gaia Thiele-Innes A,B,F,G."
+    )
+    ap.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("output"),
+        help="Directory containing *_summary.txt files (searched recursively)",
+    )
+    ap.add_argument("--dry-run", action="store_true", help="Report only; do not rewrite files")
+    args = ap.parse_args()
+
+    paths = discover_summary_files(args.output_dir)
+    if not paths:
+        print(f"No summaries under {args.output_dir.resolve()}")
+        return 1
+
+    counts: dict[str, int] = {}
+    for path in paths:
+        sid = parse_object_id_from_summary(path) or path.stem
+        status = patch_summary_path(path, dry_run=args.dry_run)
+        counts[status] = counts.get(status, 0) + 1
+        if status in ("patched", "would_patch"):
+            print(f"{status}: {sid} ({path})")
+
+    print(
+        f"done: {len(paths)} summaries — "
+        + ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_patch_summary_inclination.py
+++ b/tests/test_patch_summary_inclination.py
@@ -1,0 +1,27 @@
+"""Tests for patch_summary_inclination_from_thiele_innes.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from darkhunter_rv.thiele_innes_inclination import campbell_to_thiele_innes
+from scripts.patch_summary_inclination_from_thiele_innes import patch_summary_path
+
+
+def test_patch_summary_writes_inclination(tmp_path: Path) -> None:
+    A, B, F, G = campbell_to_thiele_innes(2.0, 72.0, 30.0, 110.0)
+    summ = tmp_path / "Gaia_DR3_1234567890123456789_summary.txt"
+    summ.write_text(
+        "### STAR SUMMARY: 1234567890123456789 ###\n\n"
+        "[GAIA METADATA]\n"
+        f"A_Thiele_Innes: {A:.8f}\n"
+        f"B_Thiele_Innes: {B:.8f}\n"
+        f"F_Thiele_Innes: {F:.8f}\n"
+        f"G_Thiele_Innes: {G:.8f}\n"
+        "Inclination: NaN\n"
+        "\n[PIPELINE RESULTS]\n# File | MJD | RV\n",
+        encoding="utf-8",
+    )
+    assert patch_summary_path(summ, dry_run=False) == "patched"
+    text = summ.read_text(encoding="utf-8")
+    assert "Inclination: 72." in text or "Inclination: 71." in text

--- a/tests/test_thiele_innes_inclination.py
+++ b/tests/test_thiele_innes_inclination.py
@@ -1,0 +1,97 @@
+"""Tests for Thiele-Innes → inclination conversion."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from darkhunter_rv.thiele_innes_inclination import (
+    campbell_to_thiele_innes,
+    fill_inclination_in_metadata,
+    inclination_deg_from_thiele_innes,
+    inclination_from_thiele_innes,
+    thiele_innes_from_metadata,
+)
+
+
+@pytest.mark.parametrize(
+    "i_deg,omega_deg,Omega_deg",
+    [
+        (60.0, 45.0, 120.0),
+        (120.0, 30.0, 200.0),
+        (35.0, 10.0, 50.0),
+        (145.0, 210.0, 80.0),
+    ],
+)
+def test_inclination_round_trip(i_deg: float, omega_deg: float, Omega_deg: float) -> None:
+    A, B, F, G = campbell_to_thiele_innes(2.5, i_deg, omega_deg, Omega_deg)
+    got = inclination_deg_from_thiele_innes(A, B, F, G)
+    assert got is not None
+    assert got == pytest.approx(i_deg, abs=1e-6)
+
+
+def test_inclination_error_propagation() -> None:
+    A, B, F, G = campbell_to_thiele_innes(1.8, 74.0, 55.0, 130.0)
+    ti = thiele_innes_from_metadata(
+        {
+            "A_Thiele_Innes": A,
+            "B_Thiele_Innes": B,
+            "F_Thiele_Innes": F,
+            "G_Thiele_Innes": G,
+            "A_Thiele_Innes_Error": 0.05,
+            "B_Thiele_Innes_Error": 0.05,
+            "F_Thiele_Innes_Error": 0.05,
+            "G_Thiele_Innes_Error": 0.05,
+        }
+    )
+    assert ti is not None
+    i_deg, i_err = inclination_from_thiele_innes(ti)
+    assert i_deg == pytest.approx(74.0, abs=1e-5)
+    assert i_err is not None
+    assert i_err > 0
+    assert i_err < 30.0
+
+
+def test_fill_inclination_in_metadata_from_ti() -> None:
+    A, B, F, G = campbell_to_thiele_innes(2.0, 60.0, 40.0, 100.0)
+    meta = {
+        "Inclination": float("nan"),
+        "A_Thiele_Innes": A,
+        "B_Thiele_Innes": B,
+        "F_Thiele_Innes": F,
+        "G_Thiele_Innes": G,
+        "A_Thiele_Innes_Error": 0.02,
+        "B_Thiele_Innes_Error": 0.02,
+        "F_Thiele_Innes_Error": 0.02,
+        "G_Thiele_Innes_Error": 0.02,
+    }
+    assert fill_inclination_in_metadata(meta)
+    assert meta["Inclination"] == pytest.approx(60.0, abs=1e-5)
+    assert "Inclination_Error" in meta
+
+
+def test_fill_skips_when_database_inclination_present() -> None:
+    A, B, F, G = campbell_to_thiele_innes(2.0, 60.0, 40.0, 100.0)
+    meta = {
+        "Inclination": 55.0,
+        "A_Thiele_Innes": A,
+        "B_Thiele_Innes": B,
+        "F_Thiele_Innes": F,
+        "G_Thiele_Innes": G,
+    }
+    assert not fill_inclination_in_metadata(meta)
+    assert meta["Inclination"] == 55.0
+
+
+def test_lowercase_adql_keys() -> None:
+    A, B, F, G = campbell_to_thiele_innes(1.5, 88.0, 20.0, 60.0)
+    ti = thiele_innes_from_metadata(
+        {
+            "a_thiele_innes": A,
+            "b_thiele_innes": B,
+            "f_thiele_innes": F,
+            "g_thiele_innes": G,
+        }
+    )
+    assert ti is not None
+    assert inclination_deg_from_thiele_innes(ti.A, ti.B, ti.F, ti.G) == pytest.approx(88.0, abs=1e-5)


### PR DESCRIPTION
## Summary

Gaia DR3 **`inclination`** in `nss_two_body_orbit` is populated only for eclipsing solutions; astrometric binaries expose **Thiele-Innes A,B,F,G** instead. This PR:

- Adds `darkhunter_rv/thiele_innes_inclination.py` — Binnendijk/Halbwachs inversion (same branch as `rv_fits/astrometric_orbit`) with **Monte Carlo σ_i** from TI parameter errors
- Adds `scripts/patch_summary_inclination_from_thiele_innes.py` to backfill `[GAIA METADATA] Inclination` in all `*_summary.txt` files
- Falls back automatically in **`gaia_utils.process_query_results`**, **`fetch_gaia_nss_orbit`**, **`prefetch_gaia_nss_bulk`**, and **`load_mass_priors_from_summary`** when the DB inclination is missing but TI elements exist

## Test plan

- [x] `pytest tests/test_thiele_innes_inclination.py tests/test_patch_summary_inclination.py tests/test_fit_apf_rv_keplerian.py` (44 passed)
- [ ] On ziggy: run patch script on `output/`, then `repair_website_table.sh` — `INCLINATION (deg)` and `M2 at i` populated for astrometric binaries with TI solutions

## Ziggy deploy (after merge)

```bash
cd /data2/darkhunter/dark-hunter_rv && git pull

# Backfill Inclination in existing summaries from A,B,F,G
PYTHONPATH=. python3 scripts/patch_summary_inclination_from_thiele_innes.py \
  --output-dir /data2/darkhunter/dark-hunter_rv/output

# Refresh table (inclination, M2 at i, masses); prefetch also derives i from TI
PREFETCH_GAIA_NSS=1 bash scripts/repair_website_table.sh
```

Optional dry run first: add `--dry-run` to the patch script.


Made with [Cursor](https://cursor.com)