### PR TITLE
Fix patch_summary_inclination script without scipy on ziggy

### DIFF
--- a/darkhunter_rv/summary_paths.py
+++ b/darkhunter_rv/summary_paths.py
@@ -1,0 +1,86 @@
+"""Discover star summary files under output/ (no scipy / fit dependencies)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+from darkhunter_rv.gaia_utils import parse_gaia_metadata_from_star_summary
+
+
+def parse_object_id_from_summary(path: Path) -> Optional[str]:
+    m = re.search(r"Gaia_DR3_(\d{18,19})", f"{path.parent.name}/{path.stem}")
+    if m:
+        return m.group(1)
+    meta = parse_gaia_metadata_from_star_summary(path)
+    if meta is not None:
+        sid = meta.get("Source_ID", meta.get("source_id"))
+        if sid is not None:
+            try:
+                return str(int(sid))
+            except (TypeError, ValueError):
+                pass
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if line.startswith("# OBJECT ID"):
+            m = re.search(r"=\s*([0-9]+)", line)
+            if m:
+                return m.group(1)
+    m = re.match(r"([0-9]+)_summary$", path.stem)
+    return m.group(1) if m else None
+
+
+def count_pipeline_rows(path: Path) -> int:
+    """Rows in [PIPELINE RESULTS] (or legacy table), including NaN RV epochs."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if "[PIPELINE RESULTS]" in text:
+        lines = text.split("[PIPELINE RESULTS]", 1)[-1].splitlines()
+    else:
+        lines = text.splitlines()
+    n = 0
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#") or (line.startswith("[") and line.endswith("]")):
+            continue
+        if len(line.split()) >= 5:
+            n += 1
+    return n
+
+
+def discover_summary_files(output_dir: Path) -> list[Path]:
+    """One summary per Gaia source_id; prefer flat output/Gaia_DR3_<id>_summary.txt over nested stubs."""
+    if not output_dir.is_dir():
+        return []
+    out_root = output_dir.resolve()
+    by_sid: dict[str, Path] = {}
+
+    def _rank(path: Path) -> tuple:
+        flat = int(path.parent.resolve() == out_root)
+        gaia_named = int(path.name.startswith("Gaia_DR3_"))
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        return (flat, gaia_named, count_pipeline_rows(path), mtime)
+
+    for p in output_dir.rglob("*_summary.txt"):
+        if not p.is_file():
+            continue
+        sid = parse_object_id_from_summary(p)
+        if not sid:
+            continue
+        prev = by_sid.get(sid)
+        if prev is None or _rank(p) > _rank(prev):
+            by_sid[sid] = p.resolve()
+    return sorted(by_sid.values())
+
+
+def discover_summary_path(output_dir: Path, gaia_source_id: str) -> Optional[Path]:
+    """Best summary path for one Gaia source (flat or nested under output/)."""
+    sid = str(gaia_source_id).strip()
+    if not sid:
+        return None
+    for p in discover_summary_files(output_dir):
+        if parse_object_id_from_summary(p) == sid:
+            return p
+    return None

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -34,6 +34,12 @@ import numpy as np
 from astropy.timeseries import LombScargle
 from astropy.time import Time
 
+from darkhunter_rv.summary_paths import (
+    count_pipeline_rows,
+    discover_summary_files,
+    discover_summary_path,
+    parse_object_id_from_summary,
+)
 from darkhunter_rv.thiele_innes_inclination import fill_inclination_in_metadata, inclination_from_row_dict
 from scipy.optimize import least_squares
 import matplotlib.pyplot as plt
@@ -72,27 +78,6 @@ def _meta_float(meta: Dict[str, Any], *keys: str) -> Optional[float]:
         if np.isfinite(val):
             return val
     return None
-
-
-def parse_object_id_from_summary(path: Path) -> Optional[str]:
-    m = re.search(r"Gaia_DR3_(\d{18,19})", f"{path.parent.name}/{path.stem}")
-    if m:
-        return m.group(1)
-    meta = _parse_gaia_metadata(path)
-    if meta is not None:
-        sid = meta.get("Source_ID", meta.get("source_id"))
-        if sid is not None:
-            try:
-                return str(int(sid))
-            except (TypeError, ValueError):
-                pass
-    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-        if line.startswith("# OBJECT ID"):
-            m = re.search(r"=\s*([0-9]+)", line)
-            if m:
-                return m.group(1)
-    m = re.match(r"([0-9]+)_summary$", path.stem)
-    return m.group(1) if m else None
 
 
 def load_nss_priors_from_summary(path: Path) -> Optional[Dict[str, float]]:
