### PR TITLE
Fix gaia_utils import on Python 3.9 (ziggy base env)

### DIFF
--- a/darkhunter_rv/gaia_utils.py
+++ b/darkhunter_rv/gaia_utils.py
@@ -1,4 +1,6 @@
 # gaia_utils.py
+from __future__ import annotations
+
 import logging
 import re
 from pathlib import Path


### PR DESCRIPTION
## Summary

Ziggy `(base)` Python is 3.9, which does not support PEP 604 union syntax (`dict | None`) at runtime. Importing `gaia_utils` (pulled in by the inclination patch script) failed with:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

Adds `from __future__ import annotations` to `gaia_utils.py` (same pattern as `config.py`).

## Test plan

- [x] `PYTHONPATH=. python3 -c "from scripts.patch_summary_inclination_from_thiele_innes import main"`
- [ ] On ziggy after merge: patch script runs without TypeError


Made with [Cursor](https://cursor.com)