@@ -1641,62 +1626,6 @@ def build_plot(
     out_png.parent.mkdir(parents=True, exist_ok=True)
     fig.savefig(out_png, dpi=180, bbox_inches="tight", pad_inches=0.06)
     plt.close(fig)
-
-
-def count_pipeline_rows(path: Path) -> int:
-    """Rows in [PIPELINE RESULTS] (or legacy table), including NaN RV epochs."""
-    text = path.read_text(encoding="utf-8", errors="replace")
-    if "[PIPELINE RESULTS]" in text:
-        lines = text.split("[PIPELINE RESULTS]", 1)[-1].splitlines()
-    else:
-        lines = text.splitlines()
-    n = 0
-    for line in lines:
-        line = line.strip()
-        if not line or line.startswith("#") or (line.startswith("[") and line.endswith("]")):
-            continue
-        if len(line.split()) >= 5:
-            n += 1
-    return n
-
-
-def discover_summary_files(output_dir: Path) -> List[Path]:
-    """One summary per Gaia source_id; prefer flat output/Gaia_DR3_<id>_summary.txt over nested stubs."""
-    if not output_dir.is_dir():
-        return []
-    out_root = output_dir.resolve()
-    by_sid: dict[str, Path] = {}
-
-    def _rank(path: Path) -> tuple:
-        flat = int(path.parent.resolve() == out_root)
-        gaia_named = int(path.name.startswith("Gaia_DR3_"))
-        try:
-            mtime = path.stat().st_mtime
-        except OSError:
-            mtime = 0.0
-        return (flat, gaia_named, count_pipeline_rows(path), mtime)
-
-    for p in output_dir.rglob("*_summary.txt"):
-        if not p.is_file():
-            continue
-        sid = parse_object_id_from_summary(p)
-        if not sid:
-            continue
-        prev = by_sid.get(sid)
-        if prev is None or _rank(p) > _rank(prev):
-            by_sid[sid] = p.resolve()
-    return sorted(by_sid.values())
-
-
-def discover_summary_path(output_dir: Path, gaia_source_id: str) -> Optional[Path]:
-    """Best summary path for one Gaia source (flat or nested under output/)."""
-    sid = str(gaia_source_id).strip()
-    if not sid:
-        return None
-    for p in discover_summary_files(output_dir):
-        if parse_object_id_from_summary(p) == sid:
-            return p
-    return None
 
 
 def newest_summary(output_dir: Path) -> Optional[Path]:

--- a/scripts/build_apf_observability_cache.py
+++ b/scripts/build_apf_observability_cache.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from darkhunter_rv.apf_observability import observability_for_summary
 from darkhunter_rv.website_table_csv import gaia_id_from_row
-from fit_apf_rv_keplerian import discover_summary_path
+from darkhunter_rv.summary_paths import discover_summary_path
 
 
 def main() -> int:

--- a/scripts/patch_summary_inclination_from_thiele_innes.py
+++ b/scripts/patch_summary_inclination_from_thiele_innes.py
@@ -12,7 +12,7 @@ from darkhunter_rv.thiele_innes_inclination import (
     metadata_inclination_is_missing,
     thiele_innes_from_metadata,
 )
-from fit_apf_rv_keplerian import discover_summary_files, parse_object_id_from_summary
+from darkhunter_rv.summary_paths import discover_summary_files, parse_object_id_from_summary
 from darkhunter_rv.gaia_utils import parse_gaia_metadata_from_star_summary
 
 


### PR DESCRIPTION
## Summary

`patch_summary_inclination_from_thiele_innes.py` imported `fit_apf_rv_keplerian`, which requires scipy. On ziggy's base conda env that fails with `ModuleNotFoundError: No module named 'scipy'`.

Moves `discover_summary_files`, `discover_summary_path`, and `parse_object_id_from_summary` to lightweight `darkhunter_rv/summary_paths.py` (numpy-free aside from gaia_utils).

## Test plan

- [x] `pytest tests/test_thiele_innes_inclination.py tests/test_patch_summary_inclination.py tests/test_fit_apf_rv_keplerian.py`
- [x] Patch script imports without scipy
- [ ] On ziggy: `PYTHONPATH=. python3 scripts/patch_summary_inclination_from_thiele_innes.py --output-dir ...`


Made with [Cursor](https://cursor.com)