### PR TITLE
Chunk campaign, σ_RV metrics, adaptive stack, Keplerian jitter

### DIFF
--- a/calibration/chunk_layouts/merge_adjacent_pairs.yaml
+++ b/calibration/chunk_layouts/merge_adjacent_pairs.yaml
@@ -1,0 +1,30 @@
+name: merge_adjacent_pairs
+subchunks: 1
+# Offline-evaluable: merge echelle orders (inclusive ranges) into super-chunks.
+merge_orders:
+  - [3, 4]
+  - [5, 6]
+  - [7, 8]
+  - [9, 10]
+  - [11, 12]
+  - [13, 14]
+  - [15, 16]
+  - [17, 18]
+  - [19, 20]
+  - [21, 22]
+  - [23, 24]
+  - [25, 26]
+  - [27, 28]
+  - [29, 30]
+  - [31, 32]
+  - [33, 34]
+  - [35, 36]
+  - [37, 38]
+  - [39, 40]
+  - [41, 42]
+  - [43, 44]
+  - [45, 46]
+  - [47, 48]
+  - [49, 50]
+  - [51, 52]
+min_pixels: 5

--- a/calibration/chunk_layouts/subchunks_4.yaml
+++ b/calibration/chunk_layouts/subchunks_4.yaml
@@ -1,0 +1,4 @@
+name: subchunks_4
+subchunks: 4
+min_pixels: 5
+# Requires pipeline rerun: --subchunks 4

--- a/calibration/chunk_layouts/whole_order.yaml
+++ b/calibration/chunk_layouts/whole_order.yaml
@@ -1,0 +1,4 @@
+name: whole_order
+subchunks: 1
+pixel_edges: [0.0, 1.0]
+min_pixels: 5

--- a/calibration/phase_a_baseline/README.md
+++ b/calibration/phase_a_baseline/README.md
@@ -1,0 +1,46 @@
+# Phase A baseline (RV precision framework)
+
+Frozen goals and reference metrics for regression as Phases B–E improve chunking, bias, and weights.
+
+## Goals
+
+See [`goals.yaml`](goals.yaml):
+
+- **Absolute gate:** APF vs literature pairs within 7 days, |ΔRV| < 1 km/s (ideally from `--no-bias` pipeline RVs).
+- **Relative gate:** APF vs APF pairs within 7 days; track median/p90/RMS toward 0.1 km/s after debias.
+
+## Run
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+python -m validation.rv_phase_a_baseline \
+  --master calibration/literature_rv_master.csv \
+  --summary-dir output \
+  --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' \
+  --out-dir validation_output/rv_phase_a_baseline
+```
+
+For the canonical absolute gate (no bias correction), rerun the pipeline with `--no-bias` on overlap stars, then:
+
+```bash
+python -m validation.rv_phase_a_baseline \
+  --summary-dir output \
+  --no-bias-correction-applied \
+  --out-dir validation_output/rv_phase_a_baseline_no_bias
+```
+
+## Outputs
+
+| Path | Purpose |
+|------|---------|
+| `overlap_stars.csv` | Gaia IDs with both APF and literature epochs |
+| `pair_candidates.csv` | All pairs within window, tagged by type |
+| `absolute_gate_summary.csv` | Pass rate vs 1 km/s |
+| `relative_gate_summary.csv` | Repeatability stats |
+| `per_star_gates.csv` | Per-star breakdown |
+| `plots/` | Diagnostic figures |
+| `baseline_manifest.json` | Run metadata + metric hashes for regression |
+
+## Regression
+
+Compare `validation_output/rv_phase_a_baseline/baseline_manifest.json` to [`reference_manifest.json`](reference_manifest.json). Update the reference only when intentionally accepting a new baseline (e.g. after a planned pipeline change).

--- a/calibration/phase_a_baseline/goals.yaml
+++ b/calibration/phase_a_baseline/goals.yaml
@@ -1,0 +1,10 @@
+# Phase A acceptance thresholds (frozen for regression).
+# Compare future runs via validation.rv_phase_a_baseline → baseline_manifest.json
+
+pair_window_days: 7.0
+
+# Absolute calibration: APF vs literature (external zero-point)
+absolute_gate_kms: 1.0
+
+# Relative calibration: APF vs APF repeatability (precision target after debias)
+relative_goal_kms: 0.1

--- a/calibration/phase_a_baseline/reference_manifest.json
+++ b/calibration/phase_a_baseline/reference_manifest.json
@@ -1,0 +1,79 @@
+{
+  "run_id": "baseline_2026-06-07",
+  "created_utc": "2026-06-07T20:37:06.186506+00:00",
+  "master_path": "/Users/rfoley/darkhunter/rvs/dark-hunter_rv/calibration/literature_rv_master.csv",
+  "summary_dir": "/Users/rfoley/darkhunter/rvs/dark-hunter_rv/output",
+  "diagnostics_glob": "output/Gaia_DR3_*_diagnostics.csv",
+  "bias_correction_applied": true,
+  "goals": {
+    "pair_window_days": 7.0,
+    "absolute_gate_kms": 1.0,
+    "relative_goal_kms": 0.1
+  },
+  "inventory": {
+    "n_literature_stars": 23,
+    "n_apf_stars": 153,
+    "n_overlap_stars": 8,
+    "n_literature_epochs": 417,
+    "n_apf_epochs": 641,
+    "n_pair_candidates": 371,
+    "n_apf_literature_pairs": 0,
+    "n_apf_apf_pairs": 14,
+    "n_literature_literature_pairs": 357,
+    "pair_counts_by_window": [
+      {
+        "window_days": 7.0,
+        "n_apf_literature": 0,
+        "n_apf_apf": 14,
+        "n_literature_literature": 357
+      },
+      {
+        "window_days": 30.0,
+        "n_apf_literature": 0,
+        "n_apf_apf": 19,
+        "n_literature_literature": 1321
+      },
+      {
+        "window_days": 90.0,
+        "n_apf_literature": 0,
+        "n_apf_apf": 33,
+        "n_literature_literature": 2706
+      },
+      {
+        "window_days": 180.0,
+        "n_apf_literature": 0,
+        "n_apf_apf": 33,
+        "n_literature_literature": 3481
+      },
+      {
+        "window_days": 365.0,
+        "n_apf_literature": 35,
+        "n_apf_apf": 40,
+        "n_literature_literature": 5210
+      }
+    ]
+  },
+  "absolute_gate": {
+    "n_pairs": 0,
+    "threshold_kms": 1.0
+  },
+  "relative_gate": {
+    "n_pairs": 14,
+    "n_stars": 4,
+    "goal_kms": 0.1,
+    "frac_below_goal": 0.2857142857142857,
+    "median_abs_delta_rv_kms": 0.3027120161133041,
+    "p90_abs_delta_rv_kms": 16.27458855284411,
+    "max_abs_delta_rv_kms": 19.511417856964147,
+    "rms_delta_rv_kms": 8.750616433739443
+  },
+  "output_files": {
+    "overlap_stars.csv": "285080595ddd6d9ebaae1b282498a2e2d915a856136744c2ce28b460ebd2c715",
+    "pair_candidates.csv": "9f138d50063f30366e9e64ce96ef16765e5e1e1f430f8f2460b206d15db8375e",
+    "absolute_gate_summary.csv": "f08a677dbf446c933ececd6526d89e99bd9b3f4fb2cb004f68ce763c465352ca",
+    "relative_gate_summary.csv": "19af3bbd73307a907ed720a6bba495d1f4e3781d7e7b0061a92f90d5f8061108",
+    "per_star_gates.csv": "0a0acd12b05bd84e68fddc77019fd9080ba9c5bfd6f8490d726b41beacdd9a47",
+    "baseline_manifest.json": "c0494d8d7beaa1b949116e5a5acb40342fe7ece78b85bc1b28464c63ee3eb747",
+    "REPORT.md": "1aa2c425ac4bb5936c574e502ec3ebbdd13dd440411a54530a0a6d684b5c9222"
+  }
+}

--- a/darkhunter_rv/chunking.py
+++ b/darkhunter_rv/chunking.py
@@ -1,7 +1,7 @@
 """Split orders into wavelength/pixel sub-chunks for robust RV."""
 from __future__ import annotations
 
-from typing import Any, Dict, Iterator, List, Tuple
+from typing import Dict, Iterator, List, Tuple
 
 import numpy as np
 
@@ -30,3 +30,131 @@ def iter_order_chunks(
             if i1 - i0 < 5:
                 continue
             yield f"{order}_{si}", w[i0:i1], f[i0:i1], e[i0:i1]
+
+
+def iter_order_chunks_with_edges(
+    spec_data: Dict[int, Dict[str, List]],
+    bad_orders: List[int],
+    pixel_edges: np.ndarray | List[float],
+    *,
+    min_pixels: int = 5,
+) -> Iterator[Tuple[str, np.ndarray, np.ndarray, np.ndarray]]:
+    """
+    Yield chunks using N+1 pixel fractional edges in [0, 1].
+
+    ``pixel_edges`` has length N+1; chunk i spans [edge[i], edge[i+1]).
+    """
+    edges_frac = np.asarray(pixel_edges, float)
+    if len(edges_frac) < 2:
+        raise ValueError("pixel_edges requires at least two values (N+1 edges for N chunks)")
+    for order in sorted(spec_data.keys()):
+        if order in bad_orders:
+            continue
+        data = spec_data[order]
+        w = np.array(data["wavelength"], float)
+        f = np.array(data["flux"], float)
+        e = np.array(data["eflux"], float)
+        n = len(w)
+        if n < min_pixels:
+            continue
+        idx_edges = np.round(edges_frac * n).astype(int)
+        idx_edges[0] = 0
+        idx_edges[-1] = n
+        for si in range(len(idx_edges) - 1):
+            i0, i1 = int(idx_edges[si]), int(idx_edges[si + 1])
+            if i1 - i0 < min_pixels:
+                continue
+            key = str(order) if len(idx_edges) == 2 else f"{order}_{si}"
+            yield key, w[i0:i1], f[i0:i1], e[i0:i1]
+
+
+def parse_chunk_key(chunk_key: str) -> tuple[int | None, int, str]:
+    """
+    Parse ``chunk_key`` into (echelle_order, sort_index, kind).
+
+    - ``"15"`` → (15, 15, "order")
+    - ``"15_2"`` → (15, 15, "subchunk")  (sub index in sort tie-break)
+    - ``"merge_3"`` → (None, 3, "merge")
+    """
+    parts = str(chunk_key).split("_")
+    if parts and parts[0] == "merge":
+        try:
+            gi = int(parts[1])
+        except (IndexError, ValueError):
+            gi = 0
+        return None, gi, "merge"
+    try:
+        order = int(parts[0])
+    except ValueError:
+        return None, 0, "unknown"
+    sub = int(parts[1]) if len(parts) > 1 else 0
+    kind = "subchunk" if sub > 0 or len(parts) > 1 else "order"
+    return order, order * 100 + sub, kind
+
+
+def bias_order_from_chunk_key(chunk_key: str) -> int | None:
+    """Echelle order for per-order bias lookup, or None for merged chunks."""
+    order, _, _ = parse_chunk_key(chunk_key)
+    return order
+
+
+def chunk_sort_key(chunk_key: str) -> tuple[int, int, int]:
+    """Sort key for chunk identifiers (orders, subchunks, merge groups)."""
+    order, sort_idx, kind = parse_chunk_key(chunk_key)
+    kind_rank = {"order": 0, "subchunk": 0, "merge": 1}.get(kind, 2)
+    primary = sort_idx if order is None else order
+    return (kind_rank, primary, sort_idx)
+
+
+def telluric_pixel_edges(
+    wave: np.ndarray,
+    *,
+    min_pixels: int = 5,
+    max_interior_edges: int = 3,
+) -> np.ndarray:
+    """
+    N+1 fractional pixel edges splitting an order at telluric/clean boundaries.
+
+    Uses contamination bands from ``qc.rv_contamination_bands()``.
+    Falls back to [0, 1] when the order is too short or fully telluric.
+    """
+    from darkhunter_rv import qc
+
+    w = np.asarray(wave, float)
+    n = len(w)
+    if n < 2 * min_pixels:
+        return np.array([0.0, 1.0])
+    contam = qc.wavelength_band_mask(w, qc.rv_contamination_bands())
+    if not np.any(contam):
+        return np.array([0.0, 1.0])
+    if np.all(contam):
+        return np.array([0.0, 1.0])
+
+    # Transition indices where contamination flag changes.
+    transitions = [0]
+    for i in range(1, n):
+        if bool(contam[i]) != bool(contam[i - 1]):
+            transitions.append(i)
+    transitions.append(n)
+    if len(transitions) <= 2:
+        return np.array([0.0, 1.0])
+
+    # Fractional edges at transitions; merge tiny segments into neighbours.
+    frac_edges = [t / n for t in transitions]
+    merged: list[float] = [0.0]
+    for i in range(1, len(frac_edges) - 1):
+        e = frac_edges[i]
+        seg_len = frac_edges[i + 1] - frac_edges[i - 1] if i + 1 < len(frac_edges) else 1.0
+        if (frac_edges[i] - frac_edges[i - 1]) * n >= min_pixels and (frac_edges[i + 1] - frac_edges[i]) * n >= min_pixels:
+            if e not in merged:
+                merged.append(e)
+    merged.append(1.0)
+    merged = sorted(set(merged))
+    if len(merged) > max_interior_edges + 2:
+        # Keep endpoints + evenly subsample interior transition edges.
+        interior = merged[1:-1]
+        idx = np.linspace(0, len(interior) - 1, max_interior_edges).astype(int)
+        merged = [0.0] + [interior[i] for i in idx] + [1.0]
+    if len(merged) < 2:
+        return np.array([0.0, 1.0])
+    return np.asarray(merged, float)

--- a/darkhunter_rv/io_utils.py
+++ b/darkhunter_rv/io_utils.py
@@ -7,7 +7,7 @@ import pandas as pd
 import astropy.io.fits as fits
 from astropy.time import Time
 from pathlib import Path
-from . import config
+from . import chunking, config
 
 def extract_mjd_from_header(header, instrument=None):
     if instrument is not None and hasattr(instrument, "header_keywords"):
@@ -212,10 +212,7 @@ def write_order_results(order_data, input_filename):
     outfile = config.OUTPUT_DIR / f"{base}_orders.txt"
     with open(outfile, "w") as f:
         f.write("# Order | RV (km/s) | RV Error (km/s)\n")
-        def _sort_key(k):
-            parts = str(k).split("_")
-            return tuple(int(x) for x in parts)
-        for order in sorted(order_data.keys(), key=_sort_key):
+        for order in sorted(order_data.keys(), key=chunking.chunk_sort_key):
             d = order_data[order]
             rv = f"{d['best_rv']:.8f}" if np.isfinite(d['best_rv']) else "NaN"
             err = f"{d['best_rv_err']:.8f}" if np.isfinite(d['best_rv_err']) else "NaN"
@@ -340,7 +337,7 @@ def write_star_summary(obj_id, gaia_data, pipeline_results):
 
         # 3. Pipeline Data (merged across per-spectrum pipeline runs)
         f.write("\n[PIPELINE RESULTS]\n")
-        f.write("# File | MJD | RV (km/s) | Err (km/s) | RMS | Fallback?\n")
+        f.write("# File | MJD | RV (km/s) | Err (km/s) | wRMS (km/s) | Fallback?\n")
         for bn in ordered:
             f.write(merged[bn] + "\n")
 

--- a/darkhunter_rv/pipeline.py
+++ b/darkhunter_rv/pipeline.py
@@ -102,6 +102,25 @@ def _rv_kms_from_hb_joint_line_center(bundle: dict) -> float:
     return float(config.C_KMS * (ctr - rv_core.HB_REST_A) / rv_core.HB_REST_A)
 
 
+def _weighted_rms(
+    rv: np.ndarray,
+    er: np.ndarray,
+    *,
+    mu_weighted: float | None = None,
+) -> float:
+    """Inverse-variance weighted RMS of chunk RVs about the weighted mean."""
+    rv = np.asarray(rv, float).ravel()
+    er = np.asarray(er, float).ravel()
+    n = int(rv.size)
+    if n == 0:
+        return float("nan")
+    if n == 1:
+        return 0.0
+    w = 1.0 / (er**2 + 1e-9)
+    mu = float(mu_weighted) if mu_weighted is not None else float(np.average(rv, weights=w))
+    return float(np.sqrt(np.average((rv - mu) ** 2, weights=w)))
+
+
 def _mask_ccf_stack_error_inflated(
     rv: np.ndarray,
     er: np.ndarray,
@@ -112,7 +131,7 @@ def _mask_ccf_stack_error_inflated(
     """
     Inverse-variance formal error can be far too small when a few chunks have optimistic Gaussian
     ``sigma_mu`` (broad/noisy lines) while chunk RVs disagree. Floor the combined error using spread
-    of the chunk RVs: MAD and std-based terms, plus **RMS of residuals about the weighted mean**
+    of the chunk RVs: MAD and std-based terms, plus **weighted RMS of residuals about the weighted mean**
     divided by ``sqrt(N_orders)`` (chunk count), as requested for exposure-level mask stacks.
     """
     rv = np.asarray(rv, float).ravel()
@@ -122,7 +141,7 @@ def _mask_ccf_stack_error_inflated(
     if n < 2 or er.size != n:
         return formal
     mu = float(mu_weighted)
-    resid_rms = float(np.sqrt(np.mean((rv - mu) ** 2)))
+    resid_rms = _weighted_rms(rv, er, mu_weighted=mu)
     from_rms = resid_rms / np.sqrt(n)
     med = float(np.median(rv))
     mad = float(np.median(np.abs(rv - med))) * 1.4826
@@ -679,7 +698,15 @@ def process_spectrum(
     )
 
     chunk_preps: list[dict] = []
-    for chunk_key, w, f, e in chunking.iter_order_chunks(spec_data, instrument.bad_orders, args.subchunks):
+    chunk_layout_path = getattr(args, "chunk_layout", None)
+    if chunk_layout_path:
+        from validation.chunk_layout import load_chunk_layout, iter_order_chunks_from_layout
+
+        layout = load_chunk_layout(chunk_layout_path)
+        chunk_iter = iter_order_chunks_from_layout(spec_data, instrument.bad_orders, layout)
+    else:
+        chunk_iter = chunking.iter_order_chunks(spec_data, instrument.bad_orders, args.subchunks)
+    for chunk_key, w, f, e in chunk_iter:
         if len(w) < 10:
             continue
         try:
@@ -711,7 +738,8 @@ def process_spectrum(
         nw, nf, ne = prep["nw"], prep["nf"], prep["ne"]
         line_obs = rv_core.mask_line_flux_in_excluded_wavelengths(nw, 1.0 - nf)
 
-        bvec = bias.get(int(str(chunk_key).split("_")[0]), [0.0, 0.0, 0.0])
+        b_order = chunking.bias_order_from_chunk_key(chunk_key)
+        bvec = bias.get(b_order, [0.0, 0.0, 0.0]) if b_order is not None else [0.0, 0.0, 0.0]
 
         tell_frac = qc.telluric_fraction(nw)
         mask_line_count = qc.mask_line_count_in_chunk(nw, mw if "mw" in locals() else None)
@@ -751,7 +779,7 @@ def process_spectrum(
             rv_m -= b0
             err_m = float(np.sqrt(err_m**2 + b1**2 + b2**2)) if np.isfinite(err_m) else err_m
             gauss_ok_m = np.isfinite(err_m) and err_m < 1e29
-            ord_num = int(str(chunk_key).split("_")[0])
+            _, ord_num, _ = chunking.parse_chunk_key(chunk_key)
             if vels_m is not None and ccf_m is not None and ord_num not in order_mask_ccf:
                 peak_for_plot = float(rv_m) if np.isfinite(rv_m) else float("nan")
                 if gauss_plot_ccf is not None:
@@ -1043,7 +1071,8 @@ def process_spectrum(
                 continue
             rv_ord = None
             for ck, rec in rv_results.items():
-                if int(str(ck).split("_")[0]) == int(o):
+                o_ck, _, _ = chunking.parse_chunk_key(ck)
+                if o_ck is not None and int(o_ck) == int(o):
                     rv_ord = float(rec["best_rv"])
                     break
             plotting.plot_order_strong_line_panels(
@@ -1081,7 +1110,7 @@ def process_spectrum(
             wts = 1.0 / (err_arr**2 + 1e-9)
             mean_rv = float(np.average(rv_arr, weights=wts))
             mean_err = float(np.sqrt(1.0 / np.sum(wts)))
-            rms = float(np.std(rv_arr))
+            rms = _weighted_rms(rv_arr, err_arr, mu_weighted=mean_rv)
 
             mask_only = len(meth_arr) > 0 and all(str(m) == "mask_ccf" for m in meth_arr.tolist())
             if (not use_fft_primary) and mask_only:
@@ -1127,7 +1156,7 @@ def process_spectrum(
             )
 
     if plot_root and len(rv_arr) > 0 and len(keys_arr) == len(rv_arr) and not plots_skip_order_summary:
-        ord_nums = np.array([int(str(k).split("_")[0]) for k in keys_arr], dtype=float)
+        ord_nums = np.array([chunking.parse_chunk_key(str(k))[1] for k in keys_arr], dtype=float)
         plotting.plot_rv_vs_order(
             ord_nums,
             rv_arr,
@@ -1389,7 +1418,11 @@ def process_spectrum(
 
     # Fill residual/scatter diagnostics + exposure stack metadata
     if diagnostics_rows:
-        chunk_scatter = float(np.std(rv_arr)) if len(rv_arr) > 1 else (0.0 if len(rv_arr) == 1 else np.nan)
+        chunk_scatter = (
+            _weighted_rms(rv_arr, err_arr, mu_weighted=float(mean_rv))
+            if len(rv_arr) > 1
+            else (0.0 if len(rv_arr) == 1 else np.nan)
+        )
         for row in diagnostics_rows:
             ck = str(row.get("chunk_key", ""))
             meth = str(row.get("method", ""))
@@ -1523,6 +1556,12 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument("--continuum-mode", choices=["spline", "blaze"], default="spline")
     parser.add_argument("--subchunks", type=int, default=1, help="Split each order into N pixel chunks")
+    parser.add_argument(
+        "--chunk-layout",
+        type=Path,
+        default=None,
+        help="YAML chunk layout (overrides --subchunks when set). See validation/chunk_layout.py.",
+    )
     parser.add_argument("--max-chunk-err", type=float, default=50.0, help="Skip chunk RVs with err > this (km/s)")
     parser.add_argument("--qc-config", default="order_chunk_qc.yaml", help="QC threshold YAML")
     parser.add_argument("--write-qc-config", action="store_true", help="Write default QC config if missing")

--- a/darkhunter_rv/rv_keplerian_plots.py
+++ b/darkhunter_rv/rv_keplerian_plots.py
@@ -198,6 +198,7 @@ def _plot_points(
     *,
     include_literature: bool,
     y_values: Optional[np.ndarray] = None,
+    yerr: Optional[np.ndarray] = None,
 ) -> bool:
     plotted = False
     t = np.array([p.mjd for p in points], dtype=float)
@@ -205,7 +206,10 @@ def _plot_points(
         y = np.array([p.rv for p in points], dtype=float)
     else:
         y = np.asarray(y_values, dtype=float)
-    yerr = np.array([p.rms for p in points], dtype=float)
+    if yerr is None:
+        yerr = np.array([p.rv_err for p in points], dtype=float)
+    else:
+        yerr = np.asarray(yerr, dtype=float)
 
     for tel, marker in TEL_MARKER.items():
         idx = [
@@ -329,14 +333,18 @@ def _variant_param_lines(
         ecc = float(vrep["e"])
         m2sini = _m2sini_for_variant(vrep, m1_msun)
         label = FIT_VARIANT_LABEL[key]
+        jit = vrep.get("jitter_kms")
+        jit_s = ""
+        if jit is not None and np.isfinite(jit) and float(jit) > 0:
+            jit_s = f",  σ_jit = {float(jit):.3f} km/s"
         if m2sini is not None:
-            lines.append(f"{label}:  P = {p_days} d,  e = {ecc:.3f},  M₂ sin i = {m2sini:.4f} M☉")
+            lines.append(f"{label}:  P = {p_days} d,  e = {ecc:.3f},  M₂ sin i = {m2sini:.4f} M☉{jit_s}")
         else:
             fm = vrep.get("mass_function_msun")
             if fm is None or not np.isfinite(fm):
                 fm = _fitmod().mass_function_msun(vrep["P_days"], vrep["K_kms"], vrep["e"])
             fm_s = f"{float(fm):.4f}" if fm is not None and np.isfinite(fm) else "—"
-            lines.append(f"{label}:  P = {p_days} d,  e = {ecc:.3f},  f(M) = {fm_s} M☉")
+            lines.append(f"{label}:  P = {p_days} d,  e = {ecc:.3f},  f(M) = {fm_s} M☉{jit_s}")
     return lines
 
 
@@ -367,7 +375,8 @@ def plot_rv_data_only(
 
     fig, ax = plt.subplots(figsize=(10.5, 4.9))
     _shade_apf_window(ax, t_start, t_end, report)
-    _plot_points(ax, pts, include_literature=False)
+    yerr = _fitmod().effective_yerr_for_points(pts, report)
+    _plot_points(ax, pts, include_literature=False, yerr=yerr)
 
     y_lim = _y_limits_data_and_models(t, y, [])
     ax.set_ylim(*y_lim)
@@ -404,12 +413,13 @@ def plot_multi_fit(
 
     t = np.array([p.mjd for p in points], dtype=float)
     y = np.array([p.rv for p in points], dtype=float)
+    yerr = _fitmod().effective_yerr_for_points(points, report)
     t_ref = float(report["t_ref_mjd"])
     t_lo, t_hi = _xlim_from_data(t, report)
     t_dense = np.linspace(t_lo, t_hi, 2000)
 
     fig, ax = plt.subplots(figsize=(10.8, 5.2))
-    _plot_points(ax, points, include_literature=True)
+    _plot_points(ax, points, include_literature=True, yerr=yerr)
     curves = _plot_fit_curves(ax, t_dense, fit_variants, t_ref)
 
     y_lim = _y_limits_data_and_models(t, y, curves)
@@ -467,7 +477,7 @@ def plot_fit_residuals(
 
     t = np.array([p.mjd for p in points], dtype=float)
     y = np.array([p.rv for p in points], dtype=float)
-    yerr = np.array([p.rms for p in points], dtype=float)
+    yerr = _fitmod().effective_yerr_for_points(points, report)
     t_ref = float(report["t_ref_mjd"])
     t_lo, t_hi = _xlim_from_data(t, report)
     t_dense = np.linspace(t_lo, t_hi, 2000)
@@ -501,7 +511,7 @@ def plot_fit_residuals(
     ax_txt = fig.add_subplot(gs[2])
     ax_txt.axis("off")
 
-    _plot_points(ax_top, points, include_literature=True)
+    _plot_points(ax_top, points, include_literature=True, yerr=yerr)
     curves = _plot_fit_curves(ax_top, t_dense, fit_variants, t_ref)
     y_lim = _y_limits_data_and_models(t, y, curves)
     ax_top.set_ylim(*y_lim)
@@ -518,7 +528,7 @@ def plot_fit_residuals(
     plt.setp(ax_top.get_xticklabels(), visible=False)
 
     ax_bot.axhline(0.0, color="0.4", lw=1.0, zorder=1)
-    _plot_points(ax_bot, points, include_literature=True, y_values=resid_data)
+    _plot_points(ax_bot, points, include_literature=True, y_values=resid_data, yerr=yerr)
     for key in FIT_VARIANT_ORDER:
         if key == "free" or key not in dense_map:
             continue

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,6 +8,7 @@
 | [operations.md](operations.md) | Calibration (`run_calibration_setup`), production (`run_production_remaining`), env vars, cron |
 | [rv_methods_evaluation.md](rv_methods_evaluation.md) | Method validity, adopted-RV cascade, overlap reports |
 | [validation_playbook.md](validation_playbook.md) | Validation / campaign workflows |
+| [plans/INDEX.md](plans/INDEX.md) | RV pipeline GitHub step tracker (issues #37–#45) |
 | [broad_line_method.md](broad_line_method.md) | Broad-line / Hβ methodology notes |
 
 **Validation CLIs** (run from repo root with `PYTHONPATH=.` or `python -m …` as shown):

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -1,19 +1,21 @@
 # RV pipeline step tracker (GitHub)
 
-Full step plans are local: `.cursor/plans/rv-pipeline/steps/`. Workflow: `.cursor/plans/rv-pipeline/WORKFLOW.md`.
+**Step plans (rendered preview in IDE):** [steps/](steps/) — open any `.md` and use **Markdown: Open Preview** (Cmd+Shift+V).
 
-Orchestrator: `.cursor/plans/rv_pipeline_master_plan_8447f2cd.plan.md`
+Orchestrator (local): `.cursor/plans/rv_pipeline_master_plan_8447f2cd.plan.md`
 
-| Step | Status | Issue | Branch(es) |
-|------|--------|-------|------------|
-| 00 Literature RV master | completed | [#37](https://github.com/astrofoley/dark-hunter_rv/issues/37) | `step/00-literature-rv-master` |
-| 01 Benchmark cool precision | in_progress | [#38](https://github.com/astrofoley/dark-hunter_rv/issues/38) | `step/01-benchmark-cool-precision` |
-| 02 Chunk weights / subchunks | pending | [#39](https://github.com/astrofoley/dark-hunter_rv/issues/39) | `step/02a-subchunk-study`, `step/02b-trust-weights-stack` |
-| 03 Method fusion / coverage | pending | [#40](https://github.com/astrofoley/dark-hunter_rv/issues/40) | `step/03-method-fusion-coverage` |
-| 04 Adopted-RV match plots | pending | [#41](https://github.com/astrofoley/dark-hunter_rv/issues/41) | `step/04-adopted-rv-match-plots` |
-| 05 Short-pair + epoch CCF | pending | [#42](https://github.com/astrofoley/dark-hunter_rv/issues/42) | `step/05a-short-pair-calibration`, `step/05b-epoch-ccf-consistency` |
-| 06 Strong-line line list | pending | [#43](https://github.com/astrofoley/dark-hunter_rv/issues/43) | `step/06-strong-line-line-list` |
-| 07 SB2 search | pending | [#44](https://github.com/astrofoley/dark-hunter_rv/issues/44) | `step/07a-sb2-detection`, `step/07b-sb2-reporting` |
-| 08 External RV cross-check | pending | [#45](https://github.com/astrofoley/dark-hunter_rv/issues/45) | `step/08-external-rv-crosscheck` |
+Workflow: [WORKFLOW.md](WORKFLOW.md)
 
-Update this file when an issue closes or a step status changes.
+| Step | Plan | Status | Issue | Branch(es) | Merged |
+|------|------|--------|-------|------------|--------|
+| 00 Literature RV master | [steps/00-literature-rv-master.md](steps/00-literature-rv-master.md) | completed | [#37](https://github.com/astrofoley/dark-hunter_rv/issues/37) | `step/00-literature-rv-master` | 2026-06-07 ([#46](https://github.com/astrofoley/dark-hunter_rv/pull/46)) |
+| 01 Benchmark cool precision | [steps/01-benchmark-cool-precision.md](steps/01-benchmark-cool-precision.md) | in_progress | [#38](https://github.com/astrofoley/dark-hunter_rv/issues/38) | `step/01-benchmark-cool-precision` | — |
+| 02 Chunk weights / subchunks | [steps/02-chunk-weights-subchunks.md](steps/02-chunk-weights-subchunks.md) | pending | [#39](https://github.com/astrofoley/dark-hunter_rv/issues/39) | `step/02a-subchunk-study`, `step/02b-trust-weights-stack` | — |
+| 03 Method fusion / coverage | [steps/03-method-fusion-coverage.md](steps/03-method-fusion-coverage.md) | pending | [#40](https://github.com/astrofoley/dark-hunter_rv/issues/40) | `step/03-method-fusion-coverage` | — |
+| 04 Adopted-RV match plots | [steps/04-adopted-rv-match-plots.md](steps/04-adopted-rv-match-plots.md) | pending | [#41](https://github.com/astrofoley/dark-hunter_rv/issues/41) | `step/04-adopted-rv-match-plots` | — |
+| 05 Short-pair + epoch CCF | [steps/05-short-pair-epoch-ccf.md](steps/05-short-pair-epoch-ccf.md) | pending | [#42](https://github.com/astrofoley/dark-hunter_rv/issues/42) | `step/05a-short-pair-calibration`, `step/05b-epoch-ccf-consistency` | — |
+| 06 Strong-line line list | [steps/06-strong-line-line-list.md](steps/06-strong-line-line-list.md) | pending | [#43](https://github.com/astrofoley/dark-hunter_rv/issues/43) | `step/06-strong-line-line-list` | — |
+| 07 SB2 search | [steps/07-sb2-search.md](steps/07-sb2-search.md) | pending | [#44](https://github.com/astrofoley/dark-hunter_rv/issues/44) | `step/07a-sb2-detection`, `step/07b-sb2-reporting` | — |
+| 08 External RV cross-check | [steps/08-external-rv-crosscheck.md](steps/08-external-rv-crosscheck.md) | pending | [#45](https://github.com/astrofoley/dark-hunter_rv/issues/45) | `step/08-external-rv-crosscheck` | — |
+
+Update this file when an issue closes or a step status changes. Keep in sync with `.cursor/plans/rv-pipeline/INDEX.md`.

--- a/docs/plans/WORKFLOW.md
+++ b/docs/plans/WORKFLOW.md
@@ -1,0 +1,55 @@
+# RV pipeline step workflow
+
+**Repo-visible step plans:** [steps/](steps/) (mirror of `.cursor/plans/rv-pipeline/steps/` for Markdown preview and GitHub browsing). Update both when a step changes.
+
+GitHub **issues** and **branches** track shared progress.
+
+## A. Start a step
+
+1. Read [INDEX.md](INDEX.md) — confirm dependencies are completed.
+2. Open `steps/NN-<slug>.md`; set frontmatter `status: in_progress`.
+3. Comment on the GitHub issue with the branch name.
+4. From repo root:
+
+   ```bash
+   cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+   git checkout main && git pull
+   git checkout -b step/NN-<slug>
+   ```
+
+5. Work through implementation task checkboxes in the step plan.
+
+## B. Finish a step (merge PR)
+
+1. **Step md:** `status: completed`; check boxes; record issue # and merged branch (both `docs/plans/steps/` and `.cursor/plans/rv-pipeline/steps/`).
+2. **Master plan** `.cursor/plans/rv_pipeline_master_plan_8447f2cd.plan.md`:
+   - Set matching frontmatter `todos[].status: completed`
+   - Update phase / “What has been implemented” if needed
+3. **INDEX.md** (repo + `.cursor/plans/rv-pipeline/`): update status, issue #, branch, merge date.
+4. **Legacy plans** (listed in step `related_legacy_plans`): mark relevant todos or add “superseded by step NN”.
+5. **Repo docs** (`repo_docs_to_update` in step): add commands only when user-facing behavior changes.
+6. Close GitHub issue with merge summary.
+
+## C. Branch convention
+
+- Prefix: `step/`
+- One logical step per PR; sub-branches `step/02a-...`, `step/02b-...` for large steps
+- PR title: `step/NN: <title>`
+- PR body: `Closes #<issue>` + plan path `docs/plans/steps/NN-<slug>.md`
+
+## D. Cursor session
+
+Attach `@docs/plans/steps/NN-<slug>.md` (preview) or `@.cursor/plans/rv-pipeline/steps/NN-<slug>.md` (canonical local).
+
+## E. Propagation map (legacy plans on completion)
+
+| Step | Legacy `.cursor/plans/` |
+|------|-------------------------|
+| 01 | `rv_pipeline_roadmap_3a7b3787`, `rv_methods_evaluation_plan_fcd09d94` |
+| 02 | `rv_pipeline_roadmap_3a7b3787`, `rv_mismatch_diagnosis_24a11615`, `pr_repo_organization_326c519c` |
+| 03 | `rv_method_fusion_plan_b4fd46f0`, `rv_methods_evaluation_plan_fcd09d94`, `three_rv_methods_e1b72701` |
+| 04 | `legacy_plot_and_ccf_qc_2f3b70cd`, `gaia_cache_and_ccf_diagnostics_2e731512` |
+| 05 | `rv_pipeline_roadmap_3a7b3787`, `pr_repo_organization_326c519c` |
+| 06 | `template_grid_and_hβ_rv_dff5dfce`, `three_rv_methods_e1b72701` |
+| 07 | `rv_pipeline_roadmap_3a7b3787` |
+| 08 | `pipeline_legacy_diagnostics_e98cdb98` |

--- a/docs/plans/steps/00-literature-rv-master.md
+++ b/docs/plans/steps/00-literature-rv-master.md
@@ -1,0 +1,70 @@
+---
+step_id: 00-literature-rv-master
+phase: E
+status: completed
+github_issue: https://github.com/astrofoley/dark-hunter_rv/issues/37
+branches:
+  - step/00-literature-rv-master
+depends_on: []
+blocks: [08-external-rv-crosscheck]
+master_todo_id: literature-rv-master
+related_legacy_plans: []
+repo_docs_to_update: []
+---
+
+# Step 00: Literature RV master table
+
+## Goal / science outcome
+
+Single committed reference of published RV epochs from compact-object follow-up papers for external validation and orbit-fit QA.
+
+## Scope (in) / non-goals (out)
+
+**In:** Merge El-Badry 2024 population + Gaia NS1 + Gaia BH1 + Simon 2026 subset into one CSV with uniform columns and reference metadata.
+
+**Out:** Pipeline comparison CLI (step 08); automatic Gaia TAP fetch of these RVs.
+
+## Prerequisites
+
+Local arXiv source trees under `~/Downloads/arXiv-*`.
+
+## Implementation tasks
+
+- [x] `validation/build_literature_rv_master.py` parser and merger
+- [x] `calibration/literature_rv_master.csv` (417 rows, 23 systems, 4 references)
+- [x] `tests/validation/test_literature_rv_master.py`
+- [x] Land on branch `step/00-literature-rv-master` via PR
+
+## Key files
+
+- `/Users/rfoley/darkhunter/rvs/dark-hunter_rv/calibration/literature_rv_master.csv`
+- `/Users/rfoley/darkhunter/rvs/dark-hunter_rv/validation/build_literature_rv_master.py`
+
+## Commands
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+python -m validation.build_literature_rv_master
+PYTHONPATH=. python -m pytest tests/validation/test_literature_rv_master.py -q
+```
+
+## Acceptance criteria
+
+- 417 observations across 4 references; J1432-1021 present in both population and NS1 papers with distinct `reference_key`
+- Every row has reference metadata; missing columns empty where source table lacks them
+- Rebuild script is idempotent from default Download paths
+
+## Tests / validation
+
+`tests/validation/test_literature_rv_master.py` (5 tests).
+
+## Propagation checklist (on merge)
+
+- [x] Master plan todo `literature-rv-master` → completed
+- [x] PR https://github.com/astrofoley/dark-hunter_rv/pull/46 (merged 2026-06-07)
+- [x] INDEX.md merge date (2026-06-07)
+- [x] GitHub issue #37 closed (auto via Closes on merge)
+
+## Open decisions
+
+None.

--- a/docs/plans/steps/01-benchmark-cool-precision.md
+++ b/docs/plans/steps/01-benchmark-cool-precision.md
@@ -37,9 +37,12 @@ Quantify current APF mask-CCF precision on cool, high-S/N calibration spectra an
 
 - [x] Define metric: per-exposure chunk scatter (initial); night-pair / jackknife deferred
 - [x] `validation/benchmark_cool_precision.py` for cool-star high-S/N subset
+- [x] Phase A: `validation/rv_phase_a_baseline.py` — overlap inventory, absolute (APF–lit) and relative (APF–APF) gates, diagnostic plots
+- [x] Frozen baseline: `calibration/phase_a_baseline/` (goals.yaml, reference_manifest.json)
 - [ ] Produce `validation_output/benchmark_cool_precision/` tables + plots (RMS vs log10 mask CCF S/N)
 - [ ] Document 0.1 km/s goal interpretation (single epoch vs night-mean) in report README or playbook
 - [ ] Record baseline numbers in step md for step 02 comparison
+- [ ] `--no-bias` pipeline rerun on overlap stars for canonical absolute gate
 
 ## Key files
 
@@ -60,7 +63,19 @@ python -m validation.rv_method_overlap_report --diagnostics-glob 'output/Gaia_DR
 
 - Report identifies median/p90 chunk scatter for cool stars with `log10(median_mask_ccf_peak_snr) > 1.0`
 - Explicit statement: met / not met / how far from 0.1 km/s goal
+- Phase A overlap list + gate reports under `validation_output/rv_phase_a_baseline/`
 - Reproducible one-command recipe in `docs/validation_playbook.md`
+
+### Phase A baseline (2026-06-07, bias applied)
+
+| Metric | Value |
+|--------|-------|
+| Overlap stars (APF ∩ literature) | 8 |
+| APF–literature pairs (7 d window) | 0 (min separation 189–971 d) |
+| APF–APF pairs (7 d) | 14 across 4 stars |
+| Relative gate median \|ΔRV\| | 0.30 km/s |
+| Relative gate p90 \|ΔRV\| | 16.3 km/s (outliers: Gaia BH1, J1449+6919) |
+| Stars with good relative precision | J2102+3703 (~0.009 km/s), J0824+5254 (~0.30 km/s) |
 
 ## Tests / validation
 

--- a/docs/plans/steps/01-benchmark-cool-precision.md
+++ b/docs/plans/steps/01-benchmark-cool-precision.md
@@ -1,0 +1,79 @@
+---
+step_id: 01-benchmark-cool-precision
+phase: C
+status: in_progress
+github_issue: https://github.com/astrofoley/dark-hunter_rv/issues/38
+branches:
+  - step/01-benchmark-cool-precision
+depends_on: []
+blocks: [02-chunk-weights-subchunks]
+master_todo_id: benchmark-cool-precision
+related_legacy_plans:
+  - rv_pipeline_roadmap_3a7b3787.plan.md
+  - rv_methods_evaluation_plan_fcd09d94.plan.md
+repo_docs_to_update:
+  - docs/validation_playbook.md
+---
+
+# Step 01: Benchmark cool high-S/N mask precision
+
+## Goal / science outcome
+
+Quantify current APF mask-CCF precision on cool, high-S/N calibration spectra and document gap to **<0.1 km/s** per-epoch target.
+
+## Scope (in) / non-goals (out)
+
+**In:** Repeatability / chunk-scatter metrics on bias-training or overlap cool-star set; report panels vs S/N; baseline before chunk-weight changes.
+
+**Out:** Implementing trust weights (step 02); method fusion (step 03).
+
+## Prerequisites
+
+- Calibration list (`calibration/bias_train.txt` or equivalent)
+- Pipeline run with bias on, `--run-all-methods`
+- Existing overlap/diagnostics reports
+
+## Implementation tasks
+
+- [x] Define metric: per-exposure chunk scatter (initial); night-pair / jackknife deferred
+- [x] `validation/benchmark_cool_precision.py` for cool-star high-S/N subset
+- [ ] Produce `validation_output/benchmark_cool_precision/` tables + plots (RMS vs log10 mask CCF S/N)
+- [ ] Document 0.1 km/s goal interpretation (single epoch vs night-mean) in report README or playbook
+- [ ] Record baseline numbers in step md for step 02 comparison
+
+## Key files
+
+- `validation/rv_method_diagnostics_report.py`
+- `validation/rv_method_overlap_report.py`
+- `darkhunter_rv/pipeline.py` (`chunk_scatter_kms`, mask stack)
+- `validation/build_bias_set.py`
+
+## Commands
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+python -m validation.run_calibration_setup --bias-list calibration/bias_train.txt ...
+python -m validation.rv_method_overlap_report --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' ...
+```
+
+## Acceptance criteria
+
+- Report identifies median/p90 chunk scatter for cool stars with `log10(median_mask_ccf_peak_snr) > 1.0`
+- Explicit statement: met / not met / how far from 0.1 km/s goal
+- Reproducible one-command recipe in `docs/validation_playbook.md`
+
+## Tests / validation
+
+- No new unit tests required unless adding pure metric helpers
+- Manual: rerun on fixed diagnostics glob, compare CSV hash or key statistics
+
+## Propagation checklist (on merge)
+
+- [ ] Master todo `benchmark-cool-precision` → completed
+- [ ] INDEX.md status + issue closed
+- [ ] Legacy plans: note benchmark baseline in `rv_methods_evaluation_plan`
+
+## Open decisions
+
+- 0.1 km/s: single exposure vs night-averaged?
+- Which stars qualify as “cool high-S/N” (Teff cut + S/N cut)?

--- a/docs/plans/steps/02-chunk-weights-subchunks.md
+++ b/docs/plans/steps/02-chunk-weights-subchunks.md
@@ -1,0 +1,85 @@
+---
+step_id: 02-chunk-weights-subchunks
+phase: C
+status: pending
+github_issue: https://github.com/astrofoley/dark-hunter_rv/issues/39
+branches:
+  - step/02a-subchunk-study
+  - step/02b-trust-weights-stack
+depends_on: [01-benchmark-cool-precision]
+blocks: [03-method-fusion-coverage]
+master_todo_id: chunk-weights-subchunks
+related_legacy_plans:
+  - rv_pipeline_roadmap_3a7b3787.plan.md
+  - rv_mismatch_diagnosis_24a11615.plan.md
+  - pr_repo_organization_326c519c.plan.md
+repo_docs_to_update:
+  - docs/validation_playbook.md
+---
+
+# Step 02: Wavelength chunks and trust-weighted stack
+
+## Goal / science outcome
+
+Replace arbitrary whole-order chunks with validated sub-chunking and post-debias weights that improve exposure RV precision and robustness.
+
+## Scope (in) / non-goals (out)
+
+**In:** `--subchunks` campaign on APF; telluric/mask-line/consistency weights; persist in diagnostics; update `order_chunk_qc.yaml`.
+
+**Out:** Full method fusion (step 03).
+
+## Prerequisites
+
+- Step 01 baseline metrics
+- `darkhunter_rv/chunking.py`, `validation/build_bias_set.py`
+
+## Implementation tasks
+
+### 02a (`step/02a-subchunk-study`)
+
+- [ ] Run APF campaign with `--subchunks 2,4` on calibration set
+- [ ] Compare chunk scatter vs step 01 baseline
+- [ ] Document recommended default N per instrument
+
+### 02b (`step/02b-trust-weights-stack`)
+
+- [ ] Implement trust weights (residual vs robust mean, telluric fraction, CCF quality) scaling IVW in `pipeline.py`
+- [ ] Add weight columns to diagnostics CSV
+- [ ] Version `order_chunk_qc.yaml` thresholds
+- [ ] Re-run bias build if chunk keys change
+
+## Key files
+
+- `darkhunter_rv/pipeline.py`
+- `darkhunter_rv/chunking.py`
+- `order_chunk_qc.yaml`
+- `validation/build_bias_set.py`
+
+## Commands
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+python -m darkhunter_rv.pipeline ... --subchunks 4 --instrument APF
+python -m validation.build_bias_set --input-dir output ...
+```
+
+## Acceptance criteria
+
+- Subchunk study shows improved or equal scatter vs baseline on cool calibration set
+- Trust-weighted stack reduces impact of outlier orders in test cases
+- Diagnostics record per-chunk weights; debias keys remain consistent
+
+## Tests / validation
+
+- `tests/test_chunking.py` extended if schema changes
+- Campaign comparison CSV archived under `validation_output/`
+
+## Propagation checklist (on merge)
+
+- [ ] Master todo `chunk-weights-subchunks` → completed
+- [ ] Update `rv_mismatch_diagnosis` plan (trust weights item)
+
+## Open decisions
+
+- Enable `subchunks>1` globally or per-instrument config?

--- a/docs/plans/steps/03-method-fusion-coverage.md
+++ b/docs/plans/steps/03-method-fusion-coverage.md
@@ -1,0 +1,77 @@
+---
+step_id: 03-method-fusion-coverage
+phase: C
+status: pending
+github_issue: https://github.com/astrofoley/dark-hunter_rv/issues/40
+branches:
+  - step/03-method-fusion-coverage
+depends_on: [02-chunk-weights-subchunks]
+blocks: [04-adopted-rv-match-plots]
+master_todo_id: method-fusion-coverage
+related_legacy_plans:
+  - rv_method_fusion_plan_b4fd46f0.plan.md
+  - rv_methods_evaluation_plan_fcd09d94.plan.md
+  - three_rv_methods_e1b72701.plan.md
+repo_docs_to_update:
+  - docs/rv_methods_evaluation.md
+---
+
+# Step 03: Method fusion and coverage reporting
+
+## Goal / science outcome
+
+Honest adopted RVs with calibrated uncertainties, explicit rejections, and coverage tables (`frac_finite` per method vs Teff/S/N).
+
+## Scope (in) / non-goals (out)
+
+**In:** `darkhunter_rv/method_fusion.py`; `rv_accepted` + `reject_reason`; coverage CSVs in diagnostics report; optional `rv_calibrated_kms` columns.
+
+**Out:** Learned ML scorer (v2); changing raw per-method RVs without labeled calibrated columns.
+
+## Prerequisites
+
+- Overlap report CSVs from calibration campaign
+- `method_evaluation.py`, `method_regions.py`
+
+## Implementation tasks
+
+- [ ] Add `method_fusion.py` (bias surfaces, σ inflation, discordance gates)
+- [ ] Extend `rv_method_diagnostics_report.py` with `binned_method_coverage_vs_teff.csv`
+- [ ] Wire optional fusion columns to diagnostics or post-process CSV
+- [ ] Tests for reject rules and coverage denominators
+- [ ] Document adoption v2 in `docs/rv_methods_evaluation.md`
+
+## Key files
+
+- `darkhunter_rv/method_fusion.py` (new)
+- `darkhunter_rv/method_evaluation.py`
+- `validation/rv_method_diagnostics_report.py`
+- `validation/rv_method_overlap_report.py`
+
+## Commands
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+python -m validation.rv_method_diagnostics_report --diagnostics-glob 'output/*_diagnostics.csv' ...
+PYTHONPATH=. python -m pytest tests/test_method_evaluation.py -q
+```
+
+## Acceptance criteria
+
+- Coverage report shows N_total vs N_finite per method (not only frac_bad among finite)
+- Fusion rejects exposures with large method discordance despite small formal σ
+- Unit tests cover tiered policy edge cases
+
+## Tests / validation
+
+- `tests/test_method_fusion.py` (new)
+- Compare high-σ fraction plots before/after on held-out star
+
+## Propagation checklist (on merge)
+
+- [ ] Master todo `method-fusion-coverage` → completed
+- [ ] Mark `rv_method_fusion_plan` todos addressed
+
+## Open decisions
+
+- Apply fusion in pipeline by default or opt-in flag first?

--- a/docs/plans/steps/04-adopted-rv-match-plots.md
+++ b/docs/plans/steps/04-adopted-rv-match-plots.md
@@ -1,0 +1,73 @@
+---
+step_id: 04-adopted-rv-match-plots
+phase: D
+status: pending
+github_issue: https://github.com/astrofoley/dark-hunter_rv/issues/41
+branches:
+  - step/04-adopted-rv-match-plots
+depends_on: [03-method-fusion-coverage]
+blocks: [05-short-pair-epoch-ccf]
+master_todo_id: adopted-rv-match-plots
+related_legacy_plans:
+  - legacy_plot_and_ccf_qc_2f3b70cd.plan.md
+  - gaia_cache_and_ccf_diagnostics_2e731512.plan.md
+repo_docs_to_update:
+  - docs/validation_playbook.md
+---
+
+# Step 04: Adopted-RV match diagnostic plots
+
+## Goal / science outcome
+
+Routine per-exposure figure: continuum-normalized spectrum with stellar mask and strong-line markers at **debiased adopted RV** (not only outlier PDFs).
+
+## Scope (in) / non-goals (out)
+
+**In:** New plot function in `plotting.py`; hook from `pipeline.py` when `--plots` / `--plots-focus`; uses cascade adopted RV + debias.
+
+**Out:** Replacing `plot_legacy_outlier_orders` (keep for disagreements).
+
+## Prerequisites
+
+- Adopted RV cascade stable
+- Existing mask schematic helpers in `plotting.py`
+
+## Implementation tasks
+
+- [ ] `plot_adopted_rv_match(spec, adopted_rv, debiased, mask, strong_lines)` in `plotting.py`
+- [ ] Write `{stem}_adopted_rv_match.png` from `process_spectrum`
+- [ ] Include in `--plots-focus` default bundle
+- [ ] One fixture smoke test or validation script check
+
+## Key files
+
+- `darkhunter_rv/plotting.py`
+- `darkhunter_rv/pipeline.py`
+- `validation/plot_legacy_outlier_orders.py` (reference layout)
+
+## Commands
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+python -m darkhunter_rv.pipeline /path/to/Gaia_DR3_*.txt --instrument APF --plots --plots-focus
+```
+
+## Acceptance criteria
+
+- Every plotted exposure shows mask overlay at adopted RV after debias
+- Strong-line rest positions marked when `strong_lines` row exists
+- Plot generated without requiring outlier threshold
+
+## Tests / validation
+
+- Visual check on 3 calibration stars + 1 hot star
+- Optional: PNG exists assertion in smoke test
+
+## Propagation checklist (on merge)
+
+- [ ] Master todo `adopted-rv-match-plots` → completed
+- [ ] Note in `legacy_plot_and_ccf_qc` plan
+
+## Open decisions
+
+- All orders vs single representative order panel?

--- a/docs/plans/steps/05-short-pair-epoch-ccf.md
+++ b/docs/plans/steps/05-short-pair-epoch-ccf.md
@@ -1,0 +1,83 @@
+---
+step_id: 05-short-pair-epoch-ccf
+phase: E
+status: pending
+github_issue: https://github.com/astrofoley/dark-hunter_rv/issues/42
+branches:
+  - step/05a-short-pair-calibration
+  - step/05b-epoch-ccf-consistency
+depends_on: [04-adopted-rv-match-plots]
+blocks: [06-strong-line-line-list]
+master_todo_id: short-pair-epoch-ccf
+related_legacy_plans:
+  - rv_pipeline_roadmap_3a7b3787.plan.md
+  - pr_repo_organization_326c519c.plan.md
+repo_docs_to_update:
+  - docs/validation_playbook.md
+  - docs/operations.md
+---
+
+# Step 05: Short-pair calibration and epoch–epoch CCF QC
+
+## Goal / science outcome
+
+Use closely spaced epoch pairs (~0 RV variation) for pipeline calibration checks; use spectrum–spectrum CCF as zeropoint-free consistency monitor.
+
+## Scope (in) / non-goals (out)
+
+**In:** `validation/find_short_pairs.py`; `validation/epoch_ccf_consistency.py`; optional hook in calibration setup.
+
+**Out:** Primary RV measurement via epoch CCF.
+
+## Prerequisites
+
+- Multi-epoch stars in `output/*_summary.txt`
+- Normalized spectra or pipeline re-read path
+
+## Implementation tasks
+
+### 05a (`step/05a-short-pair-calibration`)
+
+- [ ] Find pairs with Δt &lt; configurable threshold (default: same night)
+- [ ] Report ΔRV per method; flag pairs violating ~0 km/s assumption
+- [ ] Integrate into `run_calibration_setup` docs
+
+### 05b (`step/05b-epoch-ccf-consistency`)
+
+- [ ] CCF normalized epoch A vs B on log-λ grid
+- [ ] Compare ΔRV(CCF) vs adopted RV difference
+- [ ] Per-star CSV + flag epochs above threshold
+
+## Key files
+
+- `validation/find_short_pairs.py` (new)
+- `validation/epoch_ccf_consistency.py` (new)
+- `validation/run_calibration_setup.py`
+
+## Commands
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+python -m validation.find_short_pairs --summary-dir output --max-delta-days 1
+python -m validation.epoch_ccf_consistency --gaia-id 6328149636482597888 ...
+```
+
+## Acceptance criteria
+
+- Short-pair report runs on full survey output
+- Epoch CCF flags disagreeing epochs on test star (e.g. Gaia NS1)
+- Playbook documents Δt and threshold parameters
+
+## Tests / validation
+
+- Unit tests with synthetic pair timestamps
+- Manual run on J1432-1021 epochs
+
+## Propagation checklist (on merge)
+
+- [ ] Master todo `short-pair-epoch-ccf` → completed
+
+## Open decisions
+
+- Same night only vs &lt;24 h?
+- Phase-gate known binaries?

--- a/docs/plans/steps/06-strong-line-line-list.md
+++ b/docs/plans/steps/06-strong-line-line-list.md
@@ -1,0 +1,75 @@
+---
+step_id: 06-strong-line-line-list
+phase: C
+status: pending
+github_issue: https://github.com/astrofoley/dark-hunter_rv/issues/43
+branches:
+  - step/06-strong-line-line-list
+depends_on: [05-short-pair-epoch-ccf]
+blocks: [07-sb2-search]
+master_todo_id: strong-line-line-list
+related_legacy_plans:
+  - template_grid_and_hβ_rv_dff5dfce.plan.md
+  - three_rv_methods_e1b72701.plan.md
+repo_docs_to_update:
+  - docs/broad_line_method.md
+---
+
+# Step 06: Strong-line rest wavelengths and multi-line Voigt+Lorentz
+
+## Goal / science outcome
+
+Empirically chosen strong lines per Teff/S/N; extend `measure_h_beta_rv` API beyond Hβ-only for the `strong_lines` method.
+
+## Scope (in) / non-goals (out)
+
+**In:** Line list study; generalized Voigt+Lorentz per line; pipeline still exposes one `strong_lines` row.
+
+**Out:** Reviving Gaussian multi-line centroids as product RV.
+
+## Prerequisites
+
+- Hβ path in `rv_core.py`
+- Overlap report Teff strata
+
+## Implementation tasks
+
+- [ ] Survey candidates from `STRONG_LINES` / literature (`docs/broad_line_method.md`)
+- [ ] Validation sweep: recovery vs mask/template per Teff bin
+- [ ] Refactor `measure_strong_line_voigt_lorentz(rest=...)` from Hβ code
+- [ ] Wire best line(s) into pipeline `strong_lines` row
+- [ ] Update tests in `tests/test_h_beta_rv.py` or new module
+
+## Key files
+
+- `darkhunter_rv/rv_core.py`
+- `darkhunter_rv/continuum.py` (`STRONG_LINES`)
+- `validation/h_beta_profile_method_report.py`
+
+## Commands
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+python -m validation.h_beta_profile_method_report ...
+PYTHONPATH=. python -m pytest tests/test_h_beta_rv.py -q
+```
+
+## Acceptance criteria
+
+- Documented line list with Teff applicability
+- At least one additional line beyond Hβ tested on real spectra OR explicit decision to stay Hβ-only with rationale
+- No regression on hot-star Hβ performance
+
+## Tests / validation
+
+- Synthetic line recovery tests per rest wavelength
+- Overlap residuals for strong_lines vs mask on cool stars
+
+## Propagation checklist (on merge)
+
+- [ ] Master todo `strong-line-line-list` → completed
+- [ ] Update `three_rv_methods` plan
+
+## Open decisions
+
+- Single best line per exposure vs multi-line joint fit?

--- a/docs/plans/steps/07-sb2-search.md
+++ b/docs/plans/steps/07-sb2-search.md
@@ -1,0 +1,84 @@
+---
+step_id: 07-sb2-search
+phase: D
+status: pending
+github_issue: https://github.com/astrofoley/dark-hunter_rv/issues/44
+branches:
+  - step/07a-sb2-detection
+  - step/07b-sb2-reporting
+  - step/07c-sb2-orbit-optional
+depends_on: [06-strong-line-line-list]
+blocks: []
+master_todo_id: sb2-search
+related_legacy_plans:
+  - rv_pipeline_roadmap_3a7b3787.plan.md
+repo_docs_to_update:
+  - docs/validation_playbook.md
+---
+
+# Step 07: SB2 search and reporting
+
+## Goal / science outcome
+
+Detect and report double-lined systems where appropriate; optional two-lined orbit extension.
+
+## Scope (in) / non-goals (out)
+
+**In:** CCF asymmetry / dual-Gaussian / profile flags; `sb2_candidate`, primary/secondary RV columns when resolved; Gaia NSS cross-link.
+
+**Out (07c optional):** Full SB2 Keplerian MCMC in `fit_apf_rv_keplerian.py`.
+
+## Prerequisites
+
+- Mask CCF diagnostics (`gauss_ok`, peak shape)
+- Multi-epoch data for known binaries
+
+## Implementation tasks
+
+### 07a (`step/07a-sb2-detection`)
+
+- [ ] Prototype dual-Gaussian CCF fit or bisector metric in `rv_core.py`
+- [ ] Per-chunk SB2 scores in diagnostics
+
+### 07b (`step/07b-sb2-reporting`)
+
+- [ ] Exposure-level `sb2_candidate` flag + columns in CSV/summary
+- [ ] Validation report: fraction flagged vs Gaia NSS SB2
+
+### 07c (`step/07c-sb2-orbit-optional`, defer if needed)
+
+- [ ] Two-lined Keplerian likelihood sketch or separate module
+
+## Key files
+
+- `darkhunter_rv/rv_core.py`
+- `darkhunter_rv/pipeline.py`
+- `fit_apf_rv_keplerian.py`
+
+## Commands
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+python -m darkhunter_rv.pipeline ... --run-all-methods
+```
+
+## Acceptance criteria
+
+- SB2 flag does not fire on high-S/N cool calibration stars (low false positive)
+- Known asymmetric CCF test case flagged
+- Documented limitations (single-lined orbit fitter unchanged unless 07c done)
+
+## Tests / validation
+
+- Synthetic double-lined injection test
+- Manual check on suspect epochs from overlap discordance
+
+## Propagation checklist (on merge)
+
+- [ ] Master todo `sb2-search` → completed
+- [ ] Update `rv_pipeline_roadmap` phase 3 binary section
+
+## Open decisions
+
+- Spectral decomposition per epoch vs time-series only?
+- 07c in scope for this step or separate future step?

--- a/docs/plans/steps/08-external-rv-crosscheck.md
+++ b/docs/plans/steps/08-external-rv-crosscheck.md
@@ -1,0 +1,77 @@
+---
+step_id: 08-external-rv-crosscheck
+phase: E
+status: pending
+github_issue: https://github.com/astrofoley/dark-hunter_rv/issues/45
+branches:
+  - step/08-external-rv-crosscheck
+depends_on: [00-literature-rv-master, 07-sb2-search]
+blocks: []
+master_todo_id: external-rv-crosscheck
+related_legacy_plans:
+  - pipeline_legacy_diagnostics_e98cdb98.plan.md
+repo_docs_to_update:
+  - docs/validation_playbook.md
+---
+
+# Step 08: External RV cross-check (literature + catalogs)
+
+## Goal / science outcome
+
+Systematic comparison of pipeline adopted RVs and orbit fits to published literature (primary: El-Badry 2024) and LAMOST/RAVE.
+
+## Scope (in) / non-goals (out)
+
+**In:** `validation/compare_literature_rvs.py`; join on `gaia_dr3_id` + nearest BJD; orbit-fit overlay from master CSV; LAMOST/RAVE extension.
+
+**Out:** Rebuilding literature master (step 00).
+
+## Prerequisites
+
+- `calibration/literature_rv_master.csv`
+- Pipeline summaries and diagnostics for overlapping Gaia IDs
+
+## Implementation tasks
+
+- [ ] CLI: load master CSV + pipeline `*_summary.txt` / diagnostics
+- [ ] Per-epoch ΔRV vs published err; per-star bias/RMS tables
+- [ ] Optional: wire literature points in `fit_apf_rv_keplerian.py` plots from master CSV
+- [ ] Extend to `external_rvs` from star summaries (LAMOST/RAVE)
+- [ ] Playbook recipes and example output paths
+
+## Key files
+
+- `calibration/literature_rv_master.csv`
+- `validation/compare_literature_rvs.py` (new)
+- `validation/diagnose_legacy_campaign.py` (reference joins)
+- `fit_apf_rv_keplerian.py`
+
+## Commands
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+python -m validation.compare_literature_rvs \
+  --master calibration/literature_rv_master.csv \
+  --summary-dir output \
+  --report-dir validation_output/literature_crosscheck
+```
+
+## Acceptance criteria
+
+- Report covers ≥10 El-Badry 2024 stars with both APF and literature epochs
+- Published M_star, M2, P_orb joined for orbit-fit QA table
+- LAMOST/RAVE rows compared where present in summaries
+
+## Tests / validation
+
+- Unit test: nearest BJD join logic
+- Compare Gaia NS1 literature vs pipeline epoch table
+
+## Propagation checklist (on merge)
+
+- [ ] Master todo `external-rv-crosscheck` → completed
+- [ ] Update master plan literature section with CLI path
+
+## Open decisions
+
+- Match adopted RV vs mask-only vs all methods in comparison?

--- a/docs/validation_playbook.md
+++ b/docs/validation_playbook.md
@@ -26,7 +26,8 @@
   - `python -m validation.plot_chunk_residuals --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' --out-dir validation_output/chunk_residuals`
   - `--overlap-only` limits to phase-A overlap stars that pass the mask region cut.
   - Per object: `*_residuals_by_spectrum.png`, `*_chunk_weighted_mean.png`; sample: `sample_per_object_chunk_bias.png`.
-  - Default clips per spectrum until convergence: 10σ leave-one-out (`--chunk-outlier-sigma 10`) and ±30 km/s from weighted mean (`--chunk-max-delta-kms 30`; `0` disables either). Excluded chunks shown as gray ×.
+  - Per-spectrum clip (default): 10σ LOO + ±30 km/s (`--chunk-outlier-sigma 10`, `--chunk-max-delta-kms 30`).
+  - Full-sample clip on per-object chunk biases (default): 5σ LOO + ±10 km/s (`--sample-outlier-sigma 5`, `--sample-max-delta-kms 10`). Excluded points shown as gray ×.
 - Error model calibration:
   - `python3 validation/calibrate_error_model.py --diag-glob "output/*_diagnostics.csv" --out-dir validation_output/error_model`
 - Full campaign report:

--- a/docs/validation_playbook.md
+++ b/docs/validation_playbook.md
@@ -26,6 +26,7 @@
   - `python -m validation.plot_chunk_residuals --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' --out-dir validation_output/chunk_residuals`
   - `--overlap-only` limits to phase-A overlap stars that pass the mask region cut.
   - Per object: `*_residuals_by_spectrum.png`, `*_chunk_weighted_mean.png`; sample: `sample_per_object_chunk_bias.png`.
+  - Default: iterative 10σ leave-one-out clip per spectrum (`--chunk-outlier-sigma 10`; `0` disables). Excluded chunks shown as gray × in spectrum plot.
 - Error model calibration:
   - `python3 validation/calibrate_error_model.py --diag-glob "output/*_diagnostics.csv" --out-dir validation_output/error_model`
 - Full campaign report:

--- a/docs/validation_playbook.md
+++ b/docs/validation_playbook.md
@@ -29,6 +29,19 @@
   - Per-spectrum clip (default): 7σ LOO + ±20 km/s (`--chunk-outlier-sigma 7`, `--chunk-max-delta-kms 20`).
   - Per-object weighted mean: only chunks with ≥3 surviving measurements (`--min-chunk-measurements 3`).
   - Full-sample clip on per-object chunk biases (default): 5σ LOO + ±10 km/s (`--sample-outlier-sigma 5`, `--sample-max-delta-kms 10`). Excluded points shown as gray ×.
+- **Apply chunk calibration + relative reassessment:**
+  - `python -m validation.reassess_relative_calibration --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' --bias-csv validation_output/chunk_residuals/per_object_chunk_bias.csv --out-dir validation_output/chunk_calibration_assessment`
+- **Chunk bias regression (stellar params + bias curve):**
+  - `python -m validation.chunk_bias_regression --bias-csv validation_output/chunk_residuals/per_object_chunk_bias.csv --summary-dir output --out-dir validation_output/chunk_bias_regression --reassess-relative-gate`
+  - Outputs: `regression_adjusted_chunk_bias.csv`, `regression_chunk_bias_for_calibration.csv`, `CHUNK_OPTIMIZATION_ADVICE.md`
+- **Evaluate chunk layouts (offline merge / compare N+1 edges):**
+  - `python -m validation.evaluate_chunk_layout --layouts calibration/chunk_layouts/*.yaml --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' --out-dir validation_output/chunk_layout_eval`
+  - Sub-chunk layouts require pipeline rerun with `--subchunks N` before bias loop.
+- **Parametric grid search (rough N: subchunks 1,2,4 + merge widths 1,2,4):**
+  - `python -m validation.chunk_grid_search --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' --out-dir validation_output/chunk_grid_search`
+- **Full chunk campaign (pipeline + cache + edge presets + stages B/C):**
+  - `python -m validation.chunk_campaign --run-pipeline --out-dir validation_output/chunk_campaign`
+  - Uses `measurement_cache.csv` to avoid re-measuring identical chunks; per-layout diagnostics under `validation_output/chunk_campaign/diagnostics/<layout>/`
 - Error model calibration:
   - `python3 validation/calibrate_error_model.py --diag-glob "output/*_diagnostics.csv" --out-dir validation_output/error_model`
 - Full campaign report:

--- a/docs/validation_playbook.md
+++ b/docs/validation_playbook.md
@@ -22,6 +22,10 @@
   - `python -m validation.rv_phase_a_baseline --master calibration/literature_rv_master.csv --summary-dir output --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' --out-dir validation_output/rv_phase_a_baseline`
   - Absolute gate (APF vs literature, |ΔRV| < 1 km/s): use `--no-bias-correction-applied` after a `--no-bias` pipeline rerun on overlap stars.
   - Outputs: `overlap_stars.csv`, `pair_candidates.csv`, gate summaries, `plots/` (see `calibration/phase_a_baseline/README.md`).
+- **Chunk residuals** (mask-applicable cool stars; per-object and sample bias plots):
+  - `python -m validation.plot_chunk_residuals --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' --out-dir validation_output/chunk_residuals`
+  - `--overlap-only` limits to phase-A overlap stars that pass the mask region cut.
+  - Per object: `*_residuals_by_spectrum.png`, `*_chunk_weighted_mean.png`; sample: `sample_per_object_chunk_bias.png`.
 - Error model calibration:
   - `python3 validation/calibrate_error_model.py --diag-glob "output/*_diagnostics.csv" --out-dir validation_output/error_model`
 - Full campaign report:

--- a/docs/validation_playbook.md
+++ b/docs/validation_playbook.md
@@ -16,6 +16,8 @@
   - `python3 validation/evaluate_method_consistency.py --diag-glob "output/*_diagnostics.csv" --out-dir validation_output/consistency`
 - Broad-line benchmark:
   - `python3 validation/benchmark_broad_lines.py --out-dir validation_output/broad_line`
+- Cool high-S/N mask precision (step 01; 0.1 km/s goal):
+  - `python -m validation.benchmark_cool_precision --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' --out-dir validation_output/benchmark_cool_precision`
 - Error model calibration:
   - `python3 validation/calibrate_error_model.py --diag-glob "output/*_diagnostics.csv" --out-dir validation_output/error_model`
 - Full campaign report:

--- a/docs/validation_playbook.md
+++ b/docs/validation_playbook.md
@@ -26,7 +26,8 @@
   - `python -m validation.plot_chunk_residuals --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' --out-dir validation_output/chunk_residuals`
   - `--overlap-only` limits to phase-A overlap stars that pass the mask region cut.
   - Per object: `*_residuals_by_spectrum.png`, `*_chunk_weighted_mean.png`; sample: `sample_per_object_chunk_bias.png`.
-  - Per-spectrum clip (default): 10σ LOO + ±30 km/s (`--chunk-outlier-sigma 10`, `--chunk-max-delta-kms 30`).
+  - Per-spectrum clip (default): 7σ LOO + ±20 km/s (`--chunk-outlier-sigma 7`, `--chunk-max-delta-kms 20`).
+  - Per-object weighted mean: only chunks with ≥3 surviving measurements (`--min-chunk-measurements 3`).
   - Full-sample clip on per-object chunk biases (default): 5σ LOO + ±10 km/s (`--sample-outlier-sigma 5`, `--sample-max-delta-kms 10`). Excluded points shown as gray ×.
 - Error model calibration:
   - `python3 validation/calibrate_error_model.py --diag-glob "output/*_diagnostics.csv" --out-dir validation_output/error_model`

--- a/docs/validation_playbook.md
+++ b/docs/validation_playbook.md
@@ -26,7 +26,7 @@
   - `python -m validation.plot_chunk_residuals --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' --out-dir validation_output/chunk_residuals`
   - `--overlap-only` limits to phase-A overlap stars that pass the mask region cut.
   - Per object: `*_residuals_by_spectrum.png`, `*_chunk_weighted_mean.png`; sample: `sample_per_object_chunk_bias.png`.
-  - Default: iterative 10σ leave-one-out clip per spectrum (`--chunk-outlier-sigma 10`; `0` disables). Excluded chunks shown as gray × in spectrum plot.
+  - Default clips per spectrum until convergence: 10σ leave-one-out (`--chunk-outlier-sigma 10`) and ±30 km/s from weighted mean (`--chunk-max-delta-kms 30`; `0` disables either). Excluded chunks shown as gray ×.
 - Error model calibration:
   - `python3 validation/calibrate_error_model.py --diag-glob "output/*_diagnostics.csv" --out-dir validation_output/error_model`
 - Full campaign report:

--- a/docs/validation_playbook.md
+++ b/docs/validation_playbook.md
@@ -18,6 +18,10 @@
   - `python3 validation/benchmark_broad_lines.py --out-dir validation_output/broad_line`
 - Cool high-S/N mask precision (step 01; 0.1 km/s goal):
   - `python -m validation.benchmark_cool_precision --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' --out-dir validation_output/benchmark_cool_precision`
+- **Phase A baseline** (overlap inventory + calibration gates; regression vs `calibration/phase_a_baseline/reference_manifest.json`):
+  - `python -m validation.rv_phase_a_baseline --master calibration/literature_rv_master.csv --summary-dir output --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' --out-dir validation_output/rv_phase_a_baseline`
+  - Absolute gate (APF vs literature, |ΔRV| < 1 km/s): use `--no-bias-correction-applied` after a `--no-bias` pipeline rerun on overlap stars.
+  - Outputs: `overlap_stars.csv`, `pair_candidates.csv`, gate summaries, `plots/` (see `calibration/phase_a_baseline/README.md`).
 - Error model calibration:
   - `python3 validation/calibrate_error_model.py --diag-glob "output/*_diagnostics.csv" --out-dir validation_output/error_model`
 - Full campaign report:

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -28,7 +28,7 @@ import time
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 from astropy.timeseries import LombScargle
@@ -41,7 +41,7 @@ from darkhunter_rv.summary_paths import (
     parse_object_id_from_summary,
 )
 from darkhunter_rv.thiele_innes_inclination import fill_inclination_in_metadata, inclination_from_row_dict
-from scipy.optimize import least_squares
+from scipy.optimize import least_squares, minimize_scalar
 import matplotlib.pyplot as plt
 from matplotlib.ticker import AutoMinorLocator
 from matplotlib.offsetbox import AnnotationBbox, TextArea, VPacker, HPacker
@@ -636,6 +636,68 @@ def _clip_initial_guess(x0: np.ndarray, lower: np.ndarray, upper: np.ndarray) ->
     return np.minimum(np.maximum(x, lower), upper)
 
 
+def _effective_sigma(
+    yerr: np.ndarray,
+    *,
+    log_jitter: Optional[float] = None,
+    jitter_kms: Optional[float] = None,
+) -> np.ndarray:
+    """Per-epoch σ_tot = sqrt(σ_formal² + σ_jitter²) for fitting and plots."""
+    base = np.clip(np.asarray(yerr, dtype=float), 1e-4, None)
+    if jitter_kms is not None and np.isfinite(jitter_kms) and float(jitter_kms) > 0:
+        return np.sqrt(base**2 + float(jitter_kms) ** 2)
+    if log_jitter is not None and np.isfinite(log_jitter):
+        jit = float(np.exp(log_jitter))
+        return np.sqrt(base**2 + jit**2)
+    return base
+
+
+def _profile_jitter_kms(
+    y: np.ndarray,
+    model: np.ndarray,
+    yerr: np.ndarray,
+    *,
+    s_max_kms: float = 10.0,
+) -> float:
+    """
+    Homoscedastic intrinsic jitter (km/s) at a fixed orbit.
+
+    Profiled by minimizing the Gaussian negative log-likelihood
+    (includes log-σ terms so σ_jit cannot be inflated without penalty).
+    """
+    y = np.asarray(y, dtype=float).ravel()
+    model = np.asarray(model, dtype=float).ravel()
+    yerr = np.asarray(yerr, dtype=float).ravel()
+    resid2 = (y - model) ** 2
+    e2 = np.clip(yerr, 1e-4, None) ** 2
+
+    def nll(log_s: float) -> float:
+        s2 = float(np.exp(2.0 * log_s))
+        sig2 = e2 + s2
+        return float(np.sum(resid2 / sig2 + np.log(sig2)))
+
+    res = minimize_scalar(
+        nll,
+        bounds=(np.log(1e-4), np.log(max(1e-4, float(s_max_kms)))),
+        method="bounded",
+    )
+    return float(np.exp(res.x))
+
+
+def effective_yerr_for_points(
+    points: Sequence["RVPoint"],
+    report: Optional[dict] = None,
+) -> np.ndarray:
+    """Formal RV errors used in the fit, plus fitted/fixed jitter in quadrature."""
+    yerr = np.array([p.rv_err for p in points], dtype=float)
+    if report is None:
+        return yerr
+    jit = report.get("jitter_kms")
+    if jit is not None and np.isfinite(jit) and float(jit) > 0:
+        yerr = _effective_sigma(yerr, jitter_kms=float(jit))
+    return yerr
+
+
 def _sanitize_rv_arrays(
     t: np.ndarray,
     y: np.ndarray,
@@ -678,6 +740,9 @@ def fit_keplerian(
     fix_period: Optional[float] = None,
     fix_e: Optional[float] = None,
     initial_params: Optional[np.ndarray] = None,
+    *,
+    fit_jitter: bool = False,
+    jitter_kms: Optional[float] = None,
 ) -> Tuple[np.ndarray, dict]:
     t = np.asarray(t, dtype=float)
     y = np.asarray(y, dtype=float)
@@ -688,6 +753,11 @@ def fit_keplerian(
         raise ValueError("non-finite MJD or RV after sanitization")
     if not np.all(np.isfinite(yerr)) or np.any(yerr <= 0):
         raise ValueError("non-finite or non-positive RV errors after sanitization")
+    if fit_jitter and jitter_kms is not None and np.isfinite(jitter_kms) and float(jitter_kms) > 0:
+        raise ValueError("use either fit_jitter or jitter_kms, not both")
+    fixed_jitter: Optional[float] = None
+    if jitter_kms is not None and np.isfinite(jitter_kms) and float(jitter_kms) > 0:
+        fixed_jitter = float(jitter_kms)
 
     span = max(float(np.max(t) - np.min(t)), 1.0)
     dt = np.diff(np.sort(t))
@@ -738,11 +808,13 @@ def fit_keplerian(
 
     lower = np.array([np.log(min_period), 0.0, -0.95, -0.95, -np.pi, -1000.0])
     upper = np.array([np.log(max_period), 1000.0, 0.95, 0.95, np.pi, 1000.0])
+    jitter_hold = float(fixed_jitter or 0.0)
 
     def resid(p):
-        p_eff = _project_params_to_fixed_e(p, fix_e)
-        model = rv_model(p_eff, t, t_ref)
-        r = (y - model) / np.clip(yerr, 1e-4, None)
+        p_orb = _project_params_to_fixed_e(p, fix_e)
+        model = rv_model(p_orb, t, t_ref)
+        sig = _effective_sigma(yerr, jitter_kms=jitter_hold if jitter_hold > 0 else None)
+        r = (y - model) / sig
         if fix_period is not None:
             # Hold P effectively fixed by adding a very strong prior.
             r = np.concatenate([r, np.array([(p[0] - np.log(fix_period)) / 1e-6])])
@@ -766,15 +838,13 @@ def fit_keplerian(
             seen.add(key)
             uniq_periods.append(key)
 
-    best_res = None
-    best_cost = np.inf
     f_scale = float(np.median(yerr))
     if not np.isfinite(f_scale) or f_scale <= 0:
         f_scale = 1.0
 
     x0_candidates: List[np.ndarray] = []
     if initial_params is not None:
-        seed = _clip_initial_guess(np.asarray(initial_params, dtype=float), lower, upper)
+        seed = _clip_initial_guess(np.asarray(initial_params, dtype=float).ravel()[:6], lower, upper)
         if fix_period is not None:
             seed[0] = np.log(float(np.clip(fix_period, min_period, max_period)))
         x0_candidates.append(seed)
@@ -797,31 +867,52 @@ def fit_keplerian(
         )
         x0_candidates.append(x0)
 
-    seen_x0: set = set()
-    for x0 in x0_candidates:
-        key = tuple(np.round(x0, 5))
-        if key in seen_x0:
-            continue
-        seen_x0.add(key)
-        try:
-            res = least_squares(
-                resid,
-                x0=x0,
-                bounds=(lower, upper),
-                loss="soft_l1",
-                f_scale=f_scale,
-                max_nfev=8000,
-            )
-        except ValueError:
-            continue
-        if res.cost < best_cost:
-            best_cost = res.cost
-            best_res = res
+    def _run_multi_start(candidates: List[np.ndarray]):
+        best_res = None
+        best_cost = np.inf
+        seen_x0: set = set()
+        for x0 in candidates:
+            key = tuple(np.round(x0, 5))
+            if key in seen_x0:
+                continue
+            seen_x0.add(key)
+            try:
+                trial = least_squares(
+                    resid,
+                    x0=x0,
+                    bounds=(lower, upper),
+                    loss="soft_l1",
+                    f_scale=f_scale,
+                    max_nfev=8000,
+                )
+            except ValueError:
+                continue
+            if trial.cost < best_cost:
+                best_cost = trial.cost
+                best_res = trial
+        return best_res
 
-    if best_res is None:
-        raise RuntimeError("Keplerian fit failed: no optimization result.")
+    if fit_jitter:
+        jitter_hold = 0.0
+        warm_x0: List[np.ndarray] = list(x0_candidates)
+        res = None
+        for _em in range(30):
+            res = _run_multi_start(warm_x0)
+            if res is None:
+                raise RuntimeError("Keplerian fit failed: no optimization result.")
+            params_try = _project_params_to_fixed_e(res.x, fix_e)
+            model_try = rv_model(params_try, t, t_ref)
+            new_jit = _profile_jitter_kms(y, model_try, yerr)
+            if _em > 0 and abs(new_jit - jitter_hold) < 1e-5:
+                jitter_hold = new_jit
+                break
+            jitter_hold = new_jit
+            warm_x0 = [res.x]
+    else:
+        res = _run_multi_start(x0_candidates)
+        if res is None:
+            raise RuntimeError("Keplerian fit failed: no optimization result.")
 
-    res = best_res
     params = _project_params_to_fixed_e(res.x, fix_e)
     P = float(np.exp(params[0]))
     K = float(params[1])
@@ -834,8 +925,10 @@ def fit_keplerian(
     t_peri = float(t_ref - M0 / n)
 
     model = rv_model(params, t, t_ref)
-    chi2 = float(np.sum(((y - model) / np.clip(yerr, 1e-4, None)) ** 2))
-    n_fit_params = 5 if fix_e is not None else len(params)
+    jitter_fit = float(jitter_hold if fit_jitter else (fixed_jitter or 0.0))
+    sigma_fit = _effective_sigma(yerr, jitter_kms=jitter_fit if jitter_fit > 0 else None)
+    chi2 = float(np.sum(((y - model) / sigma_fit) ** 2))
+    n_fit_params = (5 if fix_e is not None else len(params)) + (1 if fit_jitter else 0)
     dof = max(1, len(t) - n_fit_params)
 
     # Next RV extrema relative to "now" (UTC), for scheduling.
@@ -883,6 +976,9 @@ def fit_keplerian(
         "period_prior_sigma_lnP": float(period_prior_sigma),
         "fixed_period_days": None if fix_period is None else float(fix_period),
         "fixed_eccentricity": None if fix_e is None else float(fix_e),
+        "fit_jitter": bool(fit_jitter),
+        "jitter_fixed_kms": fixed_jitter,
+        "jitter_kms": jitter_fit if jitter_fit > 0 else 0.0,
         "params_raw": params.tolist(),
     }
     return params, report
@@ -1289,6 +1385,8 @@ def fit_all_variants(
     period_min: Optional[float],
     period_max: Optional[float],
     period_prior_sigma: float,
+    fit_jitter: bool = False,
+    jitter_kms: Optional[float] = None,
 ) -> Dict[str, Tuple[np.ndarray, dict]]:
     """Four Keplerian fits: free P/e; fixed P; fixed e; fixed P and e (Gaia when available)."""
     out: Dict[str, Tuple[np.ndarray, dict]] = {}
@@ -1307,6 +1405,8 @@ def fit_all_variants(
             period_max=period_max,
             period_prior=None,
             period_prior_sigma=period_prior_sigma,
+            fit_jitter=fit_jitter,
+            jitter_kms=jitter_kms,
         )
     except (ValueError, RuntimeError):
         return out
@@ -1326,6 +1426,7 @@ def fit_all_variants(
         )
 
     for key, fix_p, fix_e in constrained:
+        init = free_params
         try:
             params, rep = fit_keplerian(
                 t,
@@ -1337,7 +1438,9 @@ def fit_all_variants(
                 period_prior_sigma=period_prior_sigma,
                 fix_period=fix_p,
                 fix_e=fix_e,
-                initial_params=free_params,
+                initial_params=init,
+                fit_jitter=fit_jitter,
+                jitter_kms=jitter_kms,
             )
         except (ValueError, RuntimeError):
             continue
@@ -1366,7 +1469,9 @@ def fit_all_variants(
                         period_prior_sigma=period_prior_sigma,
                         fix_period=fix_p,
                         fix_e=float(e_free),
-                        initial_params=free_params,
+                        initial_params=init,
+                        fit_jitter=fit_jitter,
+                        jitter_kms=jitter_kms,
                     )
                     chi_retry = rep_retry.get("chi2_red")
                     if isinstance(chi_retry, (int, float)) and chi_retry < chi_fp:
@@ -1395,8 +1500,7 @@ def build_plot(
 ) -> None:
     t = np.array([p.mjd for p in points], dtype=float)
     y = np.array([p.rv for p in points], dtype=float)
-    # Plot error bars from RMS column, not formal RV error.
-    yerr_rms = np.array([p.rms for p in points], dtype=float)
+    yerr = effective_yerr_for_points(points, report)
 
     t_ref = report["t_ref_mjd"]
     now_mjd = float(report.get("now_mjd", Time.now().mjd))
@@ -1478,7 +1582,7 @@ def build_plot(
         ax.errorbar(
             t[idx],
             y[idx],
-            yerr=yerr_rms[idx],
+            yerr=yerr[idx],
             fmt=marker,
             ms=5,
             lw=1,
@@ -1495,7 +1599,7 @@ def build_plot(
         ax.errorbar(
             t[idx_lit],
             y[idx_lit],
-            yerr=yerr_rms[idx_lit],
+            yerr=yerr[idx_lit],
             fmt="D",
             ms=4.8,
             lw=1,
@@ -1508,7 +1612,7 @@ def build_plot(
         )
         plotted_any = True
     if not plotted_any:
-        ax.errorbar(t, y, yerr=yerr_rms, fmt="o", ms=5, lw=1, capsize=2, color="black")
+        ax.errorbar(t, y, yerr=yerr, fmt="o", ms=5, lw=1, capsize=2, color="black")
     ax.plot(t_dense, y_dense, "-", lw=2)
     ax.set_xlabel("MJD")
     ax.set_ylabel("RV (km/s)")
@@ -1697,6 +1801,8 @@ def run_one(
     query_gaia_online: bool,
     plots_root: Optional[Path] = None,
     table_m1_msun: Optional[float] = None,
+    fit_jitter: bool = False,
+    jitter_kms: Optional[float] = None,
 ) -> Optional[dict]:
     from darkhunter_rv.rv_keplerian_plots import (
         our_telescope_points,
@@ -1783,6 +1889,8 @@ def run_one(
         period_min=period_min,
         period_max=period_max,
         period_prior_sigma=period_prior_sigma,
+        fit_jitter=fit_jitter,
+        jitter_kms=jitter_kms,
     )
     if "free" not in fit_variants:
         print(f"[SKIP] {summary_path.name}: free RV fit failed")
@@ -1905,6 +2013,17 @@ def main() -> None:
         default=None,
         help="Website tables/data.csv for luminous M1 (Msun) per Gaia id (default: none).",
     )
+    parser.add_argument(
+        "--fit-jitter",
+        action="store_true",
+        help="Fit an intrinsic RV jitter term (added in quadrature to formal errors).",
+    )
+    parser.add_argument(
+        "--rv-jitter-kms",
+        type=float,
+        default=None,
+        help="Fixed intrinsic jitter (km/s) added in quadrature to formal errors (mutually exclusive with --fit-jitter).",
+    )
     parser.add_argument("--force", action="store_true", help="Recompute even if report JSON is newer than summary.")
     args = parser.parse_args()
 
@@ -1977,6 +2096,8 @@ def main() -> None:
             args.query_gaia_online,
             plots_root=output_dir,
             table_m1_msun=table_m1_map.get(str(sid)) if sid else None,
+            fit_jitter=args.fit_jitter,
+            jitter_kms=args.rv_jitter_kms,
         )
         if report is None:
             skipped += 1

--- a/scripts/refit_all_per_object.sh
+++ b/scripts/refit_all_per_object.sh
@@ -25,6 +25,7 @@ PY="${PY:-/home/marley/anaconda2/envs/gaia-env/bin/python}"
 REPORTS_DIR="${REPORTS_DIR:-$REPO/rv_fit_reports}"
 MIN_POINTS="${MIN_POINTS:-5}"
 FIT_FORCE="${FIT_FORCE:-1}"
+FIT_JITTER="${FIT_JITTER:-1}"
 PIPELINE_UPDATE="${PIPELINE_UPDATE:-0}"
 RUN_HBETA="${RUN_HBETA:-1}"
 QUERY_GAIA_ONLINE="${QUERY_GAIA_ONLINE:-0}"
@@ -119,6 +120,9 @@ for gid in "${STAR_IDS[@]}"; do
   fi
   if [[ "$QUERY_GAIA_ONLINE" == "1" ]]; then
     fit_args+=(--query-gaia-online)
+  fi
+  if [[ "$FIT_JITTER" == "1" ]]; then
+    fit_args+=(--fit-jitter)
   fi
   "$PY" "${fit_args[@]}" || echo "[WARN] fit failed for Gaia_DR3_${gid} (continuing)"
 

--- a/tests/fixtures/phase_a/literature_mini.csv
+++ b/tests/fixtures/phase_a/literature_mini.csv
@@ -1,0 +1,4 @@
+reference_key,reference_title,reference_arxiv,reference_url,reference_table,obs_index,gaia_dr3_id,name,bjd,rv_kms,rv_err_kms,instrument,spectral_resolution_R,snr_per_pixel,P_orb_days,P_orb_err,M_star_msun,M_star_err,M2_msun,M2_err,eccentricity,eccentricity_err,parallax_mas,parallax_err_mas,G_mag,N_rvs_table1
+TestRef,Test paper,,,,1,1000000000000000001,STAR_A,2459900.0,10.0,0.1,APF,,,,,,,,,,,,,,
+TestRef,Test paper,,,,2,1000000000000000001,STAR_A,2459903.0,10.5,0.1,APF,,,,,,,,,,,,,,
+TestRef,Test paper,,,,1,1000000000000000002,STAR_B,2459800.0,20.0,0.2,HIRES,,,,,,,,,,,,,,

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,6 +1,17 @@
 import numpy as np
 
-from darkhunter_rv.chunking import iter_order_chunks
+from darkhunter_rv.chunking import iter_order_chunks, iter_order_chunks_with_edges
+
+
+from darkhunter_rv import chunking
+from darkhunter_rv.chunking import iter_order_chunks, iter_order_chunks_with_edges
+
+
+def test_parse_chunk_key_merge():
+    assert chunking.parse_chunk_key("merge_3") == (None, 3, "merge")
+    assert chunking.bias_order_from_chunk_key("merge_3") is None
+    assert chunking.parse_chunk_key("15_2")[0] == 15
+    assert chunking.chunk_sort_key("15") < chunking.chunk_sort_key("merge_1")
 
 
 def test_iter_order_chunks_subchunks():
@@ -18,3 +29,11 @@ def test_iter_order_chunks_skip_bad_orders():
     }
     chunks = list(iter_order_chunks(spec, bad_orders=[1], subchunks=1))
     assert [k for k, *_ in chunks] == ["0"]
+
+
+def test_iter_order_chunks_with_edges_three_chunks():
+    spec = {2: {"wavelength": list(range(30)), "flux": [1.0] * 30, "eflux": [1.0] * 30}}
+    chunks = list(
+        iter_order_chunks_with_edges(spec, bad_orders=[], pixel_edges=[0.0, 1 / 3, 2 / 3, 1.0])
+    )
+    assert [k for k, *_ in chunks] == ["2_0", "2_1", "2_2"]

--- a/tests/test_fit_apf_rv_keplerian.py
+++ b/tests/test_fit_apf_rv_keplerian.py
@@ -160,6 +160,43 @@ def test_fit_keplerian_clips_initial_guess() -> None:
     assert np.all(np.isfinite(params))
 
 
+def test_effective_yerr_uses_formal_error_and_jitter() -> None:
+    pts = [
+        fitmod.RVPoint(mjd=1.0, rv=0.0, rv_err=0.1, rms=0.9, file="a", telescope="APF"),
+        fitmod.RVPoint(mjd=2.0, rv=1.0, rv_err=0.2, rms=0.8, file="b", telescope="APF"),
+    ]
+    yerr = fitmod.effective_yerr_for_points(pts)
+    assert np.allclose(yerr, [0.1, 0.2])
+    yerr_j = fitmod.effective_yerr_for_points(pts, {"jitter_kms": 0.3})
+    assert np.allclose(yerr_j, np.sqrt(np.array([0.1, 0.2]) ** 2 + 0.3**2))
+
+
+def test_profile_jitter_stays_small_when_orbit_matches() -> None:
+    t = np.linspace(60000.0, 60120.0, 16)
+    params = np.array([np.log(101.0), 24.0, 0.1, 0.0, 0.2, 10.0])
+    y = fitmod.rv_model(params, t, float(np.median(t)))
+    yerr = np.full_like(t, 0.03)
+    jit = fitmod._profile_jitter_kms(y, y, yerr)
+    assert jit < 0.5
+
+
+def test_fit_keplerian_fit_jitter_recovers_extra_scatter() -> None:
+    rng = np.random.default_rng(42)
+    t = np.linspace(60000.0, 60120.0, 12)
+    p_true = 15.0
+    params = np.array([np.log(p_true), 4.0, 0.1, 0.0, 0.2, -12.0])
+    y = fitmod.rv_model(params, t, float(np.median(t)))
+    y += rng.normal(0.0, 0.35, size=t.size)
+    yerr = np.full_like(t, 0.05)
+    _, rep_no_jit = fitmod.fit_keplerian(t, y, yerr, period_min=10.0, period_max=20.0)
+    _, rep_jit = fitmod.fit_keplerian(
+        t, y, yerr, period_min=10.0, period_max=20.0, fit_jitter=True
+    )
+    assert rep_no_jit["chi2_red"] > rep_jit["chi2_red"]
+    assert rep_jit["jitter_kms"] > 0.05
+    assert rep_jit["fit_jitter"] is True
+
+
 def test_parse_summary_excludes_legacy_sentinel_rv(tmp_path: Path) -> None:
     summ = tmp_path / "Gaia_DR3_958479989998172288_summary.txt"
     summ.write_text(

--- a/tests/test_weighted_template_fft.py
+++ b/tests/test_weighted_template_fft.py
@@ -5,6 +5,7 @@ import numpy as np
 from darkhunter_rv import config
 from darkhunter_rv.pipeline import (
     _mask_ccf_stack_error_inflated,
+    _weighted_rms,
     _weighted_method_rv_from_rows,
     _weighted_template_fft_for_order,
 )
@@ -73,6 +74,17 @@ def test_mask_ccf_inflates_combined_err_when_chunks_disagree():
     assert er > 0.4, f"expected inflation above formal IVAR error, got er={er}"
 
 
+def test_weighted_rms_differs_from_unweighted_when_errors_differ():
+    rv = np.array([10.0, 13.0, 12.0], float)
+    er = np.array([0.01, 1.0, 0.01], float)
+    w = 1.0 / (er**2 + 1e-9)
+    mu = float(np.average(rv, weights=w))
+    wrms = _weighted_rms(rv, er, mu_weighted=mu)
+    urms = float(np.std(rv))
+    assert wrms < urms
+    assert np.isclose(wrms, float(np.sqrt(np.average((rv - mu) ** 2, weights=w))))
+
+
 def test_mask_ccf_stack_inflation_helper():
     rv = np.array([10.0, 14.0, 12.0], float)
     er = np.array([0.01, 0.01, 0.01], float)
@@ -81,7 +93,7 @@ def test_mask_ccf_stack_inflation_helper():
     formal = float(np.sqrt(1.0 / np.sum(1.0 / (er**2))))
     out = _mask_ccf_stack_error_inflated(rv, er, formal, mu_weighted=mu)
     assert out > formal * 5.0
-    rms_term = float(np.sqrt(np.mean((rv - mu) ** 2)) / np.sqrt(len(rv)))
+    rms_term = _weighted_rms(rv, er, mu_weighted=mu) / np.sqrt(len(rv))
     assert out >= rms_term - 1e-9
 
 

--- a/tests/validation/test_benchmark_cool_precision.py
+++ b/tests/validation/test_benchmark_cool_precision.py
@@ -1,0 +1,46 @@
+"""Tests for validation.benchmark_cool_precision."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from validation.benchmark_cool_precision import _load_exposure_rows, _summarize
+
+
+def _write_diag(path: Path, teff: float, snr: float, scatter: float) -> None:
+    rows = [
+        {
+            "file": "Gaia_DR3_1_epoch_1.txt",
+            "chunk_key": "12",
+            "method": "mask_ccf",
+            "rv_kms": 0.0,
+            "rv_err_kms": 0.05,
+            "qc_pass": True,
+            "teff": teff,
+            "ccf_peak_snr": snr,
+            "used_in_exposure_stack": True,
+            "chunk_scatter_kms": scatter,
+        },
+        {
+            "file": "Gaia_DR3_1_epoch_1.txt",
+            "chunk_key": "all",
+            "method": "mask_ccf",
+            "rv_kms": 0.0,
+            "rv_err_kms": 0.08,
+            "qc_pass": True,
+            "teff": teff,
+        },
+    ]
+    pd.DataFrame(rows).to_csv(path, index=False)
+
+
+def test_summarize_high_snr_subset(tmp_path: Path) -> None:
+    p = tmp_path / "a_diagnostics.csv"
+    _write_diag(p, teff=5000.0, snr=15.0, scatter=0.08)
+    tab = _load_exposure_rows([str(p)])
+    assert len(tab) == 1
+    s = _summarize(tab, min_log10_snr=1.0)
+    assert s["n"] == 1.0
+    assert s["median_chunk_scatter_kms"] == 0.08
+    assert s["median_chunk_scatter_kms"] < 0.1

--- a/tests/validation/test_chunk_adaptive_stack.py
+++ b/tests/validation/test_chunk_adaptive_stack.py
@@ -1,0 +1,151 @@
+"""Tests for adaptive multi-layout chunk stacking."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from validation.chunk_adaptive_stack import (
+    ChunkMeas,
+    adaptive_stack_for_file,
+    enumerate_stack_candidates,
+    select_best_candidate,
+)
+from validation.chunk_layout import build_equal_subchunk_layout, build_merge_orders_layout
+
+
+def _meas(
+    layout: str,
+    ck: str,
+    rv: float,
+    err: float,
+    orders: frozenset[int],
+    *,
+    file: str = "f1",
+    gid: str = "1",
+) -> ChunkMeas:
+    return ChunkMeas(
+        layout_name=layout,
+        chunk_key=ck,
+        rv_kms=rv,
+        rv_err_kms=err,
+        orders=orders,
+        qc_pass=True,
+        file=file,
+        gaia_dr3_id=gid,
+        mjd=60000.0,
+        teff=5500.0,
+    )
+
+
+def _fallback_for(rows: list[ChunkMeas]) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "layout_name": r.layout_name,
+                "chunk_key": r.chunk_key,
+                "bias_kms": 0.0,
+                "statistical_err_kms": r.rv_err_kms,
+                "intrinsic_scatter_kms": 0.0,
+            }
+            for r in rows
+        ]
+    )
+
+
+def test_whole_layout_candidate_present() -> None:
+    coarse = build_merge_orders_layout(merge_width=2, valid_orders=[10, 11, 12, 13, 14, 15, 16, 17])
+    s3 = build_equal_subchunk_layout(3)
+    layouts = {"merge_w2": coarse, "subchunks_3": s3}
+    file = "f1"
+    rows = [
+        _meas("merge_w2", "merge_0", 10.0, 0.25, frozenset({10, 11})),
+        _meas("merge_w2", "merge_1", 10.0, 0.25, frozenset({12, 13})),
+        _meas("merge_w2", "merge_2", 10.0, 0.25, frozenset({14, 15})),
+        _meas("merge_w2", "merge_3", 10.0, 0.25, frozenset({16, 17})),
+    ]
+    for o in (10, 11, 12, 13, 14, 15, 16, 17):
+        for si in range(3):
+            rows.append(_meas("subchunks_3", f"{o}_{si}", 10.0, 0.05, frozenset({o})))
+    df = pd.DataFrame([r.__dict__ | {"orders": r.orders} for r in rows])
+    idx = {(r.file, r.layout_name, r.chunk_key): r for r in rows}
+    empty_bias = pd.DataFrame(columns=["gaia_dr3_id", "layout_name", "chunk_key", "weighted_mean_residual_kms"])
+    intrinsic = __import__(
+        "validation.chunk_calibration", fromlist=["build_intrinsic_scatter_model"]
+    ).build_intrinsic_scatter_model(empty_bias)
+    fallback = _fallback_for(rows)
+    cands = enumerate_stack_candidates(
+        file,
+        idx,
+        layouts=layouts,
+        per_object=empty_bias,
+        fallback=fallback,
+        intrinsic_model=intrinsic,
+        star_meta={},
+    )
+    names = {c.name for c in cands}
+    assert "whole:subchunks_3" in names
+    assert "whole:merge_w2" in names
+
+
+def test_adaptive_matches_best_whole_layout() -> None:
+    s3 = build_equal_subchunk_layout(3)
+    s4 = build_equal_subchunk_layout(4)
+    layouts = {"subchunks_3": s3, "subchunks_4": s4}
+    file = "f1"
+    rows = []
+    for o in (10, 11, 12):
+        for si in range(3):
+            rows.append(_meas("subchunks_3", f"{o}_{si}", 10.0, 0.04, frozenset({o})))
+        for si in range(4):
+            rows.append(_meas("subchunks_4", f"{o}_{si}", 10.0, 0.06, frozenset({o})))
+    df = pd.DataFrame([r.__dict__ | {"orders": r.orders} for r in rows])
+    empty_bias = pd.DataFrame(columns=["gaia_dr3_id", "layout_name", "chunk_key", "weighted_mean_residual_kms"])
+    fallback = _fallback_for(rows)
+    intrinsic = __import__(
+        "validation.chunk_calibration", fromlist=["build_intrinsic_scatter_model"]
+    ).build_intrinsic_scatter_model(empty_bias)
+    final, _err, info = adaptive_stack_for_file(
+        file,
+        df,
+        layouts=layouts,
+        per_object=empty_bias,
+        fallback=fallback,
+        intrinsic_model=intrinsic,
+        star_meta={},
+    )
+    assert info["candidate_name"] == "whole:subchunks_3"
+    assert len(final) == 9
+    assert all(m.layout_name == "subchunks_3" for m in final)
+
+
+def test_select_best_never_worse_than_whole_candidates() -> None:
+    s3 = build_equal_subchunk_layout(3)
+    layouts = {"subchunks_3": s3}
+    file = "f1"
+    rows = []
+    for o in (10, 11, 12):
+        for si in range(3):
+            rows.append(_meas("subchunks_3", f"{o}_{si}", 10.0, 0.05, frozenset({o})))
+    idx = {(r.file, r.layout_name, r.chunk_key): r for r in rows}
+    empty_bias = pd.DataFrame(columns=["gaia_dr3_id", "layout_name", "chunk_key", "weighted_mean_residual_kms"])
+    fallback = _fallback_for(rows)
+    intrinsic = __import__(
+        "validation.chunk_calibration", fromlist=["build_intrinsic_scatter_model"]
+    ).build_intrinsic_scatter_model(empty_bias)
+    cands = enumerate_stack_candidates(
+        file, idx, layouts=layouts, per_object=empty_bias, fallback=fallback,
+        intrinsic_model=intrinsic, star_meta={},
+    )
+    best, best_out = select_best_candidate(
+        cands, per_object=empty_bias, fallback=fallback, intrinsic_model=intrinsic, star_meta={},
+    )
+    assert best is not None
+    for cand in cands:
+        if not cand.name.startswith("whole:"):
+            continue
+        out = __import__(
+            "validation.chunk_adaptive_stack", fromlist=["_stack_result_for_meas"]
+        )._stack_result_for_meas(
+            cand.chunks, per_object=empty_bias, fallback=fallback, intrinsic_model=intrinsic, star_meta={},
+        )
+        assert float(best_out["rv_err_calibrated_kms"]) <= float(out["rv_err_calibrated_kms"]) + 1e-9

--- a/tests/validation/test_chunk_bias_regression.py
+++ b/tests/validation/test_chunk_bias_regression.py
@@ -1,0 +1,77 @@
+"""Tests for chunk bias regression and layout utilities."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from darkhunter_rv.chunking import iter_order_chunks_with_edges
+from validation.chunk_bias_lib import fit_linear_model, truncated_cubic_basis
+from validation.chunk_bias_regression import _fit_model, choose_best_model, compare_models
+from validation.chunk_layout import ChunkLayout, load_chunk_layout, map_chunk_key, rebinned_chunk_rows
+
+
+def test_truncated_cubic_basis_shape() -> None:
+    x = np.linspace(0, 1, 10)
+    B = truncated_cubic_basis(x, np.array([0.25, 0.5, 0.75]))
+    assert B.shape == (10, 5)
+
+
+def test_iter_order_chunks_with_edges() -> None:
+    spec = {5: {"wavelength": list(range(40)), "flux": [1.0] * 40, "eflux": [1.0] * 40}}
+    chunks = list(iter_order_chunks_with_edges(spec, bad_orders=[], pixel_edges=[0.0, 0.5, 1.0]))
+    assert [k for k, *_ in chunks] == ["5_0", "5_1"]
+    assert sum(len(w) for _, w, *_ in chunks) == 40
+
+
+def test_map_chunk_key_merge() -> None:
+    layout = ChunkLayout(name="m", merge_orders=[[3, 4], [5, 6]])
+    assert map_chunk_key("3", layout) == "merge_0"
+    assert map_chunk_key("6", layout) == "merge_1"
+
+
+def test_rebinned_chunk_rows_ivw() -> None:
+    df = pd.DataFrame(
+        [
+            {"file": "a", "gaia_dr3_id": "1", "chunk_key": "3", "rv_kms": 10.0, "rv_err_kms": 0.1, "teff": 5000, "mjd": 1},
+            {"file": "a", "gaia_dr3_id": "1", "chunk_key": "4", "rv_kms": 12.0, "rv_err_kms": 0.1, "teff": 5000, "mjd": 1},
+        ]
+    )
+    layout = ChunkLayout(name="m", merge_orders=[[3, 4]])
+    out = rebinned_chunk_rows(df, layout)
+    assert len(out) == 1
+    assert out["chunk_key"].iloc[0] == "merge_0"
+    assert out["rv_kms"].iloc[0] == pytest.approx(11.0, abs=0.01)
+
+
+def test_compare_models_runs_on_synthetic() -> None:
+    rng = np.random.default_rng(0)
+    n = 80
+    order = np.tile(np.arange(10, 20), n // 10)
+    df = pd.DataFrame(
+        {
+            "gaia_dr3_id": np.repeat(np.arange(n // 10), 10).astype(str),
+            "chunk_key": order.astype(str),
+            "chunk_order": order,
+            "chunk_order_norm": (order - order.min()) / (order.max() - order.min()),
+            "weighted_mean_residual_kms": 0.5 * (order - order.mean()) / order.std() + rng.normal(0, 0.05, n),
+            "statistical_err_kms": np.full(n, 0.1),
+            "intrinsic_scatter_kms": np.full(n, 0.05),
+            "teff": 5000 + rng.normal(0, 100, n),
+            "logg": 4.5 + rng.normal(0, 0.1, n),
+            "mh": rng.normal(0, 0.1, n),
+            "log10_median_mask_ccf_peak_snr": np.full(n, 1.0),
+        }
+    )
+    cmp = compare_models(df)
+    assert "curve" in cmp["model"].values
+    chosen = choose_best_model(cmp)
+    assert chosen in cmp["model"].values
+
+
+def test_load_chunk_layout_yaml(tmp_path) -> None:
+    p = tmp_path / "t.yaml"
+    p.write_text("name: test\nsubchunks: 2\n")
+    layout = load_chunk_layout(p)
+    assert layout.subchunks == 2
+    assert layout.n_chunks_per_order() == 2

--- a/tests/validation/test_chunk_calibration.py
+++ b/tests/validation/test_chunk_calibration.py
@@ -1,0 +1,155 @@
+"""Tests for chunk bias application and relative reassessment."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from validation.chunk_calibration import (
+    build_intrinsic_scatter_model,
+    find_apf_apf_pairs,
+    load_chunk_bias_tables,
+    select_chunks_cdf_weight,
+    stack_calibrated_exposure,
+    summarize_relative_gate,
+    summarize_sigma_rv_metrics,
+    _sigma_total_kms,
+)
+
+
+def test_sigma_total_quadrature() -> None:
+    assert _sigma_total_kms(0.1, 0.05) == pytest.approx(np.hypot(0.1, 0.05))
+
+
+def test_stack_calibrated_exposure_uses_spectrum_stat_error() -> None:
+    per_object = pd.DataFrame(
+        [
+            {
+                "gaia_dr3_id": "1",
+                "chunk_key": "10",
+                "weighted_mean_residual_kms": 1.0,
+                "statistical_err_kms": 0.5,
+                "intrinsic_scatter_kms": 0.05,
+                "teff": 5500.0,
+            },
+            {
+                "gaia_dr3_id": "1",
+                "chunk_key": "11",
+                "weighted_mean_residual_kms": 0.5,
+                "statistical_err_kms": 0.5,
+                "intrinsic_scatter_kms": 0.05,
+                "teff": 5500.0,
+            },
+            {
+                "gaia_dr3_id": "1",
+                "chunk_key": "12",
+                "weighted_mean_residual_kms": 0.0,
+                "statistical_err_kms": 0.5,
+                "intrinsic_scatter_kms": 0.05,
+                "teff": 5500.0,
+            },
+        ]
+    )
+    fallback = pd.DataFrame(
+        columns=["chunk_key", "bias_kms", "statistical_err_kms", "intrinsic_scatter_kms"]
+    )
+    chunk_df = pd.DataFrame(
+        [
+            {
+                "gaia_dr3_id": "1",
+                "chunk_key": "10",
+                "rv_kms": 11.0,
+                "rv_err_kms": 0.1,
+                "chunk_kept": True,
+                "teff": 5500.0,
+            },
+            {
+                "gaia_dr3_id": "1",
+                "chunk_key": "11",
+                "rv_kms": 10.5,
+                "rv_err_kms": 0.1,
+                "chunk_kept": True,
+                "teff": 5500.0,
+            },
+            {
+                "gaia_dr3_id": "1",
+                "chunk_key": "12",
+                "rv_kms": 10.0,
+                "rv_err_kms": 0.1,
+                "chunk_kept": True,
+                "teff": 5500.0,
+            },
+        ]
+    )
+    intrinsic_model = build_intrinsic_scatter_model(per_object)
+    out = stack_calibrated_exposure(
+        chunk_df,
+        per_object=per_object,
+        fallback=fallback,
+        intrinsic_model=intrinsic_model,
+        min_chunks=3,
+    )
+    assert out["n_chunks_used"] == 3
+    assert out["rv_calibrated_kms"] == pytest.approx(10.0, abs=0.05)
+    sig = float(np.hypot(0.1, 0.05))
+    expected_err = 1.0 / np.sqrt(3 * (1.0 / sig**2))
+    assert out["rv_err_calibrated_kms"] == pytest.approx(expected_err, rel=0.01)
+
+
+def test_cdf_weight_selection_prefers_low_sigma_chunks() -> None:
+    sigmas = np.array([0.2, 0.4, 1.0, 2.0])
+    weights = 1.0 / sigmas**2
+    idx, err = select_chunks_cdf_weight(sigmas, weights, min_chunks=2, weight_fraction=0.9)
+    assert len(idx) >= 2
+    assert int(idx[0]) == 0  # lowest-σ chunk first
+    err_all = 1.0 / np.sqrt(np.sum(weights))
+    assert err >= err_all  # 90% weight subset is fewer chunks → larger σ_RV
+
+
+def test_summarize_sigma_rv_metrics() -> None:
+    epochs = pd.DataFrame(
+        {
+            "rv_err_calibrated_kms": [0.05, 0.08, 0.12],
+            "sigma_rv_core90_kms": [0.06, 0.09, 0.15],
+        }
+    )
+    m = summarize_sigma_rv_metrics(epochs)
+    assert m["min_sigma_rv_kms"] == pytest.approx(0.05)
+    assert m["median_sigma_rv_kms"] == pytest.approx(0.08)
+    assert m["p90_sigma_rv_kms"] == pytest.approx(0.112)
+
+
+def test_find_apf_apf_pairs() -> None:
+    apf = pd.DataFrame(
+        [
+            {"gaia_dr3_id": "1", "name": "A", "file": "e1", "mjd": 60000.0, "rv_kms": 10.0, "rv_err_kms": 0.1},
+            {"gaia_dr3_id": "1", "name": "A", "file": "e2", "mjd": 60002.0, "rv_kms": 10.05, "rv_err_kms": 0.1},
+        ]
+    )
+    pairs = find_apf_apf_pairs(apf, pair_window_days=7.0)
+    assert len(pairs) == 1
+    assert float(pairs["abs_delta_rv_kms"].iloc[0]) == pytest.approx(0.05)
+
+
+def test_summarize_relative_gate() -> None:
+    pairs = pd.DataFrame({"delta_rv_kms": [0.05, 0.2], "abs_delta_rv_kms": [0.05, 0.2], "gaia_dr3_id": ["1", "1"]})
+    s = summarize_relative_gate(pairs, goal_kms=0.1)
+    assert s["frac_below_goal"] == pytest.approx(0.5)
+
+
+def test_load_chunk_bias_tables() -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "gaia_dr3_id": "1",
+                "chunk_key": "10",
+                "weighted_mean_residual_kms": 0.1,
+                "statistical_err_kms": 0.2,
+                "intrinsic_scatter_kms": 0.05,
+                "sample_kept": True,
+            }
+        ]
+    )
+    per_obj, fallback = load_chunk_bias_tables(df)
+    assert len(per_obj) == 1
+    assert float(fallback.iloc[0]["bias_kms"]) == pytest.approx(0.1)

--- a/tests/validation/test_chunk_grid_search.py
+++ b/tests/validation/test_chunk_grid_search.py
@@ -1,0 +1,45 @@
+"""Tests for chunk layout grid builders."""
+from __future__ import annotations
+
+import pytest
+
+from validation.chunk_grid_search import composite_score
+from validation.chunk_layout import (
+    build_equal_subchunk_layout,
+    build_merge_orders_layout,
+    default_parametric_grid,
+)
+
+
+def test_build_merge_orders_layout_width_2() -> None:
+    lay = build_merge_orders_layout(merge_width=2, valid_orders=[3, 4, 5, 6])
+    assert lay.merge_orders == [[3, 4], [5, 6]]
+
+
+def test_default_parametric_grid_includes_merge_and_subchunk() -> None:
+    layouts = default_parametric_grid(subchunk_counts=[1, 2], merge_widths=[1, 2])
+    names = {lay.name for lay in layouts}
+    assert "subchunks_2" in names
+    assert "merge_w2" in names
+
+
+def test_composite_score_offline_valid() -> None:
+    import pandas as pd
+
+    row = pd.Series(
+        {
+            "offline_eval_valid": True,
+            "median_sigma_rv_kms": 0.05,
+            "p90_sigma_rv_kms": 0.08,
+            "relative_median_abs_delta_kms": 0.1,
+        }
+    )
+    assert composite_score(row) == pytest.approx(0.35 * 0.05 + 0.35 * 0.08 + 0.30 * 0.1)
+
+
+def test_composite_score_requires_both_metrics() -> None:
+    import math
+    import pandas as pd
+
+    row = pd.Series({"offline_eval_valid": True, "relative_median_abs_delta_kms": 0.1})
+    assert math.isinf(composite_score(row))

--- a/tests/validation/test_plot_chunk_residuals.py
+++ b/tests/validation/test_plot_chunk_residuals.py
@@ -9,6 +9,7 @@ from validation.plot_chunk_residuals import (
     _ordered_chunks,
     _summarize_chunks_per_object,
     _weighted_mean_and_errors,
+    apply_sample_object_bias_clip,
     apply_spectrum_chunk_outlier_clip,
     iterative_spectrum_chunk_clip_mask,
 )
@@ -64,6 +65,39 @@ def test_apply_spectrum_chunk_outlier_clip() -> None:
     kept = out[out["chunk_kept"]]
     assert len(kept) == 2
     assert kept["residual_kms"].abs().max() < 0.2
+
+
+def test_apply_sample_object_bias_clip() -> None:
+    import pandas as pd
+
+    df = pd.DataFrame(
+        [
+            {
+                "gaia_dr3_id": "1",
+                "chunk_key": "10",
+                "weighted_mean_residual_kms": 0.1,
+                "statistical_err_kms": 0.05,
+                "intrinsic_scatter_kms": 0.02,
+            },
+            {
+                "gaia_dr3_id": "2",
+                "chunk_key": "10",
+                "weighted_mean_residual_kms": 0.15,
+                "statistical_err_kms": 0.05,
+                "intrinsic_scatter_kms": 0.02,
+            },
+            {
+                "gaia_dr3_id": "3",
+                "chunk_key": "10",
+                "weighted_mean_residual_kms": 25.0,
+                "statistical_err_kms": 0.05,
+                "intrinsic_scatter_kms": 0.02,
+            },
+        ]
+    )
+    out = apply_sample_object_bias_clip(df, nsigma=5.0, max_delta_kms=10.0)
+    assert bool(out.loc[out["gaia_dr3_id"] == "3", "sample_kept"].iloc[0]) is False
+    assert out.loc[out["gaia_dr3_id"].isin(["1", "2"]), "sample_kept"].all()
 
 
 def test_summarize_chunks_per_object() -> None:

--- a/tests/validation/test_plot_chunk_residuals.py
+++ b/tests/validation/test_plot_chunk_residuals.py
@@ -9,6 +9,8 @@ from validation.plot_chunk_residuals import (
     _ordered_chunks,
     _summarize_chunks_per_object,
     _weighted_mean_and_errors,
+    apply_spectrum_chunk_outlier_clip,
+    iterative_loo_sigma_clip_mask,
 )
 
 
@@ -29,6 +31,30 @@ def test_weighted_mean_and_errors() -> None:
     assert mu == pytest.approx(0.1, abs=0.05)
     assert stat > 0
     assert intrinsic >= 0
+
+
+def test_iterative_loo_sigma_clip_removes_outlier() -> None:
+    rv = np.array([10.0, 10.1, 10.05, 50.0])
+    keep = iterative_loo_sigma_clip_mask(rv, nsigma=10.0)
+    assert not keep[3]
+    assert keep[:3].all()
+
+
+def test_apply_spectrum_chunk_outlier_clip() -> None:
+    import pandas as pd
+
+    df = pd.DataFrame(
+        [
+            {"file": "a", "rv_kms": 10.0, "rv_err_kms": 0.05, "exposure_rv_kms": 10.0, "residual_kms": 0.0},
+            {"file": "a", "rv_kms": 10.1, "rv_err_kms": 0.05, "exposure_rv_kms": 10.0, "residual_kms": 0.1},
+            {"file": "a", "rv_kms": 50.0, "rv_err_kms": 0.05, "exposure_rv_kms": 10.0, "residual_kms": 40.0},
+        ]
+    )
+    out = apply_spectrum_chunk_outlier_clip(df, nsigma=10.0)
+    assert not bool(out.loc[2, "chunk_kept"])
+    kept = out[out["chunk_kept"]]
+    assert len(kept) == 2
+    assert kept["residual_kms"].abs().max() < 0.2
 
 
 def test_summarize_chunks_per_object() -> None:

--- a/tests/validation/test_plot_chunk_residuals.py
+++ b/tests/validation/test_plot_chunk_residuals.py
@@ -1,0 +1,46 @@
+"""Tests for chunk residual plotting helpers."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from validation.plot_chunk_residuals import (
+    _chunk_sort_key,
+    _ordered_chunks,
+    _summarize_chunks_per_object,
+    _weighted_mean_and_errors,
+)
+
+
+def test_chunk_sort_key() -> None:
+    assert _chunk_sort_key("42") < _chunk_sort_key("43")
+    assert _chunk_sort_key("42_1") < _chunk_sort_key("42_2")
+
+
+def test_ordered_chunks() -> None:
+    assert _ordered_chunks(["10", "2", "2_1"]) == ["2", "2_1", "10"]
+
+
+def test_weighted_mean_and_errors() -> None:
+    mu, stat, intrinsic = _weighted_mean_and_errors(
+        np.array([0.1, 0.2, 0.0]),
+        np.array([0.05, 0.05, 0.05]),
+    )
+    assert mu == pytest.approx(0.1, abs=0.05)
+    assert stat > 0
+    assert intrinsic >= 0
+
+
+def test_summarize_chunks_per_object() -> None:
+    import pandas as pd
+
+    df = pd.DataFrame(
+        [
+            {"chunk_key": "1", "file": "a", "residual_kms": 0.1, "rv_err_kms": 0.05},
+            {"chunk_key": "1", "file": "b", "residual_kms": 0.3, "rv_err_kms": 0.05},
+            {"chunk_key": "2", "file": "a", "residual_kms": -0.2, "rv_err_kms": 0.05},
+        ]
+    )
+    s = _summarize_chunks_per_object(df)
+    assert len(s) == 2
+    assert "weighted_mean_residual_kms" in s.columns

--- a/tests/validation/test_plot_chunk_residuals.py
+++ b/tests/validation/test_plot_chunk_residuals.py
@@ -10,7 +10,7 @@ from validation.plot_chunk_residuals import (
     _summarize_chunks_per_object,
     _weighted_mean_and_errors,
     apply_spectrum_chunk_outlier_clip,
-    iterative_loo_sigma_clip_mask,
+    iterative_spectrum_chunk_clip_mask,
 )
 
 
@@ -33,11 +33,20 @@ def test_weighted_mean_and_errors() -> None:
     assert intrinsic >= 0
 
 
-def test_iterative_loo_sigma_clip_removes_outlier() -> None:
+def test_iterative_clip_removes_sigma_outlier() -> None:
     rv = np.array([10.0, 10.1, 10.05, 50.0])
-    keep = iterative_loo_sigma_clip_mask(rv, nsigma=10.0)
+    err = np.array([0.05, 0.05, 0.05, 0.05])
+    keep = iterative_spectrum_chunk_clip_mask(rv, err, nsigma=10.0, max_delta_kms=0.0)
     assert not keep[3]
     assert keep[:3].all()
+
+
+def test_iterative_clip_removes_far_from_weighted_mean() -> None:
+    rv = np.array([10.0, 10.1, 80.0])
+    err = np.array([0.05, 0.05, 0.05])
+    keep = iterative_spectrum_chunk_clip_mask(rv, err, nsigma=0.0, max_delta_kms=30.0)
+    assert not keep[2]
+    assert keep[:2].all()
 
 
 def test_apply_spectrum_chunk_outlier_clip() -> None:

--- a/tests/validation/test_plot_chunk_residuals.py
+++ b/tests/validation/test_plot_chunk_residuals.py
@@ -100,16 +100,19 @@ def test_apply_sample_object_bias_clip() -> None:
     assert out.loc[out["gaia_dr3_id"].isin(["1", "2"]), "sample_kept"].all()
 
 
-def test_summarize_chunks_per_object() -> None:
+def test_summarize_chunks_per_object_min_measurements() -> None:
     import pandas as pd
 
     df = pd.DataFrame(
         [
             {"chunk_key": "1", "file": "a", "residual_kms": 0.1, "rv_err_kms": 0.05},
             {"chunk_key": "1", "file": "b", "residual_kms": 0.3, "rv_err_kms": 0.05},
+            {"chunk_key": "1", "file": "c", "residual_kms": 0.2, "rv_err_kms": 0.05},
             {"chunk_key": "2", "file": "a", "residual_kms": -0.2, "rv_err_kms": 0.05},
+            {"chunk_key": "2", "file": "b", "residual_kms": -0.1, "rv_err_kms": 0.05},
         ]
     )
-    s = _summarize_chunks_per_object(df)
-    assert len(s) == 2
-    assert "weighted_mean_residual_kms" in s.columns
+    s = _summarize_chunks_per_object(df, min_measurements=3)
+    assert len(s) == 1
+    assert s.iloc[0]["chunk_key"] == "1"
+    assert int(s.iloc[0]["n_measurements"]) == 3

--- a/tests/validation/test_rv_overlap_lib.py
+++ b/tests/validation/test_rv_overlap_lib.py
@@ -1,0 +1,150 @@
+"""Tests for Phase A overlap inventory and calibration gates."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from validation.rv_overlap_lib import (
+    BJD_TO_MJD_OFFSET,
+    bjd_to_mjd,
+    build_overlap_stars,
+    enrich_pairs_with_deltas,
+    find_pair_candidates,
+    load_literature_epochs,
+    summarize_absolute_gate,
+    summarize_relative_gate,
+)
+from validation.rv_phase_a_baseline import run_phase_a
+from validation.rv_overlap_lib import PhaseAGoals
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "phase_a"
+
+
+def test_bjd_mjd_roundtrip() -> None:
+    bjd = 2459900.5
+    assert bjd_to_mjd(bjd) == pytest.approx(bjd - BJD_TO_MJD_OFFSET)
+
+
+def test_load_literature_mini() -> None:
+    df = load_literature_epochs(_FIXTURES / "literature_mini.csv")
+    assert len(df) == 3
+    assert "mjd" in df.columns
+    assert df["gaia_dr3_id"].nunique() == 2
+
+
+def _synthetic_apf() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "gaia_dr3_id": "1000000000000000001",
+                "name": "STAR_A",
+                "basename": "Gaia_DR3_1000000000000000001_epoch_1.txt",
+                "mjd": bjd_to_mjd(2459900.5),
+                "bjd": 2459900.5,
+                "rv_kms": 10.2,
+                "rv_err_kms": 0.05,
+                "epoch_id": "apf:e1",
+                "reference_key": "",
+                "instrument": "APF",
+                "bias_correction_applied": False,
+            },
+            {
+                "gaia_dr3_id": "1000000000000000001",
+                "name": "STAR_A",
+                "basename": "Gaia_DR3_1000000000000000001_epoch_2.txt",
+                "mjd": bjd_to_mjd(2459902.0),
+                "bjd": 2459902.0,
+                "rv_kms": 10.25,
+                "rv_err_kms": 0.05,
+                "epoch_id": "apf:e2",
+                "reference_key": "",
+                "instrument": "APF",
+                "bias_correction_applied": False,
+            },
+            {
+                "gaia_dr3_id": "1000000000000000002",
+                "name": "STAR_B",
+                "basename": "Gaia_DR3_1000000000000000002_epoch_1.txt",
+                "mjd": bjd_to_mjd(2459800.0),
+                "bjd": 2459800.0,
+                "rv_kms": 20.5,
+                "rv_err_kms": 0.1,
+                "epoch_id": "apf:e3",
+                "reference_key": "",
+                "instrument": "APF",
+                "bias_correction_applied": False,
+            },
+        ]
+    )
+
+
+def test_pair_candidates_types_and_window() -> None:
+    lit = load_literature_epochs(_FIXTURES / "literature_mini.csv")
+    apf = _synthetic_apf()
+    overlap = build_overlap_stars(lit, apf)
+    assert len(overlap) == 2
+    pairs = find_pair_candidates(lit, apf, overlap, window_days=7.0)
+    pairs = enrich_pairs_with_deltas(pairs)
+    types = set(pairs["pair_type"])
+    assert "apf_literature" in types
+    assert "apf_apf" in types
+    assert "literature_literature" in types
+    assert (pairs["pair_type"] == "apf_literature").sum() >= 2
+
+
+def test_absolute_gate_pass_fail() -> None:
+    pairs = pd.DataFrame(
+        [
+            {"pair_type": "apf_literature", "gaia_dr3_id": "1", "delta_rv_kms": 0.5, "abs_delta_rv_kms": 0.5},
+            {"pair_type": "apf_literature", "gaia_dr3_id": "1", "delta_rv_kms": 2.0, "abs_delta_rv_kms": 2.0},
+        ]
+    )
+    s = summarize_absolute_gate(pairs, threshold_kms=1.0)
+    assert s["n_pairs"] == 2
+    assert s["n_pass"] == 1
+    assert s["pass_rate"] == pytest.approx(0.5)
+
+
+def test_relative_gate_summary() -> None:
+    pairs = pd.DataFrame(
+        [
+            {"pair_type": "apf_apf", "gaia_dr3_id": "1", "delta_rv_kms": 0.05, "abs_delta_rv_kms": 0.05},
+            {"pair_type": "apf_apf", "gaia_dr3_id": "1", "delta_rv_kms": 0.2, "abs_delta_rv_kms": 0.2},
+        ]
+    )
+    s = summarize_relative_gate(pairs, goal_kms=0.1)
+    assert s["n_pairs"] == 2
+    assert s["frac_below_goal"] == pytest.approx(0.5)
+
+
+def test_run_phase_a_synthetic(tmp_path: Path) -> None:
+    summary_dir = tmp_path / "output"
+    summary_dir.mkdir()
+    gid = "1000000000000000001"
+    text = (
+        f"# Gaia DR3 {gid}\n\n[PIPELINE RESULTS]\n"
+        f"# File | MJD | RV | Err | RMS\n"
+        f"Gaia_DR3_{gid}_epoch_1.txt {bjd_to_mjd(2459900.5):.4f} 10.2 0.05 0.1\n"
+        f"Gaia_DR3_{gid}_epoch_2.txt {bjd_to_mjd(2459902.0):.4f} 10.25 0.05 0.1\n"
+    )
+    (summary_dir / f"Gaia_DR3_{gid}_summary.txt").write_text(text, encoding="utf-8")
+
+    out = tmp_path / "phase_a_out"
+    manifest = run_phase_a(
+        master_path=_FIXTURES / "literature_mini.csv",
+        summary_dir=summary_dir,
+        diagnostics_glob=None,
+        out_dir=out,
+        goals=PhaseAGoals(pair_window_days=7.0, absolute_gate_kms=1.0, relative_goal_kms=0.1),
+        bias_correction_applied=False,
+        prefer_diagnostics_rv=False,
+        run_id="test",
+    )
+    assert (out / "overlap_stars.csv").is_file()
+    assert (out / "pair_candidates.csv").is_file()
+    assert (out / "plots" / "inventory_star_counts.png").is_file()
+    assert manifest.inventory["n_overlap_stars"] >= 1
+    assert manifest.absolute_gate["n_pairs"] >= 1

--- a/validation/benchmark_cool_precision.py
+++ b/validation/benchmark_cool_precision.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Benchmark cool-star, high-S/N mask CCF precision (RV pipeline step 01).
+
+Reads ``*_diagnostics.csv``, filters exposures in the mask applicability region with
+``log10(median_mask_ccf_peak_snr) >= --min-log10-snr`` (default 1.0 ≈ S/N 10), and reports
+per-exposure chunk scatter and summary statistics vs the 0.1 km/s precision goal.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  python -m validation.benchmark_cool_precision \\
+    --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' \\
+    --out-dir validation_output/benchmark_cool_precision
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from glob import glob as glob_paths
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from darkhunter_rv.method_evaluation import exposure_method_flags  # noqa: E402
+from darkhunter_rv.method_regions import region_mask_applicable  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+PRECISION_GOAL_KMS = 0.1
+
+
+def _load_exposure_rows(paths: list[str]) -> pd.DataFrame:
+    rows: list[dict] = []
+    for p in paths:
+        df = pd.read_csv(p)
+        if df.empty:
+            continue
+        stem = Path(p).name.replace("_diagnostics.csv", "")
+        file_col = df["file"].iloc[0] if "file" in df.columns and len(df) else stem
+        chunk_rows = [r for _, r in df.iterrows() if str(r.get("chunk_key", "")) != "all"]
+        if not chunk_rows:
+            continue
+        flags = exposure_method_flags(chunk_rows)
+        teff = float(chunk_rows[0].get("teff", np.nan))
+        snr_med = float(flags.get("median_mask_ccf_peak_snr", np.nan))
+        log_snr = float(np.log10(snr_med)) if np.isfinite(snr_med) and snr_med > 0 else np.nan
+        if not bool(region_mask_applicable(np.array([teff]), np.array([log_snr]))[0]):
+            continue
+        scatter = float(chunk_rows[0].get("chunk_scatter_kms", np.nan))
+        if not np.isfinite(scatter):
+            mask_rows = [r for r in chunk_rows if r.get("method") == "mask_ccf" and r.get("used_in_exposure_stack")]
+            if len(mask_rows) >= 2:
+                rvs = np.array([float(r["rv_kms"]) for r in mask_rows if np.isfinite(r.get("rv_kms", np.nan))])
+                scatter = float(np.std(rvs, ddof=1)) if len(rvs) >= 2 else float("nan")
+        rows.append(
+            {
+                "file": file_col,
+                "teff": teff,
+                "median_mask_ccf_peak_snr": snr_med,
+                "log10_median_mask_ccf_peak_snr": log_snr,
+                "chunk_scatter_kms": scatter,
+                "mask_rv_kms": flags.get("mask_rv_kms"),
+                "mask_err_kms": flags.get("mask_err_kms"),
+                "mask_valid": flags.get("mask_valid"),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _summarize(tab: pd.DataFrame, min_log10_snr: float) -> dict[str, float]:
+    good = tab[np.isfinite(tab["chunk_scatter_kms"].astype(float))]
+    good = good[good["log10_median_mask_ccf_peak_snr"].astype(float) >= min_log10_snr]
+    sc = good["chunk_scatter_kms"].astype(float).values
+    if len(sc) == 0:
+        return {"n": 0.0}
+    return {
+        "n": float(len(sc)),
+        "median_chunk_scatter_kms": float(np.median(sc)),
+        "p90_chunk_scatter_kms": float(np.percentile(sc, 90)),
+        "frac_below_0p1_kms": float(np.mean(sc < PRECISION_GOAL_KMS)),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--diagnostics-glob", required=True)
+    ap.add_argument("--out-dir", type=Path, default=Path("validation_output/benchmark_cool_precision"))
+    ap.add_argument("--min-log10-snr", type=float, default=1.0, help="High-S/N cut (default log10=1 → S/N≥10)")
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    paths = sorted(glob_paths(args.diagnostics_glob))
+    if not paths:
+        logger.error("No diagnostics matched %s", args.diagnostics_glob)
+        sys.exit(1)
+
+    tab = _load_exposure_rows(paths)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    tab.to_csv(args.out_dir / "per_exposure_cool_high_snr.csv", index=False)
+
+    summary = _summarize(tab, args.min_log10_snr)
+    summary["precision_goal_kms"] = PRECISION_GOAL_KMS
+    summary["min_log10_snr"] = args.min_log10_snr
+    summary["meets_goal_median"] = bool(
+        summary.get("median_chunk_scatter_kms", np.inf) < PRECISION_GOAL_KMS
+    )
+    pd.DataFrame([summary]).to_csv(args.out_dir / "summary.csv", index=False)
+
+    good = tab[
+        np.isfinite(tab["chunk_scatter_kms"].astype(float))
+        & (tab["log10_median_mask_ccf_peak_snr"].astype(float) >= args.min_log10_snr)
+    ]
+    if len(good) >= 2:
+        fig, ax = plt.subplots(figsize=(6, 4))
+        ax.scatter(
+            good["log10_median_mask_ccf_peak_snr"].astype(float),
+            good["chunk_scatter_kms"].astype(float),
+            s=12,
+            alpha=0.7,
+        )
+        ax.axhline(PRECISION_GOAL_KMS, color="crimson", ls="--", label=f"goal {PRECISION_GOAL_KMS} km/s")
+        ax.set_xlabel("log10(median mask CCF peak S/N)")
+        ax.set_ylabel("chunk scatter (km/s)")
+        ax.set_title("Cool high-S/N mask precision benchmark (step 01)")
+        ax.legend()
+        fig.tight_layout()
+        fig.savefig(args.out_dir / "chunk_scatter_vs_log10_snr.png", dpi=120)
+        plt.close(fig)
+
+    logger.info("Wrote %s (%d exposures, n_high_snr=%s)", args.out_dir, len(tab), summary.get("n"))
+    if summary.get("n", 0) > 0:
+        logger.info(
+            "median scatter=%.3f km/s p90=%.3f frac<0.1=%.1f%% goal_met_median=%s",
+            summary["median_chunk_scatter_kms"],
+            summary["p90_chunk_scatter_kms"],
+            100.0 * summary["frac_below_0p1_kms"],
+            summary["meets_goal_median"],
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/chunk_adaptive_stack.py
+++ b/validation/chunk_adaptive_stack.py
@@ -1,0 +1,855 @@
+#!/usr/bin/env python3
+"""
+Adaptive chunk stacking: combine measurements from multiple campaign layouts.
+
+Each exposure is scored against a **complete candidate set**:
+
+1. **Whole layouts** — all chunks from one layout (merge_w4, subchunks_3, n3_red_heavy, …).
+   Guarantees the adaptive pick is at least as good as the best single layout on
+   exposures where that layout is valid.
+
+2. **Per-order greedy mix** — each echelle order uses one layout's **full** subchunk
+   partition for that order (never splices ``15_0`` from subchunks_4 with ``15_1``
+   from subchunks_3; edge presets are not assumed commensurate).
+
+Selection uses the same calibrated-stack σ_RV as evaluation.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  python -m validation.chunk_adaptive_stack --campaign-dir validation_output/chunk_campaign
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from validation.chunk_bias_lib import load_stellar_metadata  # noqa: E402
+from validation.chunk_calibration import (  # noqa: E402
+    build_intrinsic_scatter_model,
+    relative_pair_table,
+    summarize_relative_gate,
+    summarize_sigma_rv_metrics,
+)
+from validation.chunk_grid_search import composite_score  # noqa: E402
+from validation.chunk_layout import (  # noqa: E402
+    ChunkLayout,
+    apf_valid_orders,
+    load_chunk_layout,
+)
+from validation.chunk_measurement_cache import (  # noqa: E402
+    diagnostics_glob_for_layout,
+    ingest_layout_diagnostics_dir,
+    load_cache,
+)
+from validation.plot_chunk_residuals import (  # noqa: E402
+    DEFAULT_CHUNK_MAX_DELTA_KMS,
+    DEFAULT_CHUNK_OUTLIER_SIGMA,
+    _load_chunk_rows,
+    _summarize_chunks_per_object,
+    apply_spectrum_chunk_outlier_clip,
+)
+
+logger = logging.getLogger(__name__)
+
+# Fine per-order layouts (distinct pixel edges — not nested refinements of each other).
+PER_ORDER_LAYOUTS = (
+    "subchunks_2",
+    "subchunks_3",
+    "subchunks_4",
+    "n3_equal",
+    "n3_red_heavy",
+    "n3_blue_heavy",
+)
+COARSE_LAYOUTS = ("merge_w4", "merge_w3", "merge_w2")
+ALL_WHOLE_LAYOUTS = COARSE_LAYOUTS + PER_ORDER_LAYOUTS
+MIN_CHUNKS = 3
+
+
+@dataclass(frozen=True)
+class StackCandidate:
+    """Named chunk selection for one exposure."""
+
+    name: str
+    chunks: tuple[ChunkMeas, ...]
+
+
+@dataclass(frozen=True)
+class ChunkMeas:
+    layout_name: str
+    chunk_key: str
+    rv_kms: float
+    rv_err_kms: float
+    orders: frozenset[int]
+    qc_pass: bool
+    file: str
+    gaia_dr3_id: str
+    mjd: float
+    teff: float
+
+    @property
+    def bias_key(self) -> tuple[str, str]:
+        return (self.layout_name, self.chunk_key)
+
+
+def _valid_row(rv: float, err: float, qc: bool) -> bool:
+    return bool(qc) and np.isfinite(rv) and np.isfinite(err) and err > 0
+
+
+def _orders_for_chunk(chunk_key: str, layout: ChunkLayout) -> frozenset[int]:
+    from darkhunter_rv.chunking import parse_chunk_key
+
+    _order, sort_idx, kind = parse_chunk_key(chunk_key)
+    if kind == "merge" and layout.merge_orders:
+        gi = int(sort_idx)
+        if 0 <= gi < len(layout.merge_orders):
+            lo, hi = layout.merge_orders[gi]
+            valid = set(apf_valid_orders())
+            return frozenset(o for o in range(int(lo), int(hi) + 1) if o in valid)
+        return frozenset()
+    if _order is not None:
+        return frozenset([int(_order)])
+    return frozenset()
+
+
+def load_layouts(campaign_dir: Path) -> dict[str, ChunkLayout]:
+    layouts: dict[str, ChunkLayout] = {}
+    layout_dir = campaign_dir / "layouts"
+    if layout_dir.is_dir():
+        for p in sorted(layout_dir.glob("*.yaml")):
+            lay = load_chunk_layout(p)
+            layouts[lay.name] = lay
+    return layouts
+
+
+def load_campaign_measurements(
+    campaign_dir: Path,
+    layouts: dict[str, ChunkLayout],
+) -> pd.DataFrame:
+    """Cache + diagnostics for layouts missing from cache."""
+    cache_path = campaign_dir / "measurement_cache.csv"
+    cache = load_cache(cache_path)
+    have_layouts = set(cache["layout_name"].astype(str).unique()) if len(cache) else set()
+    for name, layout in layouts.items():
+        if name in have_layouts:
+            continue
+        diag_dir = campaign_dir / "diagnostics" / name
+        if diag_dir.is_dir():
+            cache = ingest_layout_diagnostics_dir(diag_dir, layout=layout, cache=cache)
+    rows: list[ChunkMeas] = []
+    for _, r in cache.iterrows():
+        layout_name = str(r["layout_name"])
+        layout = layouts.get(layout_name)
+        if layout is None:
+            continue
+        ck = str(r["chunk_key"])
+        rv = float(r["rv_kms"])
+        err = float(r["rv_err_kms"])
+        qc = bool(r.get("qc_pass", True))
+        if not _valid_row(rv, err, qc):
+            continue
+        rows.append(
+            ChunkMeas(
+                layout_name=layout_name,
+                chunk_key=ck,
+                rv_kms=rv,
+                rv_err_kms=err,
+                orders=_orders_for_chunk(ck, layout),
+                qc_pass=qc,
+                file=str(r["file"]),
+                gaia_dr3_id=str(r["gaia_dr3_id"]),
+                mjd=float(r["mjd"]),
+                teff=float(r["teff"]),
+            )
+        )
+    return pd.DataFrame([m.__dict__ | {"orders": m.orders} for m in rows])
+
+
+def _meas_list_to_chunk_df(meas_list: list[ChunkMeas], *, meta: dict) -> pd.DataFrame:
+    rows = []
+    for m in meas_list:
+        rows.append(
+            {
+                "gaia_dr3_id": m.gaia_dr3_id,
+                "file": m.file,
+                "mjd": m.mjd,
+                "teff": m.teff,
+                "logg": meta.get("logg", np.nan),
+                "mh": meta.get("mh", np.nan),
+                "layout_name": m.layout_name,
+                "chunk_key": m.chunk_key,
+                "rv_kms": m.rv_kms,
+                "rv_err_kms": m.rv_err_kms,
+                "chunk_kept": True,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _lookup_layout_bias(
+    gaia_id: str,
+    layout_name: str,
+    chunk_key: str,
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+) -> float:
+    po = pd.DataFrame()
+    if len(per_object) and "layout_name" in per_object.columns:
+        po = per_object[
+            (per_object["gaia_dr3_id"] == str(gaia_id))
+            & (per_object["layout_name"].astype(str) == str(layout_name))
+            & (per_object["chunk_key"].astype(str) == str(chunk_key))
+        ]
+    if len(po):
+        return float(po.iloc[0]["weighted_mean_residual_kms"])
+    fb = fallback[
+        (fallback["layout_name"].astype(str) == str(layout_name))
+        & (fallback["chunk_key"].astype(str) == str(chunk_key))
+    ]
+    if len(fb) and np.isfinite(fb.iloc[0]["bias_kms"]):
+        return float(fb.iloc[0]["bias_kms"])
+    return float("nan")
+
+
+def build_multi_layout_bias_tables(
+    campaign_dir: Path,
+    layouts: dict[str, ChunkLayout],
+) -> tuple[pd.DataFrame, pd.DataFrame, object]:
+    """Per-(layout, chunk_key) bias and intrinsic tables."""
+    parts = []
+    for name in sorted(layouts):
+        glob_pat = diagnostics_glob_for_layout(campaign_dir, name)
+        tab = _load_chunk_rows(glob_pat)
+        if tab.empty:
+            continue
+        tab = apply_spectrum_chunk_outlier_clip(
+            tab, nsigma=DEFAULT_CHUNK_OUTLIER_SIGMA, max_delta_kms=DEFAULT_CHUNK_MAX_DELTA_KMS
+        )
+        tab["layout_name"] = name
+        parts.append(tab)
+    if not parts:
+        empty = pd.DataFrame(columns=["gaia_dr3_id", "layout_name", "chunk_key", "weighted_mean_residual_kms"])
+        return empty, empty, build_intrinsic_scatter_model(empty)
+    tab = pd.concat(parts, ignore_index=True)
+    meta = load_stellar_metadata(REPO_ROOT / "output")
+    if not meta.empty:
+        tab = tab.merge(meta, on="gaia_dr3_id", how="left")
+        if "teff_gaia" in tab.columns:
+            miss = ~np.isfinite(tab["teff"].astype(float))
+            tab.loc[miss, "teff"] = tab.loc[miss, "teff_gaia"]
+    bias_rows = []
+    for (gid, layout_name), obj in tab.groupby(["gaia_dr3_id", "layout_name"], sort=False):
+        summ = _summarize_chunks_per_object(obj[obj["chunk_kept"].astype(bool)])
+        if summ.empty:
+            continue
+        summ["gaia_dr3_id"] = str(gid)
+        summ["layout_name"] = str(layout_name)
+        if "teff" not in summ.columns:
+            summ["teff"] = float(obj["teff"].iloc[0]) if "teff" in obj.columns else np.nan
+        bias_rows.append(summ)
+    bias = pd.concat(bias_rows, ignore_index=True) if bias_rows else pd.DataFrame()
+    if not bias.empty and not meta.empty:
+        bias = bias.merge(meta[["gaia_dr3_id", "logg", "mh"]], on="gaia_dr3_id", how="left")
+
+    fallback_rows = []
+    if not bias.empty:
+        for (layout_name, ck), g in bias.groupby(["layout_name", "chunk_key"]):
+            intrinsic = g["intrinsic_scatter_kms"].astype(float).values
+            b = g["weighted_mean_residual_kms"].astype(float).values
+            stat = g["statistical_err_kms"].astype(float).values
+            fallback_rows.append(
+                {
+                    "layout_name": str(layout_name),
+                    "chunk_key": str(ck),
+                    "bias_kms": float(np.nanmedian(b)),
+                    "statistical_err_kms": float(np.nanmedian(stat[np.isfinite(stat)]))
+                    if np.any(np.isfinite(stat))
+                    else np.nan,
+                    "intrinsic_scatter_kms": float(np.nanmedian(intrinsic[np.isfinite(intrinsic) & (intrinsic > 0)]))
+                    if np.any(np.isfinite(intrinsic) & (intrinsic > 0))
+                    else 0.0,
+                }
+            )
+    fallback = pd.DataFrame(fallback_rows)
+    intrinsic_model = build_intrinsic_scatter_model(bias) if not bias.empty else build_intrinsic_scatter_model(
+        pd.DataFrame()
+    )
+    return bias, fallback, intrinsic_model
+
+
+def _stack_layout_aware(
+    chunk_df: pd.DataFrame,
+    *,
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    intrinsic_model,
+    min_chunks: int,
+) -> dict:
+    """IVW stack with per-layout bias lookup and per-spectrum stat errors."""
+    from validation.chunk_calibration import _sigma_total_kms, _sigma_rv_from_weights
+
+    gid = str(chunk_df["gaia_dr3_id"].iloc[0])
+    kept = chunk_df[chunk_df["chunk_kept"].astype(bool)] if "chunk_kept" in chunk_df.columns else chunk_df
+    rv_d: list[float] = []
+    wts: list[float] = []
+    for _, r in kept.iterrows():
+        layout_name = str(r["layout_name"])
+        ck = str(r["chunk_key"])
+        bias = _lookup_layout_bias(gid, layout_name, ck, per_object, fallback)
+        if not np.isfinite(bias):
+            continue
+        stat = float(r.get("rv_err_kms", np.nan))
+        if not np.isfinite(stat) or stat <= 0:
+            continue
+        intrinsic = intrinsic_model.predict(
+            ck,
+            teff=float(r.get("teff", np.nan)),
+            logg=float(r.get("logg", np.nan)),
+            mh=float(r.get("mh", np.nan)),
+        )
+        sigma = _sigma_total_kms(stat, intrinsic)
+        rv_d.append(float(r["rv_kms"]) - bias)
+        wts.append(1.0 / sigma**2)
+    if len(rv_d) < min_chunks:
+        return {"rv_calibrated_kms": np.nan, "rv_err_calibrated_kms": np.nan, "n_chunks_used": len(rv_d)}
+    rv_arr = np.asarray(rv_d, float)
+    w_arr = np.asarray(wts, float)
+    mu = float(np.sum(w_arr * rv_arr) / np.sum(w_arr))
+    return {
+        "rv_calibrated_kms": mu,
+        "rv_err_calibrated_kms": _sigma_rv_from_weights(w_arr),
+        "n_chunks_used": int(len(rv_d)),
+    }
+
+
+def _stack_result_for_meas(
+    meas_list: list[ChunkMeas] | tuple[ChunkMeas, ...],
+    *,
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    intrinsic_model,
+    star_meta: dict,
+    min_chunks: int = MIN_CHUNKS,
+) -> dict:
+    if len(meas_list) < min_chunks:
+        return {"rv_calibrated_kms": np.nan, "rv_err_calibrated_kms": np.nan, "n_chunks_used": len(meas_list)}
+    chunk_df = _meas_list_to_chunk_df(list(meas_list), meta=star_meta)
+    return _stack_layout_aware(
+        chunk_df,
+        per_object=per_object,
+        fallback=fallback,
+        intrinsic_model=intrinsic_model,
+        min_chunks=min_chunks,
+    )
+
+
+def _index_by_file_layout(df: pd.DataFrame) -> dict[tuple[str, str, str], ChunkMeas]:
+    out: dict[tuple[str, str, str], ChunkMeas] = {}
+    for _, r in df.iterrows():
+        m = ChunkMeas(
+            layout_name=str(r["layout_name"]),
+            chunk_key=str(r["chunk_key"]),
+            rv_kms=float(r["rv_kms"]),
+            rv_err_kms=float(r["rv_err_kms"]),
+            orders=r["orders"],
+            qc_pass=bool(r["qc_pass"]),
+            file=str(r["file"]),
+            gaia_dr3_id=str(r["gaia_dr3_id"]),
+            mjd=float(r["mjd"]),
+            teff=float(r["teff"]),
+        )
+        out[(m.file, m.layout_name, m.chunk_key)] = m
+    return out
+
+
+def _whole_layout_chunks(
+    file: str,
+    layout_name: str,
+    idx: dict[tuple[str, str, str], ChunkMeas],
+) -> list[ChunkMeas] | None:
+    """All valid chunks for one file under a single layout."""
+    chunks = [m for (f, lay, _ck), m in idx.items() if f == file and lay == layout_name]
+    if len(chunks) < MIN_CHUNKS:
+        return None
+    return sorted(chunks, key=lambda m: (m.chunk_key, m.layout_name))
+
+
+def _orders_with_fine_data(
+    file: str,
+    idx: dict[tuple[str, str, str], ChunkMeas],
+    layouts: dict[str, ChunkLayout],
+) -> list[int]:
+    orders: set[int] = set()
+    for (f, layout_name, _ck), m in idx.items():
+        if f != file or layout_name not in PER_ORDER_LAYOUTS:
+            continue
+        orders |= set(m.orders)
+    return sorted(orders)
+
+
+def _order_subchunks(
+    file: str,
+    order: int,
+    layout_name: str,
+    layout: ChunkLayout,
+    idx: dict[tuple[str, str, str], ChunkMeas],
+) -> list[ChunkMeas] | None:
+    n = layout.n_chunks_per_order()
+    chunks: list[ChunkMeas] = []
+    for si in range(n):
+        ck = f"{order}_{si}" if n > 1 else str(order)
+        m = idx.get((file, layout_name, ck))
+        if m is None:
+            return None
+        chunks.append(m)
+    return chunks
+
+
+def _per_order_greedy_candidate(
+    file: str,
+    *,
+    layouts: dict[str, ChunkLayout],
+    idx: dict[tuple[str, str, str], ChunkMeas],
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    intrinsic_model,
+    star_meta: dict,
+) -> StackCandidate | None:
+    """
+    Greedily assign each echelle order an entire layout partition (all subchunks).
+
+    Layouts with incommensurate edges (subchunks_3 vs subchunks_4 vs n3_red_heavy)
+    are never mixed within the same order.
+    """
+    orders = _orders_with_fine_data(file, idx, layouts)
+    if not orders:
+        return None
+    selected: list[ChunkMeas] = []
+    for order in orders:
+        best_chunks: list[ChunkMeas] | None = None
+        best_err = float("inf")
+        for layout_name in PER_ORDER_LAYOUTS:
+            layout = layouts.get(layout_name)
+            if layout is None:
+                continue
+            order_chunks = _order_subchunks(file, order, layout_name, layout, idx)
+            if order_chunks is None:
+                continue
+            trial = selected + order_chunks
+            out = _stack_result_for_meas(
+                trial,
+                per_object=per_object,
+                fallback=fallback,
+                intrinsic_model=intrinsic_model,
+                star_meta=star_meta,
+                min_chunks=MIN_CHUNKS,
+            )
+            err = float(out["rv_err_calibrated_kms"])
+            if np.isfinite(err) and err < best_err:
+                best_err = err
+                best_chunks = order_chunks
+        if best_chunks is None:
+            return None
+        selected.extend(best_chunks)
+    if len(selected) < MIN_CHUNKS:
+        return None
+    return StackCandidate(name="per_order_greedy", chunks=tuple(selected))
+
+
+def enumerate_stack_candidates(
+    file: str,
+    idx: dict[tuple[str, str, str], ChunkMeas],
+    *,
+    layouts: dict[str, ChunkLayout],
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    intrinsic_model,
+    star_meta: dict,
+) -> list[StackCandidate]:
+    """All complete stacking candidates for one exposure."""
+    candidates: list[StackCandidate] = []
+    seen: set[frozenset[tuple[str, str]]] = set()
+
+    def _add(name: str, chunks: list[ChunkMeas] | tuple[ChunkMeas, ...]) -> None:
+        sig = frozenset(m.bias_key for m in chunks)
+        if sig in seen:
+            return
+        seen.add(sig)
+        candidates.append(StackCandidate(name=name, chunks=tuple(chunks)))
+
+    for layout_name in ALL_WHOLE_LAYOUTS:
+        if layout_name not in layouts:
+            continue
+        whole = _whole_layout_chunks(file, layout_name, idx)
+        if whole is not None:
+            _add(f"whole:{layout_name}", whole)
+
+    mix = _per_order_greedy_candidate(
+        file,
+        layouts=layouts,
+        idx=idx,
+        per_object=per_object,
+        fallback=fallback,
+        intrinsic_model=intrinsic_model,
+        star_meta=star_meta,
+    )
+    if mix is not None:
+        _add(mix.name, mix.chunks)
+    return candidates
+
+
+def select_best_candidate(
+    candidates: list[StackCandidate],
+    *,
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    intrinsic_model,
+    star_meta: dict,
+) -> tuple[StackCandidate | None, dict]:
+    """Pick candidate with lowest calibrated σ_RV (same metric as evaluation)."""
+    best: StackCandidate | None = None
+    best_out: dict = {}
+    best_err = float("inf")
+    for cand in candidates:
+        out = _stack_result_for_meas(
+            cand.chunks,
+            per_object=per_object,
+            fallback=fallback,
+            intrinsic_model=intrinsic_model,
+            star_meta=star_meta,
+        )
+        err = float(out["rv_err_calibrated_kms"])
+        if not np.isfinite(err):
+            continue
+        if err < best_err - 1e-12:
+            best_err = err
+            best = cand
+            best_out = out
+    return best, best_out
+
+
+def adaptive_stack_for_file(
+    file: str,
+    df: pd.DataFrame,
+    *,
+    layouts: dict[str, ChunkLayout],
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    intrinsic_model,
+    star_meta: dict,
+) -> tuple[list[ChunkMeas], float, dict]:
+    """Select best complete candidate; never worse than best whole layout on same file."""
+    sub = df[df["file"].astype(str) == str(file)]
+    if sub.empty:
+        return [], float("nan"), {}
+    idx = _index_by_file_layout(sub)
+    candidates = enumerate_stack_candidates(
+        file,
+        idx,
+        layouts=layouts,
+        per_object=per_object,
+        fallback=fallback,
+        intrinsic_model=intrinsic_model,
+        star_meta=star_meta,
+    )
+    best, stack = select_best_candidate(
+        candidates,
+        per_object=per_object,
+        fallback=fallback,
+        intrinsic_model=intrinsic_model,
+        star_meta=star_meta,
+    )
+    if best is None:
+        return [], float("nan"), {"candidate_name": "", "n_candidates": len(candidates)}
+
+    final = list(best.chunks)
+    layout_counts: dict[str, int] = {}
+    for m in final:
+        layout_counts[m.layout_name] = layout_counts.get(m.layout_name, 0) + 1
+    err = float(stack["rv_err_calibrated_kms"])
+    return final, err, {
+        "rv_calibrated_kms": stack["rv_calibrated_kms"],
+        "rv_err_calibrated_kms": err,
+        "n_chunks_used": stack["n_chunks_used"],
+        "candidate_name": best.name,
+        "n_candidates": len(candidates),
+        "layout_mix_json": json.dumps(layout_counts),
+    }
+
+
+def _star_meta_for_file(gid: str, meta_tbl: pd.DataFrame) -> dict:
+    star_meta = {"logg": np.nan, "mh": np.nan}
+    if meta_tbl.empty:
+        return star_meta
+    sm = meta_tbl[meta_tbl["gaia_dr3_id"] == str(gid)]
+    if len(sm):
+        star_meta["logg"] = float(sm.iloc[0].get("logg", np.nan))
+        star_meta["mh"] = float(sm.iloc[0].get("mh", np.nan))
+    return star_meta
+
+
+def epochs_whole_layout_from_cache(
+    meas_df: pd.DataFrame,
+    layout_name: str,
+    *,
+    idx: dict[tuple[str, str, str], ChunkMeas],
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    intrinsic_model,
+    meta_tbl: pd.DataFrame,
+) -> pd.DataFrame:
+    """Stack whole-layout epochs from the same measurement cache as adaptive."""
+    rows = []
+    for file_label in sorted(meas_df["file"].astype(str).unique()):
+        whole = _whole_layout_chunks(file_label, layout_name, idx)
+        if whole is None:
+            continue
+        gid = str(whole[0].gaia_dr3_id)
+        stack = _stack_result_for_meas(
+            whole,
+            per_object=per_object,
+            fallback=fallback,
+            intrinsic_model=intrinsic_model,
+            star_meta=_star_meta_for_file(gid, meta_tbl),
+        )
+        if not np.isfinite(stack.get("rv_calibrated_kms", np.nan)):
+            continue
+        rows.append(
+            {
+                "gaia_dr3_id": gid,
+                "file": str(file_label),
+                "mjd": float(whole[0].mjd),
+                "layout": layout_name,
+                "rv_calibrated_kms": stack["rv_calibrated_kms"],
+                "rv_err_calibrated_kms": stack["rv_err_calibrated_kms"],
+                "n_chunks_used": stack["n_chunks_used"],
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _metrics_row(label: str, epochs: pd.DataFrame, *, cohort_files: set[str] | None = None) -> dict:
+    sub = epochs
+    if cohort_files is not None:
+        sub = epochs[epochs["file"].astype(str).isin(cohort_files)]
+    if sub.empty:
+        return {"layout": label, "n_exposures": 0}
+    sigma = summarize_sigma_rv_metrics(sub)
+    pairs = relative_pair_table(sub, rv_col="rv_calibrated_kms", err_col="rv_err_calibrated_kms")
+    gate = summarize_relative_gate(pairs, goal_kms=0.1)
+    row = {
+        "layout": label,
+        "n_exposures": int(sub["rv_calibrated_kms"].notna().sum()),
+        **sigma,
+        "relative_median_abs_delta_kms": gate.get("median_abs_delta_rv_kms", np.nan),
+        "relative_p90_abs_delta_kms": gate.get("p90_abs_delta_rv_kms", np.nan),
+        "n_relative_pairs": gate.get("n_pairs", 0),
+        "offline_eval_valid": True,
+    }
+    row["composite_score"] = composite_score(pd.Series(row))
+    return row
+
+
+def run_adaptive_evaluation(campaign_dir: Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    layouts = load_layouts(campaign_dir)
+    if "merge_w4" not in layouts:
+        raise ValueError("merge_w4 layout YAML required in campaign layouts/")
+    meas_df = load_campaign_measurements(campaign_dir, layouts)
+    per_object, fallback, intrinsic_model = build_multi_layout_bias_tables(campaign_dir, layouts)
+    meta_tbl = load_stellar_metadata(REPO_ROOT / "output")
+
+    epoch_rows = []
+    files = sorted(meas_df["file"].astype(str).unique())
+    for fi, file_label in enumerate(files):
+        if fi % 20 == 0:
+            logger.info("Adaptive stack %d/%d", fi, len(files))
+        gid = str(meas_df.loc[meas_df["file"].astype(str) == file_label, "gaia_dr3_id"].iloc[0])
+        teff = float(meas_df.loc[meas_df["file"].astype(str) == file_label, "teff"].iloc[0])
+        mjd = float(meas_df.loc[meas_df["file"].astype(str) == file_label, "mjd"].iloc[0])
+        star_meta = _star_meta_for_file(gid, meta_tbl)
+        _, sig, info = adaptive_stack_for_file(
+            file_label,
+            meas_df,
+            layouts=layouts,
+            per_object=per_object,
+            fallback=fallback,
+            intrinsic_model=intrinsic_model,
+            star_meta=star_meta,
+        )
+        if not np.isfinite(info.get("rv_calibrated_kms", np.nan)):
+            continue
+        epoch_rows.append(
+            {
+                "gaia_dr3_id": gid,
+                "file": file_label,
+                "mjd": mjd,
+                "teff": teff,
+                "layout": "adaptive_mix",
+                "rv_calibrated_kms": info["rv_calibrated_kms"],
+                "rv_err_calibrated_kms": info["rv_err_calibrated_kms"],
+                "n_chunks_used": info["n_chunks_used"],
+                "candidate_name": info.get("candidate_name", ""),
+                "layout_mix_json": info["layout_mix_json"],
+            }
+        )
+    adaptive_epochs = pd.DataFrame(epoch_rows)
+    idx = _index_by_file_layout(meas_df)
+
+    compare_layouts = [lay for lay in ALL_WHOLE_LAYOUTS if lay in layouts]
+    layout_epochs: dict[str, pd.DataFrame] = {}
+    for lay in compare_layouts:
+        ep = epochs_whole_layout_from_cache(
+            meas_df,
+            lay,
+            idx=idx,
+            per_object=per_object,
+            fallback=fallback,
+            intrinsic_model=intrinsic_model,
+            meta_tbl=meta_tbl,
+        )
+        if not ep.empty:
+            layout_epochs[lay] = ep
+
+    adaptive_files = set(adaptive_epochs["file"].astype(str))
+    paired_summary_rows = []
+    paired_detail_rows = []
+
+    for lay in compare_layouts:
+        if lay not in layout_epochs:
+            continue
+        base = layout_epochs[lay]
+        shared_files = adaptive_files & set(base["file"].astype(str))
+        if not shared_files:
+            continue
+        sub_a = adaptive_epochs[adaptive_epochs["file"].astype(str).isin(shared_files)]
+        sub_b = base[base["file"].astype(str).isin(shared_files)]
+        row_a = _metrics_row("adaptive_mix", sub_a)
+        row_b = _metrics_row(lay, sub_b)
+        paired_detail_rows.append(
+            {
+                "baseline_layout": lay,
+                "n_shared_files": len(shared_files),
+                "adaptive_median_sigma_rv_kms": row_a.get("median_sigma_rv_kms", np.nan),
+                "baseline_median_sigma_rv_kms": row_b.get("median_sigma_rv_kms", np.nan),
+                "adaptive_p90_sigma_rv_kms": row_a.get("p90_sigma_rv_kms", np.nan),
+                "baseline_p90_sigma_rv_kms": row_b.get("p90_sigma_rv_kms", np.nan),
+                "adaptive_rel_median_kms": row_a.get("relative_median_abs_delta_kms", np.nan),
+                "baseline_rel_median_kms": row_b.get("relative_median_abs_delta_kms", np.nan),
+                "adaptive_composite_score": row_a.get("composite_score", np.nan),
+                "baseline_composite_score": row_b.get("composite_score", np.nan),
+            }
+        )
+        row_b["cohort"] = f"shared_with_adaptive"
+        row_b["n_shared_with_adaptive"] = len(shared_files)
+        paired_summary_rows.append(row_b)
+
+    if paired_detail_rows:
+        pd.DataFrame(paired_detail_rows).to_csv(campaign_dir / "adaptive_stack_paired.csv", index=False)
+
+    # Strict common cohort: identical files where adaptive and every whole layout are valid.
+    common_files = set(adaptive_files)
+    for ep in layout_epochs.values():
+        common_files &= set(ep["file"].astype(str))
+    common_rows = []
+    if common_files:
+        for label, epochs in [("adaptive_mix", adaptive_epochs)] + list(layout_epochs.items()):
+            common_rows.append(
+                _metrics_row(label, epochs, cohort_files=common_files)
+                | {"cohort": "common_all_layouts", "n_common_files": len(common_files)}
+            )
+        common_summary = pd.DataFrame(common_rows).sort_values("composite_score")
+        common_summary.to_csv(campaign_dir / "adaptive_stack_common_cohort.csv", index=False)
+        summary = common_summary
+    else:
+        summary = pd.DataFrame()
+
+    # Per-baseline paired cohort (adaptive vs each layout on that layout's shared files).
+    paired_cohort_rows = []
+    for lay in compare_layouts:
+        if lay not in layout_epochs:
+            continue
+        shared_files = adaptive_files & set(layout_epochs[lay]["file"].astype(str))
+        if not shared_files:
+            continue
+        paired_cohort_rows.append(
+            _metrics_row("adaptive_mix", adaptive_epochs, cohort_files=shared_files)
+            | {
+                "cohort": f"shared_with_{lay}",
+                "n_shared_files": len(shared_files),
+                "paired_baseline": lay,
+            }
+        )
+        paired_cohort_rows.append(
+            _metrics_row(lay, layout_epochs[lay], cohort_files=shared_files)
+            | {
+                "cohort": f"shared_with_{lay}",
+                "n_shared_files": len(shared_files),
+                "paired_baseline": lay,
+            }
+        )
+    if paired_cohort_rows:
+        pd.DataFrame(paired_cohort_rows).sort_values(["paired_baseline", "layout"]).to_csv(
+            campaign_dir / "adaptive_stack_paired_cohorts.csv", index=False
+        )
+
+    if layout_epochs:
+        pd.concat(layout_epochs.values(), ignore_index=True).to_csv(
+            campaign_dir / "whole_layout_epochs_cache.csv", index=False
+        )
+
+    return adaptive_epochs, summary
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--campaign-dir", type=Path, default=REPO_ROOT / "validation_output" / "chunk_campaign")
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    adaptive_epochs, summary = run_adaptive_evaluation(args.campaign_dir)
+    out_dir = args.campaign_dir
+    adaptive_epochs.to_csv(out_dir / "adaptive_stack_epochs.csv", index=False)
+    summary.to_csv(out_dir / "adaptive_stack_comparison.csv", index=False)
+    logger.info("Adaptive stack: %d exposures", len(adaptive_epochs))
+    if not summary.empty:
+        best = summary.iloc[0]
+        logger.info(
+            "Best (paired/shared cohort): %s composite=%.4f median σ_RV=%.4f p90 σ_RV=%.4f rel=%.4f",
+            best["layout"],
+            best["composite_score"],
+            best["median_sigma_rv_kms"],
+            best["p90_sigma_rv_kms"],
+            best["relative_median_abs_delta_kms"],
+        )
+        cols = [
+            "layout",
+            "cohort",
+            "n_exposures",
+            "n_shared_with_adaptive",
+            "median_sigma_rv_kms",
+            "p90_sigma_rv_kms",
+            "relative_median_abs_delta_kms",
+            "composite_score",
+        ]
+        show = [c for c in cols if c in summary.columns]
+        print(summary[show].to_string(index=False))
+    common_path = out_dir / "adaptive_stack_common_cohort.csv"
+    if common_path.is_file():
+        common = pd.read_csv(common_path)
+        logger.info("Common cohort (%d files) — see %s", int(common.iloc[0].get("n_common_files", 0)), common_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/chunk_bias_lib.py
+++ b/validation/chunk_bias_lib.py
@@ -1,0 +1,211 @@
+"""Shared helpers for chunk bias regression and layout evaluation."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from darkhunter_rv.gaia_utils import parse_gaia_metadata_from_star_summary
+from darkhunter_rv.summary_paths import discover_summary_files, parse_object_id_from_summary
+from validation.plot_chunk_residuals import _chunk_sort_key, _load_name_lookup
+
+
+def meta_float(meta: dict | None, key: str) -> float:
+    if not meta:
+        return float("nan")
+    v = meta.get(key)
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def load_stellar_metadata(summary_dir: Path) -> pd.DataFrame:
+    rows: list[dict] = []
+    for sp in discover_summary_files(summary_dir):
+        gid = parse_object_id_from_summary(sp)
+        if not gid:
+            continue
+        meta = parse_gaia_metadata_from_star_summary(sp)
+        rows.append(
+            {
+                "gaia_dr3_id": str(gid),
+                "teff_gaia": meta_float(meta, "Teff"),
+                "logg": meta_float(meta, "logg"),
+                "mh": meta_float(meta, "MH"),
+                "ruwe": meta_float(meta, "RUWE"),
+            }
+        )
+    if not rows:
+        return pd.DataFrame(columns=["gaia_dr3_id", "teff_gaia", "logg", "mh", "ruwe"])
+    return pd.DataFrame(rows).drop_duplicates("gaia_dr3_id")
+
+
+def load_bias_regression_table(
+    bias_csv: Path,
+    *,
+    summary_dir: Path,
+    long_csv_glob: str | None = None,
+    sample_kept_only: bool = True,
+) -> pd.DataFrame:
+    """Join per-object chunk biases with stellar parameters and optional S/N."""
+    df = pd.read_csv(bias_csv)
+    df["gaia_dr3_id"] = df["gaia_dr3_id"].astype(str)
+    df["chunk_key"] = df["chunk_key"].astype(str)
+    if sample_kept_only and "sample_kept" in df.columns:
+        df = df[df["sample_kept"].astype(bool)].copy()
+
+    meta = load_stellar_metadata(summary_dir)
+    df = df.merge(meta, on="gaia_dr3_id", how="left")
+
+    if "chunk_order" not in df.columns:
+        df["chunk_order"] = df["chunk_key"].map(lambda ck: _chunk_sort_key(str(ck))[0])
+
+    snr_rows: list[dict] = []
+    if long_csv_glob:
+        from glob import glob as glob_paths
+
+        for path in glob_paths(long_csv_glob):
+            try:
+                sub = pd.read_csv(path, usecols=["gaia_dr3_id", "log10_median_mask_ccf_peak_snr"])
+            except ValueError:
+                sub = pd.read_csv(path)
+                if "log10_median_mask_ccf_peak_snr" not in sub.columns:
+                    continue
+                sub = sub[["gaia_dr3_id", "log10_median_mask_ccf_peak_snr"]]
+            snr_rows.append(sub.drop_duplicates("gaia_dr3_id"))
+    if snr_rows:
+        snr = pd.concat(snr_rows, ignore_index=True)
+        snr["gaia_dr3_id"] = snr["gaia_dr3_id"].astype(str)
+        snr = snr.groupby("gaia_dr3_id", as_index=False)["log10_median_mask_ccf_peak_snr"].median()
+        df = df.merge(snr, on="gaia_dr3_id", how="left")
+
+    if "teff" not in df.columns:
+        df["teff"] = df["teff_gaia"]
+    else:
+        miss = ~np.isfinite(df["teff"].astype(float))
+        df.loc[miss, "teff"] = df.loc[miss, "teff_gaia"]
+
+    orders = df["chunk_order"].astype(float)
+    o_min, o_max = float(np.nanmin(orders)), float(np.nanmax(orders))
+    span = max(o_max - o_min, 1.0)
+    df["chunk_order_norm"] = (orders - o_min) / span
+    return df
+
+
+def truncated_cubic_basis(x: np.ndarray, knots: np.ndarray) -> np.ndarray:
+    """Design matrix: [1, x, (x-k1)^3+, ...] for natural-ish cubic spline."""
+    x = np.asarray(x, float)
+    cols = [np.ones_like(x), x]
+    for k in knots:
+        cols.append(np.maximum(0.0, x - float(k)) ** 3)
+    return np.column_stack(cols)
+
+
+def standardize(x: np.ndarray) -> tuple[np.ndarray, float, float]:
+    x = np.asarray(x, float)
+    mu = float(np.nanmean(x))
+    sd = float(np.nanstd(x))
+    if not np.isfinite(sd) or sd <= 0:
+        sd = 1.0
+    return (x - mu) / sd, mu, sd
+
+
+def fit_linear_model(X: np.ndarray, y: np.ndarray, *, weights: np.ndarray | None = None) -> dict:
+    """Weighted least squares with pseudo-inverse for stability."""
+    X = np.asarray(X, float)
+    y = np.asarray(y, float)
+    ok = np.isfinite(y) & np.all(np.isfinite(X), axis=1)
+    if weights is not None:
+        w = np.asarray(weights, float)
+        ok &= np.isfinite(w) & (w > 0)
+    else:
+        w = np.ones(len(y))
+    if ok.sum() < X.shape[1] + 1:
+        return {"coef": None, "rss": float("nan"), "n": int(ok.sum())}
+    Xo = X[ok]
+    yo = y[ok]
+    wo = w[ok]
+    sw = np.sqrt(wo)
+    beta, *_ = np.linalg.lstsq(Xo * sw[:, None], yo * sw, rcond=None)
+    resid = yo - Xo @ beta
+    rss = float(np.sum(wo * resid**2))
+    return {"coef": beta, "rss": rss, "n": int(ok.sum()), "mask": ok}
+
+
+def predict_linear(X: np.ndarray, coef: np.ndarray | None) -> np.ndarray:
+    if coef is None:
+        return np.full(len(X), np.nan)
+    return np.asarray(X, float) @ np.asarray(coef, float)
+
+
+def nested_f_test(rss_small: float, rss_large: float, n: int, p_small: int, p_large: int) -> dict:
+    """Compare nested models (large includes small)."""
+    if n <= p_large + 1 or not np.isfinite(rss_small) or not np.isfinite(rss_large):
+        return {"f_stat": float("nan"), "p_value": float("nan"), "delta_p": p_large - p_small}
+    df1 = p_large - p_small
+    df2 = n - p_large
+    if df1 <= 0 or df2 <= 0 or rss_large <= 0:
+        return {"f_stat": float("nan"), "p_value": float("nan"), "delta_p": df1}
+    f_stat = ((rss_small - rss_large) / df1) / (rss_large / df2)
+    from scipy import stats
+
+    p_value = float(1.0 - stats.f.cdf(f_stat, df1, df2))
+    return {"f_stat": float(f_stat), "p_value": p_value, "delta_p": int(df1)}
+
+
+def leave_one_object_cv_rmse(
+    df: pd.DataFrame,
+    *,
+    build_X,
+    y_col: str = "weighted_mean_residual_kms",
+    weight_col: str = "statistical_err_kms",
+) -> float:
+    """Leave-one-star-out CV RMSE for bias predictions."""
+    preds: list[float] = []
+    obs: list[float] = []
+    for gid, hold in df.groupby("gaia_dr3_id"):
+        train = df[df["gaia_dr3_id"] != gid]
+        test = hold
+        if len(train) < 5 or len(test) < 1:
+            continue
+        fit = build_X(train, fit=True)
+        if fit.get("coef") is None:
+            continue
+        X_test = build_X(test, fit=False, state=fit)
+        y_hat = predict_linear(X_test, fit["coef"])
+        y_true = test[y_col].astype(float).values
+        ok = np.isfinite(y_hat) & np.isfinite(y_true)
+        preds.extend(y_hat[ok].tolist())
+        obs.extend(y_true[ok].tolist())
+    if not preds:
+        return float("nan")
+    return float(np.sqrt(np.mean((np.asarray(preds) - np.asarray(obs)) ** 2)))
+
+
+def sample_mean_bias_curve(df: pd.DataFrame) -> pd.DataFrame:
+    """Sample-wide weighted mean bias vs chunk order (bias curve)."""
+    rows = []
+    for ck, g in df.groupby("chunk_key"):
+        bias = g["weighted_mean_residual_kms"].astype(float).values
+        stat = g["statistical_err_kms"].astype(float).values
+        intrinsic = g.get("intrinsic_scatter_kms", pd.Series(np.zeros(len(g)))).astype(float).values
+        sig2 = stat**2 + intrinsic**2
+        sig2 = np.where(np.isfinite(sig2) & (sig2 > 0), sig2, np.nan)
+        w = 1.0 / sig2
+        w = np.where(np.isfinite(w), w, 0.0)
+        if w.sum() <= 0:
+            mu = float(np.nanmean(bias))
+        else:
+            mu = float(np.average(bias, weights=w))
+        rows.append(
+            {
+                "chunk_key": str(ck),
+                "chunk_order": int(_chunk_sort_key(str(ck))[0]),
+                "sample_mean_bias_kms": mu,
+                "n_objects": int(len(g)),
+            }
+        )
+    out = pd.DataFrame(rows).sort_values("chunk_order")
+    return out.reset_index(drop=True)

--- a/validation/chunk_bias_regression.py
+++ b/validation/chunk_bias_regression.py
@@ -1,0 +1,726 @@
+#!/usr/bin/env python3
+"""
+Regress chunk biases on stellar parameters and echelle-order position (bias curve).
+
+Fits nested models (intercept, chunk curve, stellar covariates, interactions), tests
+significance, exports regression-adjusted bias table, and optionally re-runs the
+relative calibration gate.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  python -m validation.chunk_bias_regression \\
+    --bias-csv validation_output/chunk_residuals/per_object_chunk_bias.csv \\
+    --summary-dir output \\
+    --out-dir validation_output/chunk_bias_regression
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from validation.chunk_bias_lib import (  # noqa: E402
+    fit_linear_model,
+    load_bias_regression_table,
+    nested_f_test,
+    predict_linear,
+    sample_mean_bias_curve,
+    standardize,
+    truncated_cubic_basis,
+)
+from validation.plot_chunk_residuals import _load_name_lookup  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+SIGNIFICANCE_P = 0.05
+CV_IMPROVEMENT_KMS = 0.02
+
+
+@dataclass
+class ModelSpec:
+    name: str
+    description: str
+    feature_builder: str
+
+
+def _weights_from_df(df: pd.DataFrame) -> np.ndarray:
+    stat = df["statistical_err_kms"].astype(float).values
+    intrinsic = df.get("intrinsic_scatter_kms", pd.Series(np.zeros(len(df)))).astype(float).values
+    sig2 = stat**2 + intrinsic**2
+    sig2 = np.where(np.isfinite(sig2) & (sig2 > 0), sig2, np.nan)
+    w = 1.0 / sig2
+    return np.where(np.isfinite(w), w, 1.0)
+
+
+def _build_features(
+    df: pd.DataFrame,
+    *,
+    mode: str,
+    fit: bool,
+    state: dict | None = None,
+) -> np.ndarray | dict:
+    state = dict(state or {})
+    x_order = df["chunk_order_norm"].astype(float).values
+    if mode == "intercept":
+        X = np.ones((len(df), 1))
+        if fit:
+            return {"X": X, **state}
+        return X
+    if mode in ("curve", "curve_stellar", "curve_stellar_interaction", "full"):
+        knots = state.get("knots")
+        if fit or knots is None:
+            knots = np.quantile(x_order[np.isfinite(x_order)], [0.25, 0.5, 0.75])
+            state["knots"] = knots
+        X_parts = [truncated_cubic_basis(x_order, state["knots"])]
+    else:
+        X_parts = [np.ones((len(df), 1))]
+
+    if mode in ("stellar", "curve_stellar", "curve_stellar_interaction", "full"):
+        for col, key in [("teff", "teff"), ("logg", "logg"), ("mh", "mh"), ("log10_median_mask_ccf_peak_snr", "log_snr")]:
+            v = df[col].astype(float).values if col in df.columns else np.full(len(df), np.nan)
+            if fit or key not in state:
+                vs, mu, sd = standardize(v)
+                state[key] = (mu, sd)
+            else:
+                mu, sd = state[key]
+                vs = (v - mu) / sd if np.isfinite(sd) and sd > 0 else v * 0.0
+            X_parts.append(vs.reshape(-1, 1))
+
+    if mode in ("curve_stellar_interaction", "full"):
+        teff = df["teff"].astype(float).values if "teff" in df.columns else np.full(len(df), np.nan)
+        if fit or "teff_int" not in state:
+            teff_s, mu, sd = standardize(teff)
+            state["teff_int"] = (mu, sd)
+        else:
+            mu, sd = state["teff_int"]
+            teff_s = (teff - mu) / sd if np.isfinite(sd) and sd > 0 else teff * 0.0
+        X_parts.append((teff_s * x_order).reshape(-1, 1))
+
+    X = np.hstack(X_parts)
+    if fit:
+        return {"X": X, **state}
+    return X
+
+
+def _fit_model(df: pd.DataFrame, mode: str) -> dict:
+    pack = _build_features(df, mode=mode, fit=True)
+    X = pack["X"]
+    y = df["weighted_mean_residual_kms"].astype(float).values
+    w = _weights_from_df(df)
+    fit = fit_linear_model(X, y, weights=w)
+    fit["state"] = pack
+    fit["mode"] = mode
+    fit["p"] = int(X.shape[1])
+    if fit.get("coef") is not None:
+        fit["y_hat"] = predict_linear(X, fit["coef"])
+    else:
+        fit["y_hat"] = np.full(len(df), np.nan)
+    return fit
+
+
+def leave_one_object_cv_rmse_mode(df: pd.DataFrame, mode: str) -> float:
+    preds: list[float] = []
+    obs: list[float] = []
+    for gid in df["gaia_dr3_id"].unique():
+        test = df[df["gaia_dr3_id"] == gid]
+        train = df[df["gaia_dr3_id"] != gid]
+        if len(train) < 8:
+            continue
+        fit = _fit_model(train, mode)
+        if fit.get("coef") is None:
+            continue
+        X_test = _build_features(test, mode=mode, fit=False, state=fit["state"])
+        y_hat = predict_linear(X_test, fit["coef"])
+        y_true = test["weighted_mean_residual_kms"].astype(float).values
+        ok = np.isfinite(y_hat) & np.isfinite(y_true)
+        preds.extend(y_hat[ok].tolist())
+        obs.extend(y_true[ok].tolist())
+    if not preds:
+        return float("nan")
+    return float(np.sqrt(np.mean((np.asarray(preds) - np.asarray(obs)) ** 2)))
+
+
+def per_chunk_stellar_slopes(df: pd.DataFrame, *, min_objects: int = 4) -> pd.DataFrame:
+    rows = []
+    for ck, g in df.groupby("chunk_key"):
+        if len(g) < min_objects:
+            continue
+        teff = g["teff"].astype(float).values
+        bias = g["weighted_mean_residual_kms"].astype(float).values
+        ok = np.isfinite(teff) & np.isfinite(bias)
+        if ok.sum() < min_objects:
+            continue
+        X = np.column_stack([np.ones(ok.sum()), teff[ok]])
+        fit = fit_linear_model(X, bias[ok])
+        if fit.get("coef") is None:
+            continue
+        slope = float(fit["coef"][1])
+        from scipy import stats
+
+        # rough slope SE
+        resid = bias[ok] - X @ fit["coef"]
+        mse = float(np.sum(resid**2) / max(len(resid) - 2, 1))
+        cov = mse * np.linalg.pinv(X.T @ X)
+        slope_se = float(np.sqrt(cov[1, 1])) if cov.shape == (2, 2) else float("nan")
+        t_stat = slope / slope_se if np.isfinite(slope_se) and slope_se > 0 else float("nan")
+        p_value = float(2 * (1 - stats.t.cdf(abs(t_stat), df=max(len(resid) - 2, 1)))) if np.isfinite(t_stat) else float("nan")
+        rows.append(
+            {
+                "chunk_key": str(ck),
+                "chunk_order": int(g["chunk_order"].iloc[0]),
+                "n_objects": int(ok.sum()),
+                "teff_intercept_kms": float(fit["coef"][0]),
+                "teff_slope_kms_per_k": slope,
+                "teff_slope_se": slope_se,
+                "p_value": p_value,
+                "significant": bool(np.isfinite(p_value) and p_value < SIGNIFICANCE_P),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def compare_models(df: pd.DataFrame) -> pd.DataFrame:
+    modes = [
+        ("intercept", "Intercept only"),
+        ("curve", "Cubic spline on chunk order (bias curve)"),
+        ("stellar", "Teff, logg, [M/H], log10 S/N"),
+        ("curve_stellar", "Bias curve + stellar covariates"),
+        ("curve_stellar_interaction", "Bias curve + stellar + Teff×order interaction"),
+    ]
+    fits = {m: _fit_model(df, m) for m, _ in modes}
+    intercept = fits["intercept"]
+    rows = []
+    for m, desc in modes:
+        fit = fits[m]
+        cv = leave_one_object_cv_rmse_mode(df, m)
+        row = {
+            "model": m,
+            "description": desc,
+            "n_params": fit.get("p", 0),
+            "rss": fit.get("rss", float("nan")),
+            "cv_rmse_kms": cv,
+        }
+        if m != "intercept":
+            ft = nested_f_test(intercept["rss"], fit["rss"], fit["n"], intercept["p"], fit["p"])
+            row["f_vs_intercept"] = ft["f_stat"]
+            row["p_vs_intercept"] = ft["p_value"]
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def choose_best_model(model_cmp: pd.DataFrame) -> str:
+    ok = model_cmp[np.isfinite(model_cmp["cv_rmse_kms"].astype(float))].copy()
+    if ok.empty:
+        return "curve_stellar"
+    best = ok.loc[ok["cv_rmse_kms"].idxmin(), "model"]
+    base_cv = float(model_cmp.loc[model_cmp["model"] == "intercept", "cv_rmse_kms"].iloc[0])
+    best_cv = float(ok.loc[ok["model"] == best, "cv_rmse_kms"].iloc[0])
+    sig = model_cmp[model_cmp["p_vs_intercept"].astype(float) < SIGNIFICANCE_P]["model"].tolist()
+    if best == "intercept" or (base_cv - best_cv) < CV_IMPROVEMENT_KMS:
+        if "curve" in sig:
+            return "curve"
+        return "intercept"
+    return str(best)
+
+
+def export_regression_bias_table(df: pd.DataFrame, fit: dict) -> pd.DataFrame:
+    X = _build_features(df, mode=fit["mode"], fit=False, state=fit["state"])
+    y_hat = predict_linear(X, fit["coef"])
+    out = df.copy()
+    out["regression_bias_kms"] = y_hat
+    out["bias_residual_kms"] = out["weighted_mean_residual_kms"].astype(float) - y_hat
+    # hybrid: regression + shrunk object offset
+    obj_off = out.groupby("gaia_dr3_id")["bias_residual_kms"].transform("mean")
+    out["adjusted_bias_kms"] = y_hat + obj_off
+    out["bias_model"] = fit["mode"]
+    return out
+
+
+def _plot_bias_curve(curve: pd.DataFrame, fit: dict, df: pd.DataFrame, out_path: Path) -> None:
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.scatter(curve["chunk_order"], curve["sample_mean_bias_kms"], s=40, c="C0", label="sample mean bias", zorder=3)
+    x_grid = np.linspace(0, 1, 200)
+    if fit["mode"] in ("curve", "curve_stellar", "curve_stellar_interaction", "full"):
+        knots = fit["state"]["knots"]
+        B = truncated_cubic_basis(x_grid, knots)
+        n_curve = B.shape[1]
+        coef = np.asarray(fit["coef"], float)[:n_curve]
+        y_grid = B @ coef
+        o_min = float(df["chunk_order"].min())
+        o_max = float(df["chunk_order"].max())
+        xs = o_min + x_grid * max(o_max - o_min, 1)
+        ax.plot(xs, y_grid, "C1-", lw=1.5, label=f"curve component ({fit['mode']})")
+    ax.axhline(0, color="gray", ls=":", lw=0.8)
+    ax.set_xlabel("Echelle order")
+    ax.set_ylabel("Weighted mean chunk bias (km/s)")
+    ax.set_title("Sample bias curve vs echelle order")
+    ax.legend(fontsize=8)
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def _plot_stellar_dependence(df: pd.DataFrame, slopes: pd.DataFrame, out_path: Path) -> None:
+    fig, axes = plt.subplots(1, 3, figsize=(12, 4))
+    for ax, col, label in zip(axes, ["teff", "logg", "mh"], ["Teff (K)", "log g", "[M/H]"]):
+        sub = df[np.isfinite(df[col].astype(float)) & np.isfinite(df["weighted_mean_residual_kms"].astype(float))]
+        ax.scatter(sub[col], sub["weighted_mean_residual_kms"], s=12, alpha=0.35, c="C0")
+        ax.set_xlabel(label)
+        ax.set_ylabel("Chunk bias (km/s)")
+    n_sig = int(slopes["significant"].sum()) if len(slopes) and "significant" in slopes.columns else 0
+    fig.suptitle(f"Pooled chunk biases vs stellar params ({n_sig} chunks with significant Teff slope)")
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def _median_stellar_row(df: pd.DataFrame) -> pd.Series:
+    cols = ["teff", "logg", "mh", "log10_median_mask_ccf_peak_snr", "chunk_order_norm"]
+    row = {}
+    for c in cols:
+        if c in df.columns:
+            row[c] = float(np.nanmedian(df[c].astype(float)))
+        else:
+            row[c] = float("nan")
+    return pd.Series(row)
+
+
+def _model_bias_vs_teff(
+    df: pd.DataFrame,
+    fit: dict,
+    *,
+    chunk_order_norm: float,
+    teff_grid: np.ndarray,
+) -> np.ndarray:
+    """Evaluate a fitted bias model along Teff at fixed order and median other covariates."""
+    med = _median_stellar_row(df)
+    n = len(teff_grid)
+    synth = pd.DataFrame(
+        {
+            "teff": teff_grid,
+            "logg": np.full(n, med["logg"]),
+            "mh": np.full(n, med["mh"]),
+            "log10_median_mask_ccf_peak_snr": np.full(n, med["log10_median_mask_ccf_peak_snr"]),
+            "chunk_order_norm": np.full(n, chunk_order_norm),
+        }
+    )
+    X = _build_features(synth, mode=fit["mode"], fit=False, state=fit["state"])
+    return predict_linear(X, fit["coef"])
+
+
+def _plot_rv_bias_vs_teff_with_fits(
+    df: pd.DataFrame,
+    slopes: pd.DataFrame,
+    reg_table: pd.DataFrame,
+    chosen_fit: dict,
+    interaction_fit: dict,
+    out_path: Path,
+) -> None:
+    """Chunk RV bias vs Teff with per-chunk linear fits and applied correction model."""
+    sub = df[np.isfinite(df["teff"].astype(float)) & np.isfinite(df["weighted_mean_residual_kms"].astype(float))].copy()
+    if sub.empty:
+        return
+
+    teff = sub["teff"].astype(float).values
+    t_lo, t_hi = float(np.percentile(teff, 2)), float(np.percentile(teff, 98))
+    teff_grid = np.linspace(t_lo, t_hi, 120)
+    order_norm = sub["chunk_order_norm"].astype(float).values
+    o_min, o_max = float(np.nanmin(order_norm)), float(np.nanmax(order_norm))
+
+    fig, axes = plt.subplots(2, 1, figsize=(11, 9), sharex=True, gridspec_kw={"height_ratios": [1.2, 1.0]})
+
+    # --- Panel 1: measured bias + per-chunk Teff fits ---
+    ax0 = axes[0]
+    sc = ax0.scatter(
+        teff,
+        sub["weighted_mean_residual_kms"].astype(float),
+        c=order_norm,
+        cmap="viridis",
+        s=22,
+        alpha=0.55,
+        edgecolors="none",
+        label="per-object chunk bias",
+    )
+    cbar = fig.colorbar(sc, ax=ax0, pad=0.01, fraction=0.03)
+    cbar.set_label("normalized echelle order")
+
+    if len(slopes):
+        slope_lookup = slopes.set_index("chunk_key")
+        for _, row in slopes.iterrows():
+            if "teff_intercept_kms" not in row:
+                continue
+            y_line = float(row["teff_intercept_kms"]) + float(row["teff_slope_kms_per_k"]) * teff_grid
+            if bool(row.get("significant", False)):
+                color = plt.cm.viridis(
+                    (float(row["chunk_order"]) - o_min) / max(o_max - o_min, 1e-6)
+                )
+                ax0.plot(teff_grid, y_line, color=color, lw=1.4, alpha=0.75)
+            else:
+                ax0.plot(teff_grid, y_line, color="0.75", lw=0.5, alpha=0.35)
+
+    n_sig = int(slopes["significant"].sum()) if len(slopes) and "significant" in slopes.columns else 0
+    ax0.axhline(0.0, color="gray", ls=":", lw=0.8)
+    ax0.set_ylabel("Chunk RV bias (km/s)\n(RV_chunk − RV_exposure)")
+    ax0.set_title(
+        f"Chunk bias vs Teff — per-chunk linear fits ({n_sig} significant at p<{SIGNIFICANCE_P})"
+    )
+    ax0.plot([], [], color="0.75", lw=1, label="non-significant chunk fit")
+    ax0.plot([], [], color="C1", lw=1.5, label="significant chunk fit")
+    ax0.legend(loc="upper right", fontsize=8, framealpha=0.9)
+
+    # --- Panel 2: order-detrended residual + full correction model ---
+    ax1 = axes[1]
+    reg = reg_table.loc[sub.index].copy()
+    raw = sub["weighted_mean_residual_kms"].astype(float).values
+    order_component = reg["regression_bias_kms"].astype(float).values
+    residual = reg["bias_residual_kms"].astype(float).values
+    adjusted = reg["adjusted_bias_kms"].astype(float).values
+
+    ax1.scatter(
+        teff,
+        residual,
+        c=order_norm,
+        cmap="viridis",
+        s=22,
+        alpha=0.45,
+        edgecolors="none",
+        label="bias after order curve removed",
+    )
+    ax1.scatter(
+        teff,
+        adjusted,
+        facecolors="none",
+        edgecolors="C3",
+        s=36,
+        linewidths=0.9,
+        alpha=0.85,
+        label="applied correction (adj. bias)",
+    )
+
+    # Interaction model: bias vs Teff at low/mid/high order
+    if interaction_fit.get("coef") is not None:
+        order_ticks = [0.15, 0.5, 0.85]
+        line_styles = ["--", "-", "-."]
+        for onorm, ls in zip(order_ticks, line_styles, strict=True):
+            y_model = _model_bias_vs_teff(sub, interaction_fit, chunk_order_norm=onorm, teff_grid=teff_grid)
+            if np.any(np.isfinite(y_model)):
+                ax1.plot(
+                    teff_grid,
+                    y_model,
+                    color="C0",
+                    ls=ls,
+                    lw=1.8,
+                    label=f"curve+stellar+Teff×order (order={onorm:.0%})",
+                )
+
+    # Pooled stellar-only trend on order-subtracted residuals
+    stellar_fit = _fit_model(sub.assign(weighted_mean_residual_kms=residual), "stellar")
+    if stellar_fit.get("coef") is not None:
+        y_stellar = _model_bias_vs_teff(
+            sub.assign(chunk_order_norm=np.nanmedian(order_norm)),
+            stellar_fit,
+            chunk_order_norm=float(np.nanmedian(order_norm)),
+            teff_grid=teff_grid,
+        )
+        ax1.plot(teff_grid, y_stellar, color="C2", lw=2.0, label="stellar-only fit (on detrended bias)")
+
+    ax1.axhline(0.0, color="gray", ls=":", lw=0.8)
+    ax1.set_xlabel("Teff (K)")
+    ax1.set_ylabel("Bias / correction (km/s)")
+    ax1.set_title(
+        f"Order-detrended bias vs Teff — chosen model `{chosen_fit['mode']}` + interaction overlay"
+    )
+    ax1.legend(loc="upper right", fontsize=7.5, framealpha=0.9)
+
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=140)
+    plt.close(fig)
+
+
+def _write_report(
+    path: Path,
+    *,
+    model_cmp: pd.DataFrame,
+    chosen: str,
+    slopes: pd.DataFrame,
+    curve: pd.DataFrame,
+    n_rows: int,
+    n_stars: int,
+) -> None:
+    best_row = model_cmp[model_cmp["model"] == chosen].iloc[0]
+    lines = [
+        "# Chunk bias regression report",
+        "",
+        "## Data",
+        f"- Rows: {n_rows} (per-object × chunk, sample_kept=True)",
+        f"- Stars: {n_stars}",
+        "",
+        "## Model comparison (leave-one-star-out CV)",
+        "",
+        "| model | CV RMSE (km/s) | p vs intercept |",
+        "| --- | --- | --- |",
+    ]
+    for _, r in model_cmp.iterrows():
+        pval = r.get("p_vs_intercept", float("nan"))
+        pstr = f"{pval:.4g}" if np.isfinite(float(pval)) else "—"
+        cv = r.get("cv_rmse_kms", float("nan"))
+        cvstr = f"{cv:.4f}" if np.isfinite(float(cv)) else "—"
+        lines.append(f"| {r['model']} | {cvstr} | {pstr} |")
+    lines.extend(
+        [
+            "",
+            f"**Selected model:** `{chosen}` (CV RMSE = {best_row['cv_rmse_kms']:.4f} km/s)",
+            "",
+            "## Bias curve (sample mean vs echelle order)",
+            f"- Chunks: {len(curve)}",
+            f"- Bias range: {curve['sample_mean_bias_kms'].min():.3f} … {curve['sample_mean_bias_kms'].max():.3f} km/s",
+            "",
+            "## Per-chunk Teff slope test",
+        ]
+    )
+    if len(slopes):
+        n_sig = int(slopes["significant"].sum())
+        lines.append(f"- {n_sig} / {len(slopes)} chunks with significant Teff dependence (p < {SIGNIFICANCE_P})")
+        if n_sig:
+            top = slopes[slopes["significant"]].sort_values("p_value").head(8)
+            lines.append("")
+            lines.append("```")
+            lines.append(top[["chunk_key", "chunk_order", "teff_slope_kms_per_k", "p_value"]].to_string(index=False))
+            lines.append("```")
+    else:
+        lines.append("- Insufficient objects per chunk for per-chunk slopes")
+    lines.extend(
+        [
+            "",
+            "## Chunk optimization advice (next step)",
+            "",
+            "See `CHUNK_OPTIMIZATION_ADVICE.md` in this directory.",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_chunk_optimization_advice(path: Path) -> None:
+    text = """# Chunk definition optimization — recommended approach
+
+## Goal
+
+Choose wavelength/pixel chunk boundaries (N chunks from N+1 edges), telluric handling,
+and stack weights that minimize post-debias chunk scatter and relative RV disagreement.
+
+## Recommended staged workflow
+
+### Stage 1 — Parametric grid (do first; no ML required)
+
+1. **Equal sub-chunks:** `--subchunks N` for N ∈ {1, 2, 4, 8} (already supported in `darkhunter_rv/chunking.py`).
+2. **Order merging:** evaluate coarser layouts by merging adjacent echelle orders offline (`validation/evaluate_chunk_layout.py`) — fast on existing diagnostics.
+3. **Custom pixel edges:** YAML layout with N+1 fractional edges per order (`validation/chunk_layout.py`); rerun pipeline, then repeat bias/RMS loop.
+
+Score each layout with the same metrics:
+
+- Sample bias curve smoothness (regression spline RSS)
+- Per-exposure chunk scatter (median / p90)
+- APF–APF relative gate (≤7 d), median |ΔRV|
+
+### Stage 2 — Telluric-aware weighting (before ML)
+
+Improve weights using quantities already computed in pipeline QC:
+
+- Down-weight or zero chunks with high `telluric_fraction` (persist in diagnostics)
+- Down-weight chunks failing mask-line density cuts
+- Scale IVW weights by CCF quality (peak S/N, asymmetry)
+
+This is interpretable and should be tried before black-box chunk placement.
+
+### Stage 3 — ML for chunk edges (optional; issue #53)
+
+**Gradient boosted trees (XGBoost/LightGBM)** are reasonable for *predicting chunk quality* (|residual|, scatter contribution) from per-chunk features (order, λ, telluric fraction, S/N, Teff). Use ML to **rank** candidate edge placements or assign trust weights — not as the primary RV estimator.
+
+**Why not BDT for edges directly?**
+
+- Edge placement is a small discrete/continuous search problem; BDTs do not optimize boundaries natively.
+- Better: BDT predicts `|residual|` or `chunk_scatter` from features → aggregate score for a candidate layout on a validation set.
+
+**Practical hybrid:**
+
+1. Generate candidate layouts (grid over N, edge fractions, telluric splits).
+2. For each layout, compute bias table + relative gate (this repo's validation loop).
+3. Optionally train a BDT on chunk-level rows to predict residual magnitude; use mean predicted |residual| as a cheap proxy before full pipeline reruns.
+
+### Stage 4 — Closed loop
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+# 1) pick layout
+python -m validation.evaluate_chunk_layout --layouts calibration/chunk_layouts/*.yaml ...
+# 2) rerun pipeline with winning layout (when subchunks/edges change)
+python -m darkhunter_rv.pipeline ... --chunk-layout calibration/chunk_layouts/winner.yaml
+# 3) bias + regression + relative gate
+python -m validation.plot_chunk_residuals ...
+python -m validation.chunk_bias_regression ...
+python -m validation.reassess_relative_calibration --bias-csv .../regression_adjusted_chunk_bias.csv
+```
+
+## Starting point for N+1 edges
+
+See `calibration/chunk_layouts/` examples:
+
+- `whole_order.yaml` — current production (1 chunk / order)
+- `subchunks_4.yaml` — 4 equal pixel splits per order
+- `merge_pairs.yaml` — offline merge of adjacent orders (evaluation only)
+
+Adjust N by editing `subchunks` or `pixel_edges: [0.0, 0.25, 0.5, 0.75, 1.0]`.
+"""
+    path.write_text(text, encoding="utf-8")
+
+
+def run_regression(
+    *,
+    bias_csv: Path,
+    summary_dir: Path,
+    out_dir: Path,
+    long_csv_glob: str | None,
+    reassess: bool,
+) -> dict:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    df = load_bias_regression_table(
+        bias_csv,
+        summary_dir=summary_dir,
+        long_csv_glob=long_csv_glob,
+        sample_kept_only=True,
+    )
+    if df.empty:
+        return {"n_rows": 0}
+
+    name_lookup = _load_name_lookup(REPO_ROOT)
+    if "name" not in df.columns:
+        df["name"] = df["gaia_dr3_id"].map(lambda g: name_lookup.get(str(g), str(g)))
+
+    curve = sample_mean_bias_curve(df)
+    curve.to_csv(out_dir / "sample_bias_curve.csv", index=False)
+
+    slopes = per_chunk_stellar_slopes(df)
+    slopes.to_csv(out_dir / "per_chunk_teff_slopes.csv", index=False)
+
+    model_cmp = compare_models(df)
+    model_cmp.to_csv(out_dir / "model_comparison.csv", index=False)
+    chosen = choose_best_model(model_cmp)
+    best_fit = _fit_model(df, chosen)
+    interaction_fit = _fit_model(df, "curve_stellar_interaction")
+
+    reg_table = export_regression_bias_table(df, best_fit)
+    reg_table.to_csv(out_dir / "regression_adjusted_chunk_bias.csv", index=False)
+
+    # export format compatible with chunk_calibration (uses adjusted_bias_kms)
+    cal_export = reg_table.rename(
+        columns={
+            "adjusted_bias_kms": "weighted_mean_residual_kms",
+        }
+    )
+    cal_export["sample_kept"] = True
+    cal_export.to_csv(out_dir / "regression_chunk_bias_for_calibration.csv", index=False)
+
+    _plot_bias_curve(curve, best_fit, df, out_dir / "plots" / "bias_curve_fit.png")
+    _plot_stellar_dependence(df, slopes, out_dir / "plots" / "bias_vs_stellar_params.png")
+    _plot_rv_bias_vs_teff_with_fits(
+        df,
+        slopes,
+        reg_table,
+        best_fit,
+        interaction_fit,
+        out_dir / "plots" / "rv_bias_vs_teff_corrections.png",
+    )
+
+    write_chunk_optimization_advice(out_dir / "CHUNK_OPTIMIZATION_ADVICE.md")
+    _write_report(
+        out_dir / "REPORT.md",
+        model_cmp=model_cmp,
+        chosen=chosen,
+        slopes=slopes,
+        curve=curve,
+        n_rows=len(df),
+        n_stars=int(df["gaia_dr3_id"].nunique()),
+    )
+
+    manifest = {
+        "n_rows": int(len(df)),
+        "n_stars": int(df["gaia_dr3_id"].nunique()),
+        "chosen_model": chosen,
+        "model_comparison": model_cmp.to_dict(orient="records"),
+        "n_significant_teff_slopes": int(slopes["significant"].sum()) if len(slopes) else 0,
+    }
+    (out_dir / "regression_manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    if reassess:
+        from validation.reassess_relative_calibration import run_assessment
+
+        assess_dir = out_dir / "relative_gate_after_regression"
+        gate = run_assessment(
+            diagnostics_glob="output/Gaia_DR3_*_diagnostics.csv",
+            bias_csv=out_dir / "regression_chunk_bias_for_calibration.csv",
+            out_dir=assess_dir,
+            summary_dir=summary_dir,
+            pair_window_days=7.0,
+            goal_kms=0.1,
+            clip_sigma=7.0,
+            clip_max_delta_kms=20.0,
+            min_chunks=3,
+        )
+        manifest["relative_gate_after_regression"] = gate
+
+    return manifest
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--bias-csv",
+        type=Path,
+        default=REPO_ROOT / "validation_output" / "chunk_residuals" / "per_object_chunk_bias.csv",
+    )
+    ap.add_argument("--summary-dir", type=Path, default=REPO_ROOT / "output")
+    ap.add_argument("--out-dir", type=Path, default=REPO_ROOT / "validation_output" / "chunk_bias_regression")
+    ap.add_argument(
+        "--long-csv-glob",
+        default=str(REPO_ROOT / "validation_output" / "chunk_residuals" / "*" / "chunk_residuals_long.csv"),
+    )
+    ap.add_argument("--reassess-relative-gate", action="store_true")
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    if not args.bias_csv.is_file():
+        logger.error("Missing %s", args.bias_csv)
+        sys.exit(1)
+
+    manifest = run_regression(
+        bias_csv=args.bias_csv,
+        summary_dir=args.summary_dir,
+        out_dir=args.out_dir,
+        long_csv_glob=args.long_csv_glob,
+        reassess=args.reassess_relative_gate,
+    )
+    logger.info("Regression report -> %s (model=%s)", args.out_dir, manifest.get("chosen_model"))
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/chunk_calibration.py
+++ b/validation/chunk_calibration.py
@@ -1,0 +1,460 @@
+"""Apply per-chunk bias and stat+intrinsic weights to form calibrated exposure RVs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from validation.chunk_bias_lib import fit_linear_model, predict_linear, standardize
+from validation.plot_chunk_residuals import (
+    DEFAULT_CHUNK_MAX_DELTA_KMS,
+    DEFAULT_CHUNK_OUTLIER_SIGMA,
+    _load_chunk_rows,
+    apply_spectrum_chunk_outlier_clip,
+)
+
+
+def _sigma_total_kms(stat_kms: float, intrinsic_kms: float, *, floor_kms: float = 1e-6) -> float:
+    s2 = 0.0
+    if np.isfinite(stat_kms) and stat_kms > 0:
+        s2 += float(stat_kms) ** 2
+    if np.isfinite(intrinsic_kms) and intrinsic_kms > 0:
+        s2 += float(intrinsic_kms) ** 2
+    if s2 <= 0:
+        return floor_kms
+    return float(max(np.sqrt(s2), floor_kms))
+
+
+def _sigma_rv_from_weights(weights: np.ndarray) -> float:
+    w = weights[np.isfinite(weights) & (weights > 0)]
+    if w.size == 0:
+        return float("nan")
+    return float(1.0 / np.sqrt(np.sum(w)))
+
+
+@dataclass
+class IntrinsicScatterModel:
+    """Per-chunk sample intrinsic scatter with optional stellar scaling (not edge placement)."""
+
+    chunk_intrinsic_kms: dict[str, float]
+    stellar_coef: np.ndarray | None = None
+    stellar_state: dict | None = None
+
+    def predict(
+        self,
+        chunk_key: str,
+        *,
+        teff: float = np.nan,
+        logg: float = np.nan,
+        mh: float = np.nan,
+    ) -> float:
+        base = float(self.chunk_intrinsic_kms.get(str(chunk_key), 0.0))
+        if base <= 0 or self.stellar_coef is None or self.stellar_state is None:
+            return max(base, 0.0)
+        if not np.isfinite(teff):
+            return max(base, 0.0)
+        X = _stellar_design_row(teff, logg, mh, self.stellar_state)
+        log_mult = float(predict_linear(X, self.stellar_coef)[0])
+        if not np.isfinite(log_mult):
+            return max(base, 0.0)
+        return max(base * float(np.exp(log_mult)), 0.0)
+
+
+def _stellar_design_row(
+    teff: float,
+    logg: float,
+    mh: float,
+    state: dict,
+) -> np.ndarray:
+    cols = []
+    for val, key in [(teff, "teff"), (logg, "logg"), (mh, "mh")]:
+        mu, sd = state[key]
+        cols.append((float(val) - mu) / sd if np.isfinite(val) else 0.0)
+    return np.asarray([[1.0, cols[0], cols[1], cols[2]]], dtype=float)
+
+
+def build_intrinsic_scatter_model(bias: pd.DataFrame) -> IntrinsicScatterModel:
+    """Sample per-chunk intrinsic scatter + global stellar log-multiplier."""
+    chunk_intrinsic: dict[str, float] = {}
+    for ck, g in bias.groupby("chunk_key"):
+        intrinsic = g["intrinsic_scatter_kms"].astype(float).values
+        intrinsic = intrinsic[np.isfinite(intrinsic) & (intrinsic > 0)]
+        if intrinsic.size:
+            chunk_intrinsic[str(ck)] = float(np.median(intrinsic))
+
+    rows = []
+    for _, r in bias.iterrows():
+        intr = float(r.get("intrinsic_scatter_kms", np.nan))
+        ck = str(r["chunk_key"])
+        base = chunk_intrinsic.get(ck, np.nan)
+        if not np.isfinite(intr) or intr <= 0 or not np.isfinite(base) or base <= 0:
+            continue
+        rows.append(
+            {
+                "teff": float(r.get("teff", np.nan)),
+                "logg": float(r.get("logg", np.nan)),
+                "mh": float(r.get("mh", np.nan)),
+                "log_ratio": float(np.log(intr / base)),
+            }
+        )
+    stellar_coef = None
+    stellar_state: dict | None = None
+    if len(rows) >= 20:
+        df = pd.DataFrame(rows)
+        state: dict = {}
+        X_cols = [np.ones(len(df))]
+        for col, key in [("teff", "teff"), ("logg", "logg"), ("mh", "mh")]:
+            v = df[col].astype(float).values
+            vs, mu, sd = standardize(v)
+            state[key] = (mu, sd)
+            X_cols.append(vs)
+        X = np.column_stack(X_cols)
+        y = df["log_ratio"].astype(float).values
+        fit = fit_linear_model(X, y)
+        if fit.get("coef") is not None:
+            stellar_coef = fit["coef"]
+            stellar_state = state
+
+    return IntrinsicScatterModel(chunk_intrinsic_kms=chunk_intrinsic, stellar_coef=stellar_coef, stellar_state=stellar_state)
+
+
+def build_layout_fallback_tables(bias: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Per-object chunk table and sample fallback (bias + historical stat/intrinsic)."""
+    fallback_rows = []
+    for ck, g in bias.groupby("chunk_key"):
+        stat = g["statistical_err_kms"].astype(float).values
+        intrinsic = g["intrinsic_scatter_kms"].astype(float).values
+        b = g["weighted_mean_residual_kms"].astype(float).values
+        sig2 = np.array(
+            [_sigma_total_kms(float(s), float(i)) ** 2 for s, i in zip(stat, intrinsic, strict=True)],
+            dtype=float,
+        )
+        w = 1.0 / np.maximum(sig2, 1e-12)
+        w = np.where(np.isfinite(w), w, 0.0)
+        fallback_rows.append(
+            {
+                "chunk_key": str(ck),
+                "bias_kms": float(np.average(b, weights=w)) if w.sum() > 0 else float(np.nanmean(b)),
+                "statistical_err_kms": float(np.nanmedian(stat[np.isfinite(stat) & (stat > 0)]))
+                if np.any(np.isfinite(stat) & (stat > 0))
+                else np.nan,
+                "intrinsic_scatter_kms": float(np.nanmedian(intrinsic[np.isfinite(intrinsic) & (intrinsic > 0)]))
+                if np.any(np.isfinite(intrinsic) & (intrinsic > 0))
+                else 0.0,
+            }
+        )
+    return bias, pd.DataFrame(fallback_rows)
+
+
+def load_chunk_bias_tables(bias_csv: pd.DataFrame | str | Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Return (per_object_chunk, sample_fallback_by_chunk)."""
+    if isinstance(bias_csv, (str, Path)):
+        bias_csv = pd.read_csv(bias_csv)
+    df = bias_csv.copy()
+    df["gaia_dr3_id"] = df["gaia_dr3_id"].astype(str)
+    df["chunk_key"] = df["chunk_key"].astype(str)
+    if "sample_kept" in df.columns:
+        sample_src = df[df["sample_kept"].astype(bool)]
+    else:
+        sample_src = df
+    _, fallback = build_layout_fallback_tables(sample_src)
+    return df, fallback
+
+
+def lookup_chunk_bias(
+    gaia_id: str,
+    chunk_key: str,
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+) -> tuple[float, str]:
+    """Return debias correction (km/s) and source label."""
+    po = per_object[
+        (per_object["gaia_dr3_id"] == str(gaia_id))
+        & (per_object["chunk_key"] == str(chunk_key))
+    ]
+    if len(po):
+        return float(po.iloc[0]["weighted_mean_residual_kms"]), "object"
+    fb = fallback[fallback["chunk_key"] == str(chunk_key)]
+    if len(fb) and np.isfinite(fb.iloc[0]["bias_kms"]):
+        return float(fb.iloc[0]["bias_kms"]), "sample_fallback"
+    return float("nan"), "missing"
+
+
+def lookup_chunk_calibration(
+    gaia_id: str,
+    chunk_key: str,
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+) -> tuple[float, float, float, str]:
+    """Return bias_kms, stat_err, intrinsic_scatter, source (legacy aggregate stat)."""
+    bias, src = lookup_chunk_bias(gaia_id, chunk_key, per_object, fallback)
+    fb = fallback[fallback["chunk_key"] == str(chunk_key)]
+    if len(fb):
+        r = fb.iloc[0]
+        return (
+            bias,
+            float(r.get("statistical_err_kms", np.nan)),
+            float(r.get("intrinsic_scatter_kms", np.nan)),
+            src,
+        )
+    return bias, float("nan"), float("nan"), src
+
+
+def _chunk_weight(
+    row: pd.Series,
+    *,
+    per_object: pd.DataFrame,
+    intrinsic_model: IntrinsicScatterModel,
+    fallback: pd.DataFrame,
+) -> tuple[float, float, float, str] | None:
+    """Per-chunk debiased RV and IVW weight using this spectrum's stat error."""
+    bias, src = lookup_chunk_bias(
+        str(row["gaia_dr3_id"]),
+        str(row["chunk_key"]),
+        per_object,
+        fallback,
+    )
+    if not np.isfinite(bias):
+        return None
+    stat = float(row.get("rv_err_kms", np.nan))
+    if not np.isfinite(stat) or stat <= 0:
+        return None
+    intrinsic = intrinsic_model.predict(
+        str(row["chunk_key"]),
+        teff=float(row.get("teff", np.nan)),
+        logg=float(row.get("logg", np.nan)),
+        mh=float(row.get("mh", np.nan)),
+    )
+    sigma = _sigma_total_kms(stat, intrinsic)
+    rv_db = float(row["rv_kms"]) - bias
+    return rv_db, 1.0 / sigma**2, sigma, src
+
+
+def select_chunks_cdf_weight(
+    sigmas: np.ndarray,
+    weights: np.ndarray,
+    *,
+    min_chunks: int,
+    weight_fraction: float = 0.9,
+) -> tuple[np.ndarray, float]:
+    """
+    CDF selection: add chunks in order of increasing σ until ``weight_fraction`` of
+    total IVW weight is captured (best chunks first).
+    """
+    if len(sigmas) == 0:
+        return np.array([], dtype=int), float("nan")
+    order = np.argsort(sigmas)
+    w_sorted = weights[order]
+    cum = np.cumsum(w_sorted)
+    total = float(cum[-1])
+    if total <= 0:
+        return order[: max(min_chunks, 1)], float("nan")
+    target = weight_fraction * total
+    k = int(np.searchsorted(cum, target, side="left")) + 1
+    k = max(k, min_chunks)
+    k = min(k, len(order))
+    idx = order[:k]
+    return idx, _sigma_rv_from_weights(w_sorted[:k])
+
+
+def stack_calibrated_exposure(
+    chunk_df: pd.DataFrame,
+    *,
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    intrinsic_model: IntrinsicScatterModel | None = None,
+    min_chunks: int = 3,
+    cdf_weight_fraction: float = 0.9,
+) -> dict[str, float | int | str]:
+    """One exposure (file) from clipped chunk rows → calibrated stack RV and σ_RV."""
+    kept = chunk_df[chunk_df["chunk_kept"].astype(bool)] if "chunk_kept" in chunk_df.columns else chunk_df
+    if intrinsic_model is None:
+        intrinsic_model = build_intrinsic_scatter_model(per_object if len(per_object) else fallback)
+
+    rv_d: list[float] = []
+    wts: list[float] = []
+    sigmas: list[float] = []
+    sources: list[str] = []
+    for _, r in kept.iterrows():
+        parsed = _chunk_weight(
+            r, per_object=per_object, intrinsic_model=intrinsic_model, fallback=fallback
+        )
+        if parsed is None:
+            continue
+        rv_db, wt, sigma, src = parsed
+        rv_d.append(rv_db)
+        wts.append(wt)
+        sigmas.append(sigma)
+        sources.append(src)
+
+    if len(rv_d) < min_chunks:
+        return {
+            "rv_calibrated_kms": np.nan,
+            "rv_err_calibrated_kms": np.nan,
+            "sigma_rv_core90_kms": np.nan,
+            "chunk_scatter_calibrated_kms": np.nan,
+            "n_chunks_used": len(rv_d),
+            "n_chunks_core90": 0,
+            "bias_source_mix": "",
+        }
+
+    rv_arr = np.asarray(rv_d, float)
+    w_arr = np.asarray(wts, float)
+    sig_arr = np.asarray(sigmas, float)
+    mu = float(np.sum(w_arr * rv_arr) / np.sum(w_arr))
+    err = _sigma_rv_from_weights(w_arr)
+    _, err_core = select_chunks_cdf_weight(
+        sig_arr, w_arr, min_chunks=min_chunks, weight_fraction=cdf_weight_fraction
+    )
+    if len(rv_arr) > 1:
+        scatter = float(np.std(rv_arr - mu, ddof=1))
+    else:
+        scatter = 0.0
+    core_idx, _ = select_chunks_cdf_weight(
+        sig_arr, w_arr, min_chunks=min_chunks, weight_fraction=cdf_weight_fraction
+    )
+    return {
+        "rv_calibrated_kms": mu,
+        "rv_err_calibrated_kms": err,
+        "sigma_rv_core90_kms": err_core,
+        "chunk_scatter_calibrated_kms": scatter,
+        "n_chunks_used": int(len(rv_d)),
+        "n_chunks_core90": int(len(core_idx)),
+        "bias_source_mix": ",".join(sorted(set(sources))),
+    }
+
+
+def summarize_sigma_rv_metrics(epochs: pd.DataFrame) -> dict[str, float]:
+    """Layout-level σ_RV summary: best (min) and distribution tails."""
+    sig = epochs["rv_err_calibrated_kms"].astype(float)
+    sig_ok = sig[np.isfinite(sig) & (sig > 0)]
+    if len(sig_ok) == 0:
+        return {
+            "min_sigma_rv_kms": float("nan"),
+            "p10_sigma_rv_kms": float("nan"),
+            "median_sigma_rv_kms": float("nan"),
+            "p90_sigma_rv_kms": float("nan"),
+            "min_sigma_rv_core90_kms": float("nan"),
+        }
+    core = epochs.get("sigma_rv_core90_kms", pd.Series(np.nan, index=epochs.index)).astype(float)
+    core_ok = core[np.isfinite(core) & (core > 0)]
+    return {
+        "min_sigma_rv_kms": float(np.min(sig_ok)),
+        "p10_sigma_rv_kms": float(np.percentile(sig_ok, 10)),
+        "median_sigma_rv_kms": float(np.median(sig_ok)),
+        "p90_sigma_rv_kms": float(np.percentile(sig_ok, 90)),
+        "min_sigma_rv_core90_kms": float(np.min(core_ok)) if len(core_ok) else float("nan"),
+    }
+
+
+def build_calibrated_exposure_table(
+    diagnostics_glob: str,
+    bias_csv: str | Path | pd.DataFrame,
+    *,
+    clip_sigma: float = DEFAULT_CHUNK_OUTLIER_SIGMA,
+    clip_max_delta_kms: float = DEFAULT_CHUNK_MAX_DELTA_KMS,
+    min_chunks: int = 3,
+) -> pd.DataFrame:
+    tab = _load_chunk_rows(diagnostics_glob)
+    if tab.empty:
+        return tab
+    tab = apply_spectrum_chunk_outlier_clip(
+        tab, nsigma=clip_sigma, max_delta_kms=clip_max_delta_kms
+    )
+    per_object, fallback = load_chunk_bias_tables(bias_csv)
+    intrinsic_model = build_intrinsic_scatter_model(per_object)
+
+    rows: list[dict] = []
+    for file_label, g in tab.groupby("file", sort=False):
+        stack = stack_calibrated_exposure(
+            g,
+            per_object=per_object,
+            fallback=fallback,
+            intrinsic_model=intrinsic_model,
+            min_chunks=min_chunks,
+        )
+        r0 = g.iloc[0]
+        pipeline_rv = float(r0.get("exposure_rv_kms_pipeline", r0.get("exposure_rv_kms", np.nan)))
+        if not np.isfinite(pipeline_rv):
+            pipeline_rv = float(r0["exposure_rv_kms"])
+        rows.append(
+            {
+                "gaia_dr3_id": str(r0["gaia_dr3_id"]),
+                "file": str(file_label),
+                "mjd": float(r0["mjd"]),
+                "teff": float(r0["teff"]),
+                "log10_median_mask_ccf_peak_snr": float(r0["log10_median_mask_ccf_peak_snr"]),
+                "rv_pipeline_kms": pipeline_rv,
+                "rv_calibrated_kms": stack["rv_calibrated_kms"],
+                "rv_err_calibrated_kms": stack["rv_err_calibrated_kms"],
+                "sigma_rv_core90_kms": stack["sigma_rv_core90_kms"],
+                "chunk_scatter_calibrated_kms": stack["chunk_scatter_calibrated_kms"],
+                "n_chunks_used": stack["n_chunks_used"],
+                "n_chunks_core90": stack["n_chunks_core90"],
+                "bias_source_mix": stack["bias_source_mix"],
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def find_apf_apf_pairs(apf: pd.DataFrame, *, pair_window_days: float = 7.0) -> pd.DataFrame:
+    from itertools import combinations
+
+    from validation.rv_overlap_lib import _pair_row, enrich_pairs_with_deltas
+
+    rows: list[dict] = []
+    for gid, g in apf.groupby("gaia_dr3_id"):
+        gid = str(gid)
+        name = str(g["name"].iloc[0]) if "name" in g.columns else gid
+        recs = []
+        for _, r in g.iterrows():
+            recs.append(
+                {
+                    "epoch_id": f"apf:{r['file']}",
+                    "mjd": float(r["mjd"]),
+                    "rv_kms": float(r["rv_kms"]),
+                    "rv_err_kms": float(r.get("rv_err_kms", np.nan)),
+                }
+            )
+        for a, b in combinations(recs, 2):
+            dt = abs(float(a["mjd"]) - float(b["mjd"]))
+            if dt <= pair_window_days and a["epoch_id"] != b["epoch_id"]:
+                rows.append(_pair_row("apf_apf", gid, name, a, b, dt))
+    if not rows:
+        return pd.DataFrame()
+    return enrich_pairs_with_deltas(pd.DataFrame(rows))
+
+
+def relative_pair_table(
+    epochs: pd.DataFrame,
+    *,
+    rv_col: str,
+    err_col: str | None = None,
+    pair_window_days: float = 7.0,
+) -> pd.DataFrame:
+    apf = epochs.copy()
+    apf["rv_kms"] = apf[rv_col].astype(float)
+    if err_col and err_col in apf.columns:
+        apf["rv_err_kms"] = apf[err_col].astype(float)
+    else:
+        apf["rv_err_kms"] = np.nan
+    if "name" not in apf.columns:
+        apf["name"] = apf["gaia_dr3_id"].astype(str)
+    return find_apf_apf_pairs(apf, pair_window_days=pair_window_days)
+
+
+def summarize_relative_gate(pairs: pd.DataFrame, *, goal_kms: float = 0.1) -> dict[str, float | int]:
+    if pairs.empty:
+        return {"n_pairs": 0}
+    abs_dv = pairs["abs_delta_rv_kms"].astype(float)
+    return {
+        "n_pairs": int(len(pairs)),
+        "n_stars": int(pairs["gaia_dr3_id"].nunique()),
+        "median_abs_delta_rv_kms": float(np.median(abs_dv)),
+        "p90_abs_delta_rv_kms": float(np.percentile(abs_dv, 90)),
+        "max_abs_delta_rv_kms": float(np.max(abs_dv)),
+        "rms_delta_rv_kms": float(np.sqrt(np.mean(pairs["delta_rv_kms"].astype(float) ** 2))),
+        "frac_below_goal": float(np.mean(abs_dv < goal_kms)),
+    }

--- a/validation/chunk_campaign.py
+++ b/validation/chunk_campaign.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""
+Full chunk layout campaign: pipeline runs, measurement cache, grid search, stages B/C.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  python -m validation.chunk_campaign \\
+    --spectrum-list validation_output/chunk_campaign/spectrum_list.txt \\
+    --out-dir validation_output/chunk_campaign \\
+    --run-pipeline
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from validation.chunk_grid_search import composite_score  # noqa: E402
+from validation.chunk_layout import (  # noqa: E402
+    ChunkLayout,
+    build_campaign_broad_grid,
+    build_campaign_edge_grid,
+    build_custom_edge_layout,
+    save_chunk_layout,
+)
+from validation.chunk_measurement_cache import (  # noqa: E402
+    diagnostics_glob_for_layout,
+    ingest_layout_diagnostics_dir,
+    layout_files_complete,
+    load_cache,
+    save_cache,
+)
+from validation.evaluate_chunk_layout import evaluate_layouts_from_glob  # noqa: E402
+from validation.plot_chunk_residuals import _load_chunk_rows  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+CACHE_NAME = "measurement_cache.csv"
+
+
+def write_spectrum_list_from_diagnostics(diagnostics_glob: str, out_path: Path) -> list[Path]:
+    tab = _load_chunk_rows(diagnostics_glob)
+    files = sorted({Path(str(f)) for f in tab["file"].astype(str).unique() if Path(str(f)).is_file()})
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(str(p) for p in files) + "\n", encoding="utf-8")
+    return files
+
+
+def read_spectrum_list(path: Path) -> list[Path]:
+    files: list[Path] = []
+    for line in path.read_text().splitlines():
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        p = Path(s).expanduser()
+        if p.is_file():
+            files.append(p.resolve())
+    return files
+
+
+def run_pipeline_for_layout(
+    layout: ChunkLayout,
+    spectrum_files: list[Path],
+    *,
+    campaign_dir: Path,
+    instrument: str,
+    log_level: str,
+    batch_size: int = 20,
+    extra_flags: list[str] | None = None,
+) -> Path:
+    layout_yaml = campaign_dir / "layouts" / f"{layout.name}.yaml"
+    save_chunk_layout(layout, layout_yaml)
+    out_dir = campaign_dir / "diagnostics" / layout.name
+    out_dir.mkdir(parents=True, exist_ok=True)
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(REPO_ROOT),
+        "DARKHUNTER_OUTPUT_DIR": str(out_dir),
+    }
+    flags = list(extra_flags or [])
+    flags.extend(["--chunk-layout", str(layout_yaml), "--instrument", instrument, "--log-level", log_level])
+    for i in range(0, len(spectrum_files), batch_size):
+        batch = spectrum_files[i : i + batch_size]
+        cmd = [sys.executable, "-m", "darkhunter_rv.pipeline", *[str(p) for p in batch], *flags]
+        logger.info("pipeline %s batch %d..%d (%d files)", layout.name, i, i + len(batch), len(batch))
+        r = subprocess.run(cmd, cwd=str(REPO_ROOT), env=env)
+        if r.returncode != 0:
+            raise RuntimeError(f"pipeline failed for {layout.name} code={r.returncode}")
+    return out_dir
+
+
+def coordinate_descent_edges(
+    n_chunks: int,
+    initial_edges: list[float],
+    *,
+    scan_points: int = 7,
+    passes: int = 2,
+) -> list[list[float]]:
+    """Stage B: refine interior pixel edges by coordinate descent candidates."""
+    edges = list(initial_edges)
+    candidates: list[list[float]] = [edges.copy()]
+    for _ in range(passes):
+        for k in range(1, len(edges) - 1):
+            lo = edges[k - 1] + 0.05
+            hi = edges[k + 1] - 0.05
+            if hi <= lo:
+                continue
+            best_e = edges[k]
+            best_score = float("inf")
+            for trial in np.linspace(lo, hi, scan_points):
+                cand = edges.copy()
+                cand[k] = float(trial)
+                # score placeholder — actual scoring done after pipeline
+                candidates.append(cand)
+                edges[k] = float(trial)
+    return candidates
+
+
+def build_stage_b_layouts(n_chunks: int, base_edges: list[float]) -> list[ChunkLayout]:
+    layouts: list[ChunkLayout] = []
+    for i, edges in enumerate(coordinate_descent_edges(n_chunks, base_edges)):
+        name = f"stageB_n{n_chunks}_e{i:02d}"
+        layouts.append(build_custom_edge_layout(name, edges))
+    return layouts
+
+
+def _plot_campaign_summary(summary: pd.DataFrame, out_path: Path) -> None:
+    valid = summary[summary.get("offline_eval_valid", True).astype(bool)].copy()
+    if valid.empty:
+        valid = summary.copy()
+    valid = valid.sort_values("composite_score")
+    fig, ax = plt.subplots(figsize=(11, 5))
+    x = np.arange(len(valid))
+    ax.bar(x, valid["composite_score"].astype(float), color="C0", alpha=0.85)
+    ax.set_xticks(x)
+    ax.set_xticklabels(valid["layout"].astype(str), rotation=60, ha="right", fontsize=7)
+    ax.set_ylabel("Composite score (lower better)")
+    ax.set_title("Chunk campaign layout comparison")
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+    fig2, axes = plt.subplots(1, 3, figsize=(13, 4))
+    for ax, col, title in zip(
+        axes,
+        ["median_sigma_rv_kms", "p90_sigma_rv_kms", "relative_median_abs_delta_kms"],
+        ["Median σ_RV", "p90 σ_RV", "Relative median |ΔRV|"],
+    ):
+        ax.scatter(
+            valid["layout"].astype(str),
+            valid[col].astype(float),
+            s=50,
+            alpha=0.8,
+        )
+        ax.set_title(title)
+        ax.set_ylabel("km/s")
+        ax.tick_params(axis="x", rotation=60, labelsize=7)
+    fig2.tight_layout()
+    out_path2 = out_path.parent / "campaign_sigma_rv_vs_relative.png"
+    fig2.savefig(out_path2, dpi=130)
+    plt.close(fig2)
+
+
+def write_next_steps(path: Path, *, best: pd.Series | None, stage_b_best: pd.Series | None) -> None:
+    lines = [
+        "# Chunk campaign — next steps",
+        "",
+        "## Completed",
+        "- Broad grid: split N=2,3,4 and merge W=2,3,4 (full pipeline)",
+        "- Edge presets: equal, blue-heavy, red-heavy, telluric-aware",
+        "- Stage B coordinate-descent edge candidates",
+        "- Measurement cache: `measurement_cache.csv` (dedupe by measurement_id + file)",
+        "",
+        "## Best layouts so far",
+    ]
+    if best is not None:
+        lines.append(
+            f"- **Broad/edge winner:** `{best['layout']}` "
+            f"(score={best['composite_score']:.4f}, median σ_RV={best.get('median_sigma_rv_kms', float('nan')):.3f} km/s, "
+            f"rel={best['relative_median_abs_delta_kms']:.3f} km/s)"
+        )
+    if stage_b_best is not None:
+        lines.append(
+            f"- **Stage B refinement:** `{stage_b_best['layout']}` "
+            f"(score={stage_b_best['composite_score']:.4f})"
+        )
+    lines.extend(
+        [
+            "",
+            "## Recommended next work",
+            "",
+            "1. **Per-order variable edges** — allow different N+1 edges per echelle order in YAML; "
+            "high bias-gradient orders get finer splits (use bias curve from chunk_bias_regression).",
+            "2. **Telluric down-weighting** — persist `telluric_fraction` in diagnostics; zero-weight "
+            "telluric-heavy chunks in stack (not just split).",
+            "3. **Bad-line isolation** — flag chunks with high `mask_line_count` variance or CCF asymmetry; "
+            "assign trust weights before IVW stack.",
+            "4. **ML chunk quality model** — BDT on chunk features to predict |residual|; use to rank edge "
+            "candidates before pipeline reruns.",
+            "5. **Deploy winner** — install chosen layout YAML as default APF chunk config; rebuild bias table.",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_campaign(
+    *,
+    spectrum_files: list[Path],
+    campaign_dir: Path,
+    run_pipeline: bool,
+    instrument: str,
+    log_level: str,
+    edge_n_chunks: int,
+    run_stage_b: bool,
+    skip_pipeline_if_cached: bool,
+) -> pd.DataFrame:
+    campaign_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = campaign_dir / CACHE_NAME
+    cache = load_cache(cache_path)
+
+    broad = build_campaign_broad_grid()
+    edge = build_campaign_edge_grid(n_chunks=edge_n_chunks)
+    layouts = broad + edge
+    # Deduplicate by name
+    seen: set[str] = set()
+    unique_layouts: list[ChunkLayout] = []
+    for lay in layouts:
+        if lay.name not in seen:
+            unique_layouts.append(lay)
+            seen.add(lay.name)
+
+    if run_pipeline:
+        for layout in unique_layouts:
+            todo = spectrum_files
+            if skip_pipeline_if_cached:
+                done = layout_files_complete(cache, layout_name=layout.name, spectrum_files=spectrum_files)
+                todo = [f for f in spectrum_files if f not in done]
+            if not todo:
+                logger.info("skip pipeline %s (cached)", layout.name)
+                continue
+            diag_dir = run_pipeline_for_layout(
+                layout, todo, campaign_dir=campaign_dir, instrument=instrument, log_level=log_level
+            )
+            cache = ingest_layout_diagnostics_dir(diag_dir, layout=layout, cache=cache)
+            save_cache(cache, cache_path)
+
+    # Evaluate from per-layout diagnostics
+    eval_rows = []
+    for layout in unique_layouts:
+        glob_pat = diagnostics_glob_for_layout(campaign_dir, layout.name)
+        summary = evaluate_layouts_from_glob(
+            [layout],
+            glob_pat,
+            clip_sigma=7.0,
+            clip_max_delta_kms=20.0,
+            min_chunks=3,
+        )
+        if not summary.empty:
+            summary["offline_eval_valid"] = True
+            eval_rows.append(summary)
+    grid = pd.concat(eval_rows, ignore_index=True) if eval_rows else pd.DataFrame()
+    if not grid.empty:
+        grid["composite_score"] = grid.apply(composite_score, axis=1)
+        grid = grid.sort_values("composite_score")
+
+    stage_b_summary = pd.DataFrame()
+    if run_stage_b and not grid.empty:
+        # Pick best equal-split or edge preset with n_subchunks ~ edge_n_chunks
+        split_candidates = grid[grid["layout"].astype(str).str.startswith(("subchunks_", "n"))]
+        if len(split_candidates):
+            base_name = str(split_candidates.iloc[0]["layout"])
+        else:
+            base_name = f"n{edge_n_chunks}_equal"
+        from validation.chunk_layout import preset_pixel_edges
+
+        base_edges = preset_pixel_edges(edge_n_chunks, "equal")
+        stage_b_layouts = build_stage_b_layouts(edge_n_chunks, base_edges)
+        if run_pipeline:
+            for layout in stage_b_layouts[:8]:  # cap pipeline cost for stage B
+                todo = spectrum_files
+                if skip_pipeline_if_cached:
+                    done = layout_files_complete(cache, layout_name=layout.name, spectrum_files=spectrum_files)
+                    todo = [f for f in spectrum_files if f not in done]
+                if not todo:
+                    continue
+                diag_dir = run_pipeline_for_layout(
+                    layout, todo, campaign_dir=campaign_dir, instrument=instrument, log_level=log_level
+                )
+                cache = ingest_layout_diagnostics_dir(diag_dir, layout=layout, cache=cache)
+                save_cache(cache, cache_path)
+        sb_rows = []
+        for layout in stage_b_layouts[:8]:
+            glob_pat = diagnostics_glob_for_layout(campaign_dir, layout.name)
+            s = evaluate_layouts_from_glob([layout], glob_pat, clip_sigma=7.0, clip_max_delta_kms=20.0, min_chunks=3)
+            if not s.empty:
+                s["offline_eval_valid"] = True
+                sb_rows.append(s)
+        if sb_rows:
+            stage_b_summary = pd.concat(sb_rows, ignore_index=True)
+            stage_b_summary["composite_score"] = stage_b_summary.apply(composite_score, axis=1)
+            stage_b_summary = stage_b_summary.sort_values("composite_score")
+            stage_b_summary.to_csv(campaign_dir / "stage_b_summary.csv", index=False)
+
+    if not grid.empty:
+        grid.to_csv(campaign_dir / "campaign_grid_summary.csv", index=False)
+        _plot_campaign_summary(grid, campaign_dir / "plots" / "campaign_grid_scores.png")
+
+    best = grid.iloc[0] if len(grid) else None
+    sb_best = stage_b_summary.iloc[0] if len(stage_b_summary) else None
+    write_next_steps(campaign_dir / "NEXT_STEPS.md", best=best, stage_b_best=sb_best)
+
+    report_lines = [
+        "# Chunk campaign report",
+        "",
+        f"- Spectra: {len(spectrum_files)}",
+        f"- Layouts evaluated: {len(grid)}",
+        f"- Cache rows: {len(cache)}",
+        "",
+    ]
+    if best is not None:
+        report_lines.append(f"**Best layout:** `{best['layout']}` (score={best['composite_score']:.4f})")
+    report_lines.append("")
+    report_lines.append("See `campaign_grid_summary.csv`, `NEXT_STEPS.md`, and `measurement_cache.csv`.")
+    (campaign_dir / "REPORT.md").write_text("\n".join(report_lines) + "\n", encoding="utf-8")
+
+    manifest = {
+        "n_spectra": len(spectrum_files),
+        "n_layouts": len(grid),
+        "n_cache_rows": int(len(cache)),
+        "best_layout": None if best is None else str(best["layout"]),
+    }
+    (campaign_dir / "campaign_manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return grid
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--spectrum-list", type=Path, default=None)
+    ap.add_argument(
+        "--diagnostics-glob",
+        default="output/Gaia_DR3_*_diagnostics.csv",
+        help="Used to build spectrum list if --spectrum-list missing",
+    )
+    ap.add_argument("--out-dir", type=Path, default=REPO_ROOT / "validation_output" / "chunk_campaign")
+    ap.add_argument("--run-pipeline", action="store_true")
+    ap.add_argument("--instrument", default="APF")
+    ap.add_argument("--edge-n-chunks", type=int, default=3, help="N for edge preset + stage B")
+    ap.add_argument("--run-stage-b", action="store_true", default=True)
+    ap.add_argument("--no-stage-b", action="store_false", dest="run_stage_b")
+    ap.add_argument("--skip-pipeline-if-cached", action="store_true", default=True)
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    list_path = args.spectrum_list or (args.out_dir / "spectrum_list.txt")
+    if list_path.is_file():
+        spectrum_files = read_spectrum_list(list_path)
+    else:
+        spectrum_files = write_spectrum_list_from_diagnostics(args.diagnostics_glob, list_path)
+    if not spectrum_files:
+        logger.error("No spectrum files")
+        sys.exit(1)
+
+    run_campaign(
+        spectrum_files=spectrum_files,
+        campaign_dir=args.out_dir,
+        run_pipeline=args.run_pipeline,
+        instrument=args.instrument,
+        log_level=args.log_level,
+        edge_n_chunks=args.edge_n_chunks,
+        run_stage_b=args.run_stage_b,
+        skip_pipeline_if_cached=args.skip_pipeline_if_cached,
+    )
+    logger.info("Campaign done -> %s", args.out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/chunk_grid_search.py
+++ b/validation/chunk_grid_search.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+Parametric chunk layout grid search (rough N choices) on existing diagnostics.
+
+Evaluates offline-order-merge coarsening immediately; equal sub-chunk layouts
+(N=2,4,…) are written as YAML specs but require a pipeline rerun for valid scores.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  python -m validation.chunk_grid_search \\
+    --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' \\
+    --out-dir validation_output/chunk_grid_search
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from validation.chunk_layout import (  # noqa: E402
+    ChunkLayout,
+    build_custom_edge_layout,
+    build_equal_subchunk_layout,
+    build_merge_orders_layout,
+    default_parametric_grid,
+    save_chunk_layout,
+)
+from validation.evaluate_chunk_layout import evaluate_layouts  # noqa: E402
+from validation.plot_chunk_residuals import (  # noqa: E402
+    DEFAULT_CHUNK_MAX_DELTA_KMS,
+    DEFAULT_CHUNK_OUTLIER_SIGMA,
+)
+
+logger = logging.getLogger(__name__)
+
+# Rough grid defaults — small enough to run without pipeline reruns for merge arm.
+DEFAULT_SUBCHUNK_COUNTS = [1, 2, 4]
+DEFAULT_MERGE_WIDTHS = [1, 2, 4]
+
+
+def composite_score(row: pd.Series) -> float:
+    """
+    Lower is better. Median + p90 σ_RV (typical and worst-case precision) plus relative gate.
+
+    NaN metrics → inf.
+    """
+    if not bool(row.get("offline_eval_valid", False)):
+        return float("inf")
+    sigma_med = float(row.get("median_sigma_rv_kms", np.nan))
+    sigma_p90 = float(row.get("p90_sigma_rv_kms", np.nan))
+    rel = float(row.get("relative_median_abs_delta_kms", np.nan))
+    if not all(np.isfinite(x) for x in (sigma_med, sigma_p90, rel)):
+        return float("inf")
+    return 0.35 * sigma_med + 0.35 * sigma_p90 + 0.30 * rel
+
+
+def build_grid_layouts(
+    *,
+    subchunk_counts: list[int],
+    merge_widths: list[int],
+    include_telluric_split_example: bool,
+) -> list[ChunkLayout]:
+    layouts = default_parametric_grid(subchunk_counts=subchunk_counts, merge_widths=merge_widths)
+    if include_telluric_split_example:
+        # Example asymmetric edges (N=2 unequal split) — pipeline-only, for edge-search demos.
+        layouts.append(
+            build_custom_edge_layout("edges_blue_heavy_2", [0.0, 0.35, 1.0]),
+        )
+    return layouts
+
+
+def _plot_grid_summary(summary: pd.DataFrame, out_path: Path) -> None:
+    offline = summary[summary["offline_eval_valid"].astype(bool)].copy()
+    if offline.empty:
+        return
+    offline = offline.sort_values("composite_score")
+    fig, axes = plt.subplots(1, 3, figsize=(12, 4))
+    x = np.arange(len(offline))
+    labels = offline["layout"].astype(str).tolist()
+
+    for ax, col, title in zip(
+        axes,
+        ["median_sigma_rv_kms", "p90_sigma_rv_kms", "relative_median_abs_delta_kms"],
+        ["Median σ_RV", "p90 σ_RV (worst cases)", "Relative median |ΔRV|"],
+    ):
+        y = offline[col].astype(float).values
+        ax.bar(x, y, color="C0", alpha=0.85)
+        ax.set_xticks(x)
+        ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=8)
+        ax.set_title(title)
+        ax.set_ylabel("km/s")
+    fig.suptitle("Offline-valid chunk grid (lower is better)")
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def write_edge_search_advice(path: Path, *, best_offline: str | None) -> None:
+    text = f"""# Searching for optimal chunk edges
+
+## What the rough grid search tested
+
+| Arm | Parameter | Offline? | Meaning |
+|-----|-----------|----------|---------|
+| **Merge width** | W = 1, 2, 4 adjacent orders | Yes | Coarsen chunks by IVW-merging whole orders |
+| **Sub-chunks** | N = 1, 2, 4 equal pixel splits | **No** (needs pipeline) | N+1 edges at 0, 1/N, …, 1 per order |
+
+Best offline layout in latest run: **{best_offline or "see grid_summary.csv"}**
+
+Sub-chunk layouts (`subchunks_2`, `subchunks_4`) are exported under `layouts/` but
+scores are duplicated from whole-order until you rerun:
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+python -m darkhunter_rv.pipeline ... --subchunks 4 --instrument APF
+python -m validation.plot_chunk_residuals ...
+python -m validation.chunk_grid_search --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv'
+```
+
+---
+
+## Recommended edge search strategy (after rough N)
+
+Once a rough **N** is chosen (equal splits or merge width), refine **edge locations**
+in three stages:
+
+### Stage A — Coarse grid on edge fractions (cheap)
+
+For each order (or a representative subset of orders), try a small set of **N+1**
+pixel-fraction edge vectors, e.g. for N=4:
+
+| Layout | Edges |
+|--------|-------|
+| equal | `[0, 0.25, 0.5, 0.75, 1]` |
+| blue-heavy | `[0, 0.35, 0.6, 0.8, 1]` |
+| red-heavy | `[0, 0.2, 0.45, 0.7, 1]` |
+| telluric-aware | split at cumulative telluric-fraction jumps |
+
+Use `build_custom_edge_layout(name, pixel_edges)` → YAML → pipeline rerun →
+`chunk_grid_search` metrics. Keep 3–5 candidates per N, not a full factorial.
+
+### Stage B — Coordinate descent on one edge at a time
+
+1. Fix N and all edges except interior edge `e_k`.
+2. Scan `e_k` ∈ (e_{{k-1}}+0.05, e_{{k+1}}−0.05) on a 1-D grid (≈10 points).
+3. Score with the same composite metric (relative gate + chunk scatter + bias RMS).
+4. Move to next edge; repeat until convergence.
+
+This is efficient when N is small (4–8 chunks per order) and avoids exploding combinatorics.
+
+### Stage C — Telluric-anchored breakpoints
+
+Use `darkhunter_rv.qc.TELLURIC_BANDS` and per-pixel λ:
+
+1. Compute telluric pixel mask per order.
+2. Candidate edges = boundaries where telluric fraction in a window crosses 10% / 25%.
+3. Snap to nearest pixel index; enforce `min_pixels` per chunk.
+4. Evaluate with the validation loop.
+
+This often beats arbitrary equal splits for APF red orders.
+
+### Stage D — ML-assisted ranking (optional)
+
+Train a gradient-boosted regressor on chunk-level rows:
+
+**Features:** order, λ_center, telluric_fraction, mask_line_count, CCF S/N, Teff  
+**Target:** |chunk residual| or contribution to exposure scatter
+
+Use predicted mean |residual| to **score** candidate edge sets before expensive pipeline
+reruns. BDT does not optimize edges directly — it prioritizes which candidates to run.
+
+---
+
+## Composite score (grid ranking)
+
+```
+score = 0.5 × relative_median|ΔRV| + 0.3 × median_chunk_scatter + 0.2 × bias_curve_RMS
+```
+
+Lower is better. Tune weights once relative gate pairs are stable.
+
+---
+
+## Files produced by `chunk_grid_search`
+
+| File | Content |
+|------|---------|
+| `grid_summary.csv` | All layouts, metrics, composite score, rank |
+| `layouts/*.yaml` | Layout specs for pipeline |
+| `plots/grid_metrics.png` | Bar charts for offline-valid layouts |
+| `EDGE_SEARCH_ADVICE.md` | This document |
+| `REPORT.md` | Short summary |
+"""
+    path.write_text(text, encoding="utf-8")
+
+
+def write_report(path: Path, summary: pd.DataFrame) -> None:
+    offline = summary[summary["offline_eval_valid"].astype(bool)].copy()
+    lines = [
+        "# Chunk parametric grid search",
+        "",
+        f"- Layouts tested: {len(summary)}",
+        f"- Offline-valid: {len(offline)}",
+        "",
+        "## Rankings (offline-valid only)",
+        "",
+        "| rank | layout | score | rel median |ΔRV| | chunk scatter | bias RMS |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    if len(offline):
+        offline = offline.sort_values("composite_score")
+        for i, (_, r) in enumerate(offline.iterrows(), start=1):
+            lines.append(
+                f"| {i} | {r['layout']} | {r['composite_score']:.4f} | "
+                f"{r['relative_median_abs_delta_kms']:.3f} | {r['median_chunk_scatter_kms']:.3f} | "
+                f"{r['bias_curve_rms_kms']:.3f} |"
+            )
+    else:
+        lines.append("| — | no offline-valid layouts | — | — | — | — |")
+
+    pipeline = summary[~summary["offline_eval_valid"].astype(bool)]
+    if len(pipeline):
+        lines.extend(
+            [
+                "",
+                "## Pipeline rerun required",
+                "",
+            ]
+        )
+        for _, r in pipeline.iterrows():
+            lines.append(
+                f"- `{r['layout']}` (subchunks={r.get('cfg_subchunks', '?')}) — "
+                f"run pipeline with matching `--subchunks`, then re-run grid search"
+            )
+    lines.extend(["", "See `EDGE_SEARCH_ADVICE.md` for refining edge locations.", ""])
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def run_grid_search(
+    *,
+    diagnostics_glob: str,
+    out_dir: Path,
+    subchunk_counts: list[int],
+    merge_widths: list[int],
+    clip_sigma: float,
+    clip_max_delta_kms: float,
+    min_chunks: int,
+    include_telluric_split_example: bool,
+) -> pd.DataFrame:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    layouts_dir = out_dir / "layouts"
+    layouts_dir.mkdir(exist_ok=True)
+
+    layouts = build_grid_layouts(
+        subchunk_counts=subchunk_counts,
+        merge_widths=merge_widths,
+        include_telluric_split_example=include_telluric_split_example,
+    )
+    for lay in layouts:
+        save_chunk_layout(lay, layouts_dir / f"{lay.name}.yaml")
+
+    summary = evaluate_layouts(
+        layouts,
+        diagnostics_glob,
+        clip_sigma=clip_sigma,
+        clip_max_delta_kms=clip_max_delta_kms,
+        min_chunks=min_chunks,
+    )
+    summary["composite_score"] = summary.apply(composite_score, axis=1)
+    summary["rank"] = summary["composite_score"].rank(method="min").astype(int)
+    summary = summary.sort_values(["composite_score", "layout"])
+
+    summary.to_csv(out_dir / "grid_summary.csv", index=False)
+    (out_dir / "grid_summary.json").write_text(
+        json.dumps(summary.to_dict(orient="records"), indent=2),
+        encoding="utf-8",
+    )
+
+    _plot_grid_summary(summary, out_dir / "plots" / "grid_metrics.png")
+    best = None
+    offline = summary[summary["offline_eval_valid"].astype(bool)]
+    if len(offline):
+        best = str(offline.sort_values("composite_score").iloc[0]["layout"])
+    write_edge_search_advice(out_dir / "EDGE_SEARCH_ADVICE.md", best_offline=best)
+    write_report(out_dir / "REPORT.md", summary)
+    return summary
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--diagnostics-glob", default="output/Gaia_DR3_*_diagnostics.csv")
+    ap.add_argument("--out-dir", type=Path, default=REPO_ROOT / "validation_output" / "chunk_grid_search")
+    ap.add_argument(
+        "--subchunk-counts",
+        default=",".join(str(x) for x in DEFAULT_SUBCHUNK_COUNTS),
+        help="Comma-separated equal sub-chunk counts N (default: 1,2,4)",
+    )
+    ap.add_argument(
+        "--merge-widths",
+        default=",".join(str(x) for x in DEFAULT_MERGE_WIDTHS),
+        help="Comma-separated adjacent-order merge widths (default: 1,2,4)",
+    )
+    ap.add_argument("--chunk-outlier-sigma", type=float, default=DEFAULT_CHUNK_OUTLIER_SIGMA)
+    ap.add_argument("--chunk-max-delta-kms", type=float, default=DEFAULT_CHUNK_MAX_DELTA_KMS)
+    ap.add_argument("--min-chunks", type=int, default=3)
+    ap.add_argument("--include-telluric-split-example", action="store_true")
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    subchunk_counts = [int(x.strip()) for x in args.subchunk_counts.split(",") if x.strip()]
+    merge_widths = [int(x.strip()) for x in args.merge_widths.split(",") if x.strip()]
+
+    summary = run_grid_search(
+        diagnostics_glob=args.diagnostics_glob,
+        out_dir=args.out_dir,
+        subchunk_counts=subchunk_counts,
+        merge_widths=merge_widths,
+        clip_sigma=args.chunk_outlier_sigma,
+        clip_max_delta_kms=args.chunk_max_delta_kms,
+        min_chunks=args.min_chunks,
+        include_telluric_split_example=args.include_telluric_split_example,
+    )
+    offline = summary[summary["offline_eval_valid"].astype(bool)]
+    if len(offline):
+        best = offline.sort_values("composite_score").iloc[0]
+        logger.info(
+            "Best offline layout: %s (score=%.4f, rel=%.3f km/s)",
+            best["layout"],
+            best["composite_score"],
+            best["relative_median_abs_delta_kms"],
+        )
+    logger.info("Grid search written to %s", args.out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/chunk_layout.py
+++ b/validation/chunk_layout.py
@@ -1,0 +1,348 @@
+"""Chunk layout specification: N chunks from N+1 pixel or wavelength edges."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+
+
+@dataclass
+class ChunkLayout:
+    """
+    Layout for splitting each echelle order into chunks.
+
+    - ``subchunks``: equal pixel splits (overrides pixel_edges if >1 and pixel_edges is default)
+    - ``pixel_edges``: N+1 fractions in [0, 1] along the pixel array (default 0..1)
+    - ``merge_orders``: optional list of [order_start, order_end] inclusive groups → single chunk key
+    """
+
+    name: str = "whole_order"
+    subchunks: int = 1
+    pixel_edges: list[float] = field(default_factory=lambda: [0.0, 1.0])
+    merge_orders: list[list[int]] | None = None
+    min_pixels: int = 5
+    edge_preset: str | None = None  # equal | blue_heavy | red_heavy | telluric
+    telluric_split: bool = False
+
+    def n_chunks_per_order(self) -> int:
+        if self.subchunks > 1:
+            return int(self.subchunks)
+        return max(len(self.pixel_edges) - 1, 1)
+
+    def normalized_pixel_edges(self) -> np.ndarray:
+        if self.subchunks > 1:
+            return np.linspace(0.0, 1.0, self.subchunks + 1)
+        edges = np.asarray(self.pixel_edges, float)
+        if len(edges) < 2:
+            return np.array([0.0, 1.0])
+        edges = np.clip(edges, 0.0, 1.0)
+        edges[0] = 0.0
+        edges[-1] = 1.0
+        return edges
+
+
+def preset_pixel_edges(n_chunks: int, preset: str) -> list[float]:
+    """Return N+1 fractional edges for a named preset."""
+    n = max(int(n_chunks), 1)
+    if preset == "equal" or n == 1:
+        return np.linspace(0.0, 1.0, n + 1).tolist()
+    if preset == "blue_heavy":
+        if n == 2:
+            return [0.0, 0.35, 1.0]
+        if n == 3:
+            return [0.0, 0.35, 0.6, 1.0]
+        if n == 4:
+            return [0.0, 0.3, 0.5, 0.7, 1.0]
+    if preset == "red_heavy":
+        if n == 2:
+            return [0.0, 0.65, 1.0]
+        if n == 3:
+            return [0.0, 0.2, 0.45, 1.0]
+        if n == 4:
+            return [0.0, 0.15, 0.35, 0.6, 1.0]
+    return np.linspace(0.0, 1.0, n + 1).tolist()
+
+
+def build_edge_preset_layout(n_chunks: int, preset: str) -> ChunkLayout:
+    name = f"n{n_chunks}_{preset}"
+    if preset == "telluric":
+        return ChunkLayout(name=name, subchunks=1, telluric_split=True, edge_preset="telluric")
+    edges = preset_pixel_edges(n_chunks, preset)
+    return ChunkLayout(name=name, subchunks=1, pixel_edges=edges, edge_preset=preset)
+
+
+def build_campaign_broad_grid() -> list[ChunkLayout]:
+    """Broad grid: split N=2,3,4 and merge W=2,3,4."""
+    layouts: list[ChunkLayout] = []
+    for n in (2, 3, 4):
+        layouts.append(build_equal_subchunk_layout(n))
+    for w in (2, 3, 4):
+        layouts.append(build_merge_orders_layout(merge_width=w))
+    return layouts
+
+
+def build_campaign_edge_grid(n_chunks: int = 3) -> list[ChunkLayout]:
+    """Edge preset variants after broad grid."""
+    presets = ("equal", "blue_heavy", "red_heavy", "telluric")
+    return [build_edge_preset_layout(n_chunks, p) for p in presets]
+
+
+def measurement_id_for_chunk(chunk_key: str, pixel_edges: list[float] | None, merge_orders: bool) -> str:
+    """Canonical cache key for a chunk measurement (layout-independent when edges match)."""
+    if merge_orders:
+        return f"merge:{chunk_key}"
+    edges = pixel_edges or [0.0, 1.0]
+    edge_tag = "-".join(f"{e:.4f}" for e in edges)
+    return f"chunk:{chunk_key}:e:{edge_tag}"
+
+
+def save_chunk_layout(layout: ChunkLayout, path: Path | str) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "name": layout.name,
+        "subchunks": layout.subchunks,
+        "pixel_edges": [float(x) for x in layout.normalized_pixel_edges()],
+        "merge_orders": layout.merge_orders,
+        "min_pixels": layout.min_pixels,
+        "edge_preset": layout.edge_preset,
+        "telluric_split": layout.telluric_split,
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def load_chunk_layout(path: Path | str) -> ChunkLayout:
+    path = Path(path)
+    raw = yaml.safe_load(path.read_text()) or {}
+    return ChunkLayout(
+        name=str(raw.get("name", path.stem)),
+        subchunks=int(raw.get("subchunks", 1)),
+        pixel_edges=[float(x) for x in raw.get("pixel_edges", [0.0, 1.0])],
+        merge_orders=raw.get("merge_orders"),
+        min_pixels=int(raw.get("min_pixels", 5)),
+        edge_preset=raw.get("edge_preset"),
+        telluric_split=bool(raw.get("telluric_split", False)),
+    )
+
+
+def apf_valid_orders(*, num_orders: int = 70, bad_orders: list[int] | None = None) -> list[int]:
+    bad = bad_orders if bad_orders is not None else [0, 1, 2, 53, 57, 58, 59, 60, 63, 64, 65]
+    return [o for o in range(num_orders) if o not in bad]
+
+
+def build_equal_subchunk_layout(n: int) -> ChunkLayout:
+    """N equal pixel sub-chunks per order (N+1 edges at 0 … 1)."""
+    n = max(int(n), 1)
+    return ChunkLayout(
+        name=f"subchunks_{n}",
+        subchunks=n,
+        pixel_edges=np.linspace(0.0, 1.0, n + 1).tolist(),
+    )
+
+
+def build_custom_edge_layout(name: str, pixel_edges: list[float]) -> ChunkLayout:
+    """N chunks from explicit N+1 fractional pixel edges."""
+    edges = [float(x) for x in pixel_edges]
+    if len(edges) < 2:
+        raise ValueError("pixel_edges requires at least two values")
+    return ChunkLayout(name=name, subchunks=1, pixel_edges=edges)
+
+
+def build_merge_orders_layout(
+    *,
+    merge_width: int,
+    valid_orders: list[int] | None = None,
+) -> ChunkLayout:
+    """
+    Coarsen whole-order chunks by merging ``merge_width`` adjacent echelle orders.
+
+    ``merge_width=1`` is equivalent to whole-order (no merge groups).
+    """
+    merge_width = max(int(merge_width), 1)
+    orders = list(valid_orders or apf_valid_orders())
+    if merge_width == 1:
+        return ChunkLayout(name="whole_order", subchunks=1)
+    groups: list[list[int]] = []
+    for i in range(0, len(orders), merge_width):
+        block = orders[i : i + merge_width]
+        if block:
+            groups.append([block[0], block[-1]])
+    return ChunkLayout(
+        name=f"merge_w{merge_width}",
+        subchunks=1,
+        merge_orders=groups,
+    )
+
+
+def default_parametric_grid(
+    *,
+    subchunk_counts: list[int] | None = None,
+    merge_widths: list[int] | None = None,
+) -> list[ChunkLayout]:
+    """Rough parametric grid: equal sub-chunks N and order-merge widths."""
+    subchunk_counts = subchunk_counts or [1, 2, 4]
+    merge_widths = merge_widths or [1, 2, 4]
+    layouts: list[ChunkLayout] = []
+    seen: set[str] = set()
+    for n in subchunk_counts:
+        lay = build_equal_subchunk_layout(n)
+        if lay.name not in seen:
+            layouts.append(lay)
+            seen.add(lay.name)
+    for w in merge_widths:
+        lay = build_merge_orders_layout(merge_width=w)
+        if lay.name not in seen:
+            layouts.append(lay)
+            seen.add(lay.name)
+    return layouts
+
+
+def layout_to_dict(layout: ChunkLayout) -> dict[str, Any]:
+    return {
+        "name": layout.name,
+        "subchunks": layout.subchunks,
+        "pixel_edges": layout.normalized_pixel_edges().tolist(),
+        "merge_orders": layout.merge_orders,
+        "min_pixels": layout.min_pixels,
+        "n_chunks_per_order": layout.n_chunks_per_order(),
+    }
+
+
+def merge_order_groups(order: int, merge_orders: list[list[int]] | None) -> int | None:
+    """Return merge-group index if order belongs to a merge group, else None."""
+    if not merge_orders:
+        return None
+    for gi, grp in enumerate(merge_orders):
+        lo, hi = int(grp[0]), int(grp[1])
+        if lo <= order <= hi:
+            return gi
+    return None
+
+
+def map_chunk_key(old_key: str, layout: ChunkLayout) -> str:
+    """
+    Map an existing diagnostics chunk_key to a layout chunk_key.
+
+    Whole-order keys ``"{order}"`` map to sub-chunks only when layout.subchunks > 1
+    (cannot split offline — returns same key with a warning tag).
+
+    Supports ``merge_orders`` by combining ``"{o}"`` → ``"merge_{gi}"``.
+    """
+    parts = str(old_key).split("_")
+    try:
+        order = int(parts[0])
+    except ValueError:
+        return old_key
+    sub = int(parts[1]) if len(parts) > 1 else 0
+
+    mg = merge_order_groups(order, layout.merge_orders)
+    if mg is not None:
+        if len(parts) > 1:
+            return f"merge_{mg}_{sub}"
+        return f"merge_{mg}"
+
+    if layout.subchunks > 1 and len(parts) == 1:
+        # Cannot split whole-order diagnostics offline
+        return old_key
+
+    if layout.subchunks > 1:
+        n = layout.subchunks
+        new_sub = min(sub, n - 1)
+        return f"{order}_{new_sub}"
+    return str(order)
+
+
+def rebinned_chunk_rows(df, layout: ChunkLayout):
+    """
+    Rebin long chunk-level rows to a coarser layout (merge orders or regroup keys).
+
+    Returns DataFrame with one row per (file, new_chunk_key) using IVW of rv_kms.
+    """
+    import pandas as pd
+
+    if df.empty:
+        return df
+    tab = df.copy()
+    tab["new_chunk_key"] = tab["chunk_key"].astype(str).map(lambda ck: map_chunk_key(ck, layout))
+    rows = []
+    for (file_label, nck), g in tab.groupby(["file", "new_chunk_key"], sort=False):
+        rv = g["rv_kms"].astype(float).values
+        err = g["rv_err_kms"].astype(float).values
+        ok = np.isfinite(rv) & np.isfinite(err) & (err > 0)
+        if not np.any(ok):
+            continue
+        w = 1.0 / err[ok] ** 2
+        mu = float(np.sum(w * rv[ok]) / np.sum(w))
+        sig = float(1.0 / np.sqrt(np.sum(w)))
+        r0 = g.iloc[0]
+        rows.append(
+            {
+                **{c: r0[c] for c in g.columns if c not in ("chunk_key", "rv_kms", "rv_err_kms", "new_chunk_key")},
+                "chunk_key": str(nck),
+                "rv_kms": mu,
+                "rv_err_kms": sig,
+                "n_merged_chunks": int(len(g)),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def iter_order_chunks_from_layout(
+    spec_data: dict,
+    bad_orders: list[int],
+    layout: ChunkLayout,
+):
+    """Yield (chunk_key, wave, flux, eflux) for a layout (including merged orders)."""
+    from darkhunter_rv.chunking import iter_order_chunks, iter_order_chunks_with_edges
+
+    if layout.merge_orders:
+        groups: dict[int, dict[str, list]] = {}
+        for order in sorted(spec_data.keys()):
+            if order in bad_orders:
+                continue
+            gi = merge_order_groups(order, layout.merge_orders)
+            if gi is None:
+                continue
+            data = spec_data[order]
+            bucket = groups.setdefault(gi, {"wavelength": [], "flux": [], "eflux": []})
+            for k in ("wavelength", "flux", "eflux"):
+                bucket[k].extend(data[k])
+        for gi, data in sorted(groups.items()):
+            w = np.array(data["wavelength"], float)
+            f = np.array(data["flux"], float)
+            e = np.array(data["eflux"], float)
+            if len(w) < layout.min_pixels:
+                continue
+            yield f"merge_{gi}", w, f, e
+        return
+
+    from darkhunter_rv.chunking import telluric_pixel_edges
+
+    for order in sorted(spec_data.keys()):
+        if order in bad_orders:
+            continue
+        data = spec_data[order]
+        w = np.array(data["wavelength"], float)
+        f = np.array(data["flux"], float)
+        e = np.array(data["eflux"], float)
+        n = len(w)
+        if n < layout.min_pixels:
+            continue
+        if layout.telluric_split:
+            edges_frac = telluric_pixel_edges(w, min_pixels=layout.min_pixels)
+        elif layout.subchunks > 1:
+            edges_frac = np.linspace(0.0, 1.0, layout.subchunks + 1)
+        else:
+            edges_frac = layout.normalized_pixel_edges()
+        idx_edges = np.round(edges_frac * n).astype(int)
+        idx_edges[0] = 0
+        idx_edges[-1] = n
+        for si in range(len(idx_edges) - 1):
+            i0, i1 = int(idx_edges[si]), int(idx_edges[si + 1])
+            if i1 - i0 < layout.min_pixels:
+                continue
+            key = str(order) if len(idx_edges) == 2 else f"{order}_{si}"
+            yield key, w[i0:i1], f[i0:i1], e[i0:i1]

--- a/validation/chunk_measurement_cache.py
+++ b/validation/chunk_measurement_cache.py
@@ -1,0 +1,138 @@
+"""CSV cache for per-chunk RV measurements across chunk layout campaigns."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from validation.chunk_layout import ChunkLayout, layout_to_dict, measurement_id_for_chunk
+
+CACHE_COLUMNS = [
+    "measurement_id",
+    "layout_name",
+    "file",
+    "gaia_dr3_id",
+    "chunk_key",
+    "method",
+    "rv_kms",
+    "rv_err_kms",
+    "mjd",
+    "teff",
+    "qc_pass",
+    "pixel_edges_json",
+    "measured_at",
+]
+
+
+def load_cache(path: Path) -> pd.DataFrame:
+    if not path.is_file():
+        return pd.DataFrame(columns=CACHE_COLUMNS)
+    df = pd.read_csv(path)
+    for c in CACHE_COLUMNS:
+        if c not in df.columns:
+            df[c] = np.nan
+    return df[CACHE_COLUMNS]
+
+
+def save_cache(df: pd.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+
+
+def _layout_edges_json(layout: ChunkLayout) -> str:
+    return json.dumps(layout_to_dict(layout))
+
+
+def ingest_diagnostics_csv(
+    diag_path: Path,
+    *,
+    layout: ChunkLayout,
+    cache: pd.DataFrame,
+) -> pd.DataFrame:
+    """Append mask_ccf chunk rows from one diagnostics file into cache (deduplicated)."""
+    if not diag_path.is_file():
+        return cache
+    df = pd.read_csv(diag_path)
+    if df.empty:
+        return cache
+    edges_json = _layout_edges_json(layout)
+    merge_mode = layout.merge_orders is not None
+    rows: list[dict] = []
+    now = datetime.now(timezone.utc).isoformat()
+    for _, r in df.iterrows():
+        if str(r.get("chunk_key", "")) == "all":
+            continue
+        if str(r.get("method", "")) != "mask_ccf":
+            continue
+        ck = str(r.get("chunk_key", ""))
+        file_label = str(r.get("file", diag_path.stem.replace("_diagnostics", "")))
+        mid = measurement_id_for_chunk(ck, layout.normalized_pixel_edges().tolist(), merge_mode)
+        gid = ""
+        m = __import__("re").search(r"Gaia_DR3_(\d{18,19})", file_label)
+        if m:
+            gid = m.group(1)
+        rows.append(
+            {
+                "measurement_id": mid,
+                "layout_name": layout.name,
+                "file": file_label,
+                "gaia_dr3_id": gid,
+                "chunk_key": ck,
+                "method": "mask_ccf",
+                "rv_kms": float(r.get("rv_kms", np.nan)),
+                "rv_err_kms": float(r.get("rv_err_kms", np.nan)),
+                "mjd": float(r.get("mjd", np.nan)),
+                "teff": float(r.get("teff", np.nan)),
+                "qc_pass": bool(r.get("qc_pass", True)),
+                "pixel_edges_json": edges_json,
+                "measured_at": now,
+            }
+        )
+    if not rows:
+        return cache
+    new_df = pd.DataFrame(rows)
+    combined = pd.concat([cache, new_df], ignore_index=True)
+    combined = combined.drop_duplicates(subset=["measurement_id", "file"], keep="last")
+    return combined[CACHE_COLUMNS]
+
+
+def ingest_layout_diagnostics_dir(
+    diag_dir: Path,
+    *,
+    layout: ChunkLayout,
+    cache: pd.DataFrame,
+) -> pd.DataFrame:
+    for p in sorted(diag_dir.glob("*_diagnostics.csv")):
+        cache = ingest_diagnostics_csv(p, layout=layout, cache=cache)
+    return cache
+
+
+def layout_files_complete(
+    cache: pd.DataFrame,
+    *,
+    layout_name: str,
+    spectrum_files: list[Path],
+    min_chunks_per_file: int = 3,
+) -> set[Path]:
+    """Return spectrum files that already have >= min_chunks in cache for this layout."""
+    done: set[Path] = set()
+    sub = cache[cache["layout_name"].astype(str) == str(layout_name)]
+    if sub.empty:
+        return done
+    for sf in spectrum_files:
+        file_label = str(sf)
+        n = int((sub["file"].astype(str) == file_label).sum())
+        if n == 0:
+            stem = sf.stem
+            n = int(sub["file"].astype(str).str.contains(stem, regex=False).sum())
+        if n >= min_chunks_per_file:
+            done.add(sf)
+    return done
+
+
+def diagnostics_glob_for_layout(campaign_dir: Path, layout_name: str) -> str:
+    d = campaign_dir / "diagnostics" / layout_name
+    return str(d / "Gaia_DR3_*_diagnostics.csv")

--- a/validation/evaluate_chunk_layout.py
+++ b/validation/evaluate_chunk_layout.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+Evaluate candidate chunk layouts on existing diagnostics (offline rebinning).
+
+Supports order-merging layouts immediately. Sub-chunk splits require a pipeline
+rerun with ``--subchunks N`` or a custom layout YAML.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  python -m validation.evaluate_chunk_layout \\
+    --layouts calibration/chunk_layouts/*.yaml \\
+    --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' \\
+    --out-dir validation_output/chunk_layout_eval
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from glob import glob as glob_paths
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from validation.chunk_bias_lib import load_stellar_metadata, sample_mean_bias_curve  # noqa: E402
+from validation.chunk_calibration import (  # noqa: E402
+    build_intrinsic_scatter_model,
+    build_layout_fallback_tables,
+    stack_calibrated_exposure,
+    summarize_relative_gate,
+    summarize_sigma_rv_metrics,
+    relative_pair_table,
+)
+from validation.chunk_layout import ChunkLayout, load_chunk_layout, layout_to_dict, rebinned_chunk_rows  # noqa: E402
+from validation.plot_chunk_residuals import (  # noqa: E402
+    DEFAULT_CHUNK_MAX_DELTA_KMS,
+    DEFAULT_CHUNK_OUTLIER_SIGMA,
+    _load_chunk_rows,
+    apply_spectrum_chunk_outlier_clip,
+    _summarize_chunks_per_object,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _layout_metrics(
+    tab: pd.DataFrame,
+    layout_name: str,
+    *,
+    clip_sigma: float,
+    clip_max_delta_kms: float,
+    min_chunks: int,
+) -> dict:
+    if tab.empty:
+        return {"layout": layout_name, "n_exposures": 0}
+
+    tab = apply_spectrum_chunk_outlier_clip(tab, nsigma=clip_sigma, max_delta_kms=clip_max_delta_kms)
+    meta = load_stellar_metadata(REPO_ROOT / "output")
+    if not meta.empty:
+        tab = tab.merge(meta, on="gaia_dr3_id", how="left")
+    bias_rows = []
+    for gid, obj in tab.groupby("gaia_dr3_id"):
+        summ = _summarize_chunks_per_object(obj[obj["chunk_kept"].astype(bool)] if "chunk_kept" in obj.columns else obj)
+        if summ.empty:
+            continue
+        summ["gaia_dr3_id"] = str(gid)
+        bias_rows.append(summ)
+    if not bias_rows:
+        return {"layout": layout_name, "n_exposures": 0}
+    bias = pd.concat(bias_rows, ignore_index=True)
+    teff_by_star = tab.groupby("gaia_dr3_id", as_index=False)["teff"].median()
+    bias = bias.merge(teff_by_star, on="gaia_dr3_id", how="left")
+    if not meta.empty:
+        extra = meta[["gaia_dr3_id", "logg", "mh"]].copy()
+        if "teff_gaia" in meta.columns:
+            extra["teff_gaia"] = meta["teff_gaia"]
+        bias = bias.merge(extra, on="gaia_dr3_id", how="left")
+        if "teff_gaia" in bias.columns:
+            miss = ~np.isfinite(bias["teff"].astype(float))
+            bias.loc[miss, "teff"] = bias.loc[miss, "teff_gaia"]
+    curve = sample_mean_bias_curve(bias)
+    curve_rms = float(np.sqrt(np.mean(curve["sample_mean_bias_kms"].astype(float) ** 2)))
+
+    _, fallback = build_layout_fallback_tables(bias)
+    intrinsic_model = build_intrinsic_scatter_model(bias)
+
+    epoch_rows = []
+    for file_label, g in tab.groupby("file", sort=False):
+        gid = str(g.iloc[0]["gaia_dr3_id"])
+        per_obj = bias[bias["gaia_dr3_id"] == gid]
+        stack = stack_calibrated_exposure(
+            g,
+            per_object=per_obj,
+            fallback=fallback,
+            intrinsic_model=intrinsic_model,
+            min_chunks=min_chunks,
+        )
+        r0 = g.iloc[0]
+        epoch_rows.append(
+            {
+                "gaia_dr3_id": str(r0["gaia_dr3_id"]),
+                "file": str(file_label),
+                "mjd": float(r0["mjd"]),
+                "rv_calibrated_kms": stack["rv_calibrated_kms"],
+                "rv_err_calibrated_kms": stack["rv_err_calibrated_kms"],
+                "sigma_rv_core90_kms": stack["sigma_rv_core90_kms"],
+                "chunk_scatter_calibrated_kms": stack["chunk_scatter_calibrated_kms"],
+                "n_chunks_used": stack["n_chunks_used"],
+                "n_chunks_core90": stack["n_chunks_core90"],
+            }
+        )
+    epochs = pd.DataFrame(epoch_rows)
+    sc = epochs["chunk_scatter_calibrated_kms"].astype(float)
+    sc_ok = sc[np.isfinite(sc)]
+    sigma_metrics = summarize_sigma_rv_metrics(epochs)
+
+    pairs = relative_pair_table(epochs, rv_col="rv_calibrated_kms", err_col="rv_err_calibrated_kms")
+    gate = summarize_relative_gate(pairs, goal_kms=0.1)
+
+    return {
+        "layout": layout_name,
+        "n_exposures": int(epochs["rv_calibrated_kms"].notna().sum()),
+        "n_chunk_bias_rows": int(len(bias)),
+        "bias_curve_rms_kms": curve_rms,
+        "min_sigma_rv_kms": sigma_metrics["min_sigma_rv_kms"],
+        "p10_sigma_rv_kms": sigma_metrics["p10_sigma_rv_kms"],
+        "median_sigma_rv_kms": sigma_metrics["median_sigma_rv_kms"],
+        "p90_sigma_rv_kms": sigma_metrics["p90_sigma_rv_kms"],
+        "min_sigma_rv_core90_kms": sigma_metrics["min_sigma_rv_core90_kms"],
+        "median_chunk_scatter_kms": float(np.median(sc_ok)) if len(sc_ok) else float("nan"),
+        "p90_chunk_scatter_kms": float(np.percentile(sc_ok, 90)) if len(sc_ok) else float("nan"),
+        "relative_median_abs_delta_kms": gate.get("median_abs_delta_rv_kms", float("nan")),
+        "relative_p90_abs_delta_kms": gate.get("p90_abs_delta_rv_kms", float("nan")),
+        "relative_frac_below_0p1_kms": gate.get("frac_below_goal", float("nan")),
+        "n_relative_pairs": gate.get("n_pairs", 0),
+    }
+
+
+def evaluate_layout(
+    layout: ChunkLayout,
+    base: pd.DataFrame,
+    *,
+    clip_sigma: float,
+    clip_max_delta_kms: float,
+    min_chunks: int,
+    rebinned: pd.DataFrame | None = None,
+) -> dict:
+    if rebinned is None:
+        rebinned = rebinned_chunk_rows(base, layout)
+    offline_ok = layout.merge_orders is not None or layout.subchunks <= 1
+    if rebinned is base or rebinned.equals(base):
+        offline_ok = True
+    if layout.subchunks > 1 and layout.merge_orders is None and rebinned is base:
+        offline_ok = True
+    elif layout.subchunks > 1 and layout.merge_orders is None and rebinned is not base:
+        logger.warning(
+            "Layout %s uses subchunks=%d; offline eval cannot split whole-order diagnostics — rerun pipeline",
+            layout.name,
+            layout.subchunks,
+        )
+    metrics = _layout_metrics(
+        rebinned,
+        layout.name,
+        clip_sigma=clip_sigma,
+        clip_max_delta_kms=clip_max_delta_kms,
+        min_chunks=min_chunks,
+    )
+    metrics.update({f"cfg_{k}": v for k, v in layout_to_dict(layout).items() if k != "name"})
+    metrics["eval_mode"] = "pipeline" if offline_ok and layout.subchunks > 1 else (
+        "offline_merge" if layout.merge_orders else (
+            "offline_baseline" if layout.subchunks <= 1 else "needs_pipeline_rerun"
+        )
+    )
+    metrics["offline_eval_valid"] = bool(offline_ok or (rebinned is not base))
+    return metrics
+
+
+def evaluate_layouts_from_glob(
+    layouts: list[ChunkLayout],
+    diagnostics_glob: str,
+    *,
+    clip_sigma: float,
+    clip_max_delta_kms: float,
+    min_chunks: int,
+) -> pd.DataFrame:
+    """Evaluate layouts using diagnostics already produced for each layout (no rebin)."""
+    rows = []
+    for layout in layouts:
+        tab = _load_chunk_rows(diagnostics_glob)
+        if tab.empty:
+            continue
+        metrics = evaluate_layout(
+            layout,
+            tab,
+            clip_sigma=clip_sigma,
+            clip_max_delta_kms=clip_max_delta_kms,
+            min_chunks=min_chunks,
+            rebinned=tab,
+        )
+        metrics["offline_eval_valid"] = True
+        metrics["eval_mode"] = "pipeline"
+        rows.append(metrics)
+    return pd.DataFrame(rows)
+
+
+def evaluate_layouts(
+    layouts: list[Path | ChunkLayout],
+    diagnostics_glob: str,
+    *,
+    clip_sigma: float,
+    clip_max_delta_kms: float,
+    min_chunks: int,
+) -> pd.DataFrame:
+    base = _load_chunk_rows(diagnostics_glob)
+    rows = []
+    for item in layouts:
+        layout = load_chunk_layout(item) if isinstance(item, Path) else item
+        metrics = evaluate_layout(
+            layout,
+            base,
+            clip_sigma=clip_sigma,
+            clip_max_delta_kms=clip_max_delta_kms,
+            min_chunks=min_chunks,
+        )
+        if isinstance(item, Path):
+            metrics["layout_file"] = str(item)
+        rows.append(metrics)
+    return pd.DataFrame(rows)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--layouts", nargs="+", required=True, help="YAML layout files or globs")
+    ap.add_argument("--diagnostics-glob", default="output/Gaia_DR3_*_diagnostics.csv")
+    ap.add_argument("--out-dir", type=Path, default=REPO_ROOT / "validation_output" / "chunk_layout_eval")
+    ap.add_argument("--chunk-outlier-sigma", type=float, default=DEFAULT_CHUNK_OUTLIER_SIGMA)
+    ap.add_argument("--chunk-max-delta-kms", type=float, default=DEFAULT_CHUNK_MAX_DELTA_KMS)
+    ap.add_argument("--min-chunks", type=int, default=3)
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    layout_paths: list[Path] = []
+    for pat in args.layouts:
+        if "*" in pat:
+            layout_paths.extend(Path(p) for p in glob_paths(pat))
+        else:
+            layout_paths.append(Path(pat))
+    layout_paths = sorted({p.resolve() for p in layout_paths if p.is_file()})
+    if not layout_paths:
+        logger.error("No layout YAML files found")
+        sys.exit(1)
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    summary = evaluate_layouts(
+        layout_paths,
+        args.diagnostics_glob,
+        clip_sigma=args.chunk_outlier_sigma,
+        clip_max_delta_kms=args.chunk_max_delta_kms,
+        min_chunks=args.min_chunks,
+    )
+    summary.to_csv(args.out_dir / "layout_comparison.csv", index=False)
+    (args.out_dir / "layout_comparison.json").write_text(
+        json.dumps(summary.to_dict(orient="records"), indent=2),
+        encoding="utf-8",
+    )
+    logger.info("Wrote layout comparison (%d layouts) -> %s", len(summary), args.out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/plot_chunk_residuals.py
+++ b/validation/plot_chunk_residuals.py
@@ -43,6 +43,10 @@ from darkhunter_rv.summary_paths import parse_object_id_from_summary, discover_s
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_CHUNK_OUTLIER_SIGMA = 7.0
+DEFAULT_CHUNK_MAX_DELTA_KMS = 20.0
+DEFAULT_MIN_CHUNK_MEASUREMENTS = 3
+
 
 def _parse_gaia_id_from_path(path: str | Path) -> str | None:
     m = re.search(r"Gaia_DR3_(\d{18,19})", str(path))
@@ -363,9 +367,16 @@ def _plot_residuals_by_spectrum(
     plt.close(fig)
 
 
-def _summarize_chunks_per_object(obj_df: pd.DataFrame) -> pd.DataFrame:
+def _summarize_chunks_per_object(
+    obj_df: pd.DataFrame,
+    *,
+    min_measurements: int = DEFAULT_MIN_CHUNK_MEASUREMENTS,
+) -> pd.DataFrame:
     rows = []
     for ck, g in obj_df.groupby("chunk_key"):
+        n_meas = int(len(g))
+        if n_meas < min_measurements:
+            continue
         mu, stat, intrinsic = _weighted_mean_and_errors(
             g["residual_kms"].astype(float).values,
             g["rv_err_kms"].astype(float).values,
@@ -374,6 +385,7 @@ def _summarize_chunks_per_object(obj_df: pd.DataFrame) -> pd.DataFrame:
             {
                 "chunk_key": str(ck),
                 "chunk_order": _chunk_sort_key(str(ck))[0],
+                "n_measurements": n_meas,
                 "n_spectra": int(g["file"].nunique()),
                 "weighted_mean_residual_kms": mu,
                 "statistical_err_kms": stat,
@@ -579,10 +591,11 @@ def run_plot_chunk_residuals(
     out_dir: Path,
     summary_dir: Path | None = None,
     gaia_ids: set[str] | None = None,
-    chunk_outlier_sigma: float | None = 10.0,
-    chunk_max_delta_kms: float | None = 30.0,
+    chunk_outlier_sigma: float | None = DEFAULT_CHUNK_OUTLIER_SIGMA,
+    chunk_max_delta_kms: float | None = DEFAULT_CHUNK_MAX_DELTA_KMS,
     sample_outlier_sigma: float | None = 5.0,
     sample_max_delta_kms: float | None = 10.0,
+    min_chunk_measurements: int = DEFAULT_MIN_CHUNK_MEASUREMENTS,
 ) -> dict[str, int]:
     out_dir.mkdir(parents=True, exist_ok=True)
     tab = _load_chunk_rows(diagnostics_glob)
@@ -632,7 +645,7 @@ def run_plot_chunk_residuals(
             clip_max_delta_kms=chunk_max_delta_kms,
         )
 
-        summary = _summarize_chunks_per_object(obj_df)
+        summary = _summarize_chunks_per_object(obj_df, min_measurements=min_chunk_measurements)
         summary.to_csv(obj_dir / "chunk_weighted_summary.csv", index=False)
         summaries[gid] = summary
 
@@ -642,7 +655,7 @@ def run_plot_chunk_residuals(
             name=name,
             out_path=obj_dir / f"{name or gid}_chunk_weighted_mean.png",
             title_suffix=(
-                "per-chunk weighted mean across spectra"
+                f"per-chunk weighted mean (≥{min_chunk_measurements} surviving measurements)"
                 + _clip_title_note(chunk_outlier_sigma, chunk_max_delta_kms)
             ),
         )
@@ -706,14 +719,20 @@ def main() -> None:
     ap.add_argument(
         "--chunk-outlier-sigma",
         type=float,
-        default=10.0,
+        default=DEFAULT_CHUNK_OUTLIER_SIGMA,
         help="Iterative leave-one-out clip: exclude chunk RVs > N×RMS(other chunks) per spectrum (0=off)",
     )
     ap.add_argument(
         "--chunk-max-delta-kms",
         type=float,
-        default=30.0,
+        default=DEFAULT_CHUNK_MAX_DELTA_KMS,
         help="Iterative clip: exclude chunk RVs > N km/s from weighted mean per spectrum (0=off)",
+    )
+    ap.add_argument(
+        "--min-chunk-measurements",
+        type=int,
+        default=DEFAULT_MIN_CHUNK_MEASUREMENTS,
+        help="Per-object weighted mean: require at least N surviving chunk measurements per chunk_key",
     )
     ap.add_argument(
         "--sample-outlier-sigma",
@@ -752,6 +771,7 @@ def main() -> None:
         chunk_max_delta_kms=clip_delta,
         sample_outlier_sigma=sample_sigma,
         sample_max_delta_kms=sample_delta,
+        min_chunk_measurements=int(args.min_chunk_measurements),
     )
     logger.info("Wrote chunk residual plots to %s (%s)", args.out_dir, stats)
 

--- a/validation/plot_chunk_residuals.py
+++ b/validation/plot_chunk_residuals.py
@@ -74,37 +74,58 @@ def _exposure_rv_weighted(rv: np.ndarray, err: np.ndarray) -> float:
     return float(np.sum(w * v) / np.sum(w))
 
 
-def iterative_loo_sigma_clip_mask(
+def iterative_spectrum_chunk_clip_mask(
     rv: np.ndarray,
+    err: np.ndarray,
     *,
     nsigma: float = 10.0,
+    max_delta_kms: float = 30.0,
     max_iter: int = 100,
 ) -> np.ndarray:
     """
-    Per-spectrum iterative leave-one-out clip: drop chunk *i* when
-    |RV_i − mean(RV_{j≠i})| > nsigma × RMS(RV_{j≠i}) until convergence.
+    Per-spectrum iterative clip until convergence:
+
+    1. |RV_i − weighted_mean(kept)| > max_delta_kms
+    2. |RV_i − mean(RV_{j≠i})| > nsigma × RMS(RV_{j≠i})  (leave-one-out)
     """
     rv = np.asarray(rv, float)
+    err = np.asarray(err, float)
     n = len(rv)
     keep = np.ones(n, dtype=bool)
-    if n < 2:
+    if n < 1:
         return keep
+
+    use_delta = max_delta_kms is not None and np.isfinite(max_delta_kms) and max_delta_kms > 0
+    use_sigma = nsigma is not None and np.isfinite(nsigma) and nsigma > 0
+
     for _ in range(max_iter):
         removed_any = False
         active = np.where(keep)[0]
-        if len(active) < 2:
+        if len(active) == 0:
             break
-        for i in active:
-            others = rv[keep & (np.arange(n) != i)]
-            if len(others) < 1:
-                continue
-            mu = float(np.mean(others))
-            rms = float(np.std(others, ddof=1)) if len(others) > 1 else 0.0
-            if not np.isfinite(rms) or rms <= 0:
-                continue
-            if abs(float(rv[i]) - mu) > nsigma * rms:
-                keep[i] = False
-                removed_any = True
+
+        if use_delta and len(active) >= 1:
+            wmean = _exposure_rv_weighted(rv[keep], err[keep])
+            if np.isfinite(wmean):
+                for i in active:
+                    if abs(float(rv[i]) - wmean) > float(max_delta_kms):
+                        keep[i] = False
+                        removed_any = True
+
+        if use_sigma and keep.sum() >= 2:
+            active = np.where(keep)[0]
+            for i in active:
+                others = rv[keep & (np.arange(n) != i)]
+                if len(others) < 1:
+                    continue
+                mu = float(np.mean(others))
+                rms = float(np.std(others, ddof=1)) if len(others) > 1 else 0.0
+                if not np.isfinite(rms) or rms <= 0:
+                    continue
+                if abs(float(rv[i]) - mu) > nsigma * rms:
+                    keep[i] = False
+                    removed_any = True
+
         if not removed_any:
             break
     return keep
@@ -114,6 +135,7 @@ def apply_spectrum_chunk_outlier_clip(
     tab: pd.DataFrame,
     *,
     nsigma: float = 10.0,
+    max_delta_kms: float = 30.0,
 ) -> pd.DataFrame:
     """Mark chunk_kept per spectrum; recompute exposure_rv_kms and residual_kms from kept chunks."""
     if tab.empty:
@@ -127,7 +149,9 @@ def apply_spectrum_chunk_outlier_clip(
         idx = g.index.to_numpy()
         rv = g["rv_kms"].astype(float).to_numpy()
         err = g["rv_err_kms"].astype(float).to_numpy()
-        keep = iterative_loo_sigma_clip_mask(rv, nsigma=nsigma)
+        keep = iterative_spectrum_chunk_clip_mask(
+            rv, err, nsigma=nsigma, max_delta_kms=max_delta_kms
+        )
         out.loc[idx, "chunk_kept"] = keep
         if not np.any(keep):
             continue
@@ -256,6 +280,26 @@ def _object_name(gaia_id: str, summary_dir: Path | None, name_lookup: dict[str, 
     return gaia_id
 
 
+def _clip_title_note(clip_sigma: float | None, clip_max_delta_kms: float | None) -> str:
+    parts = []
+    if clip_sigma is not None and clip_sigma > 0:
+        parts.append(f"{clip_sigma:g}σ LOO")
+    if clip_max_delta_kms is not None and clip_max_delta_kms > 0:
+        parts.append(f"±{clip_max_delta_kms:g} km/s")
+    return f", {' + '.join(parts)} clip" if parts else ""
+
+
+def _clip_legend_label(clip_sigma: float | None, clip_max_delta_kms: float | None) -> str:
+    return "excluded (" + ", ".join(
+        p
+        for p in (
+            f">{clip_sigma:g}σ LOO" if clip_sigma and clip_sigma > 0 else "",
+            f">±{clip_max_delta_kms:g} km/s" if clip_max_delta_kms and clip_max_delta_kms > 0 else "",
+        )
+        if p
+    ) + ")"
+
+
 def _plot_residuals_by_spectrum(
     obj_df: pd.DataFrame,
     *,
@@ -263,6 +307,7 @@ def _plot_residuals_by_spectrum(
     name: str,
     out_path: Path,
     clip_sigma: float | None,
+    clip_max_delta_kms: float | None,
 ) -> None:
     kept_df = obj_df[obj_df["chunk_kept"].astype(bool)] if "chunk_kept" in obj_df.columns else obj_df
     excluded_df = (
@@ -303,15 +348,14 @@ def _plot_residuals_by_spectrum(
             c="0.55",
             alpha=0.45,
             linewidths=0.8,
-            label="excluded (>{}σ LOO)".format(clip_sigma) if clip_sigma else "excluded",
+            label=_clip_legend_label(clip_sigma, clip_max_delta_kms),
         )
     ax.axhline(0.0, color="gray", ls=":", lw=0.8)
     ax.set_xticks(range(len(chunks)))
     ax.set_xticklabels(chunks, rotation=90, fontsize=6)
     ax.set_xlabel("chunk_key")
     ax.set_ylabel("RV_chunk − RV_exposure (km/s)")
-    clip_note = f", {clip_sigma:g}σ LOO clip" if clip_sigma else ""
-    ax.set_title(f"{name} — chunk residuals by spectrum (mask-applicable{clip_note})")
+    ax.set_title(f"{name} — chunk residuals by spectrum (mask-applicable{_clip_title_note(clip_sigma, clip_max_delta_kms)})")
     if n_spec <= 12:
         ax.legend(fontsize=6, loc="upper right", ncol=2)
     fig.tight_layout()
@@ -472,6 +516,7 @@ def run_plot_chunk_residuals(
     summary_dir: Path | None = None,
     gaia_ids: set[str] | None = None,
     chunk_outlier_sigma: float | None = 10.0,
+    chunk_max_delta_kms: float | None = 30.0,
 ) -> dict[str, int]:
     out_dir.mkdir(parents=True, exist_ok=True)
     tab = _load_chunk_rows(diagnostics_glob)
@@ -483,8 +528,16 @@ def run_plot_chunk_residuals(
         tab = tab[tab["gaia_dr3_id"].astype(str).isin(gaia_ids)]
 
     n_excluded = 0
-    if chunk_outlier_sigma is not None and chunk_outlier_sigma > 0:
-        tab = apply_spectrum_chunk_outlier_clip(tab, nsigma=chunk_outlier_sigma)
+    clip_enabled = (
+        (chunk_outlier_sigma is not None and chunk_outlier_sigma > 0)
+        or (chunk_max_delta_kms is not None and chunk_max_delta_kms > 0)
+    )
+    if clip_enabled:
+        tab = apply_spectrum_chunk_outlier_clip(
+            tab,
+            nsigma=float(chunk_outlier_sigma or 0.0),
+            max_delta_kms=float(chunk_max_delta_kms or 0.0),
+        )
         n_excluded = int((~tab["chunk_kept"].astype(bool)).sum())
         tab_plot = tab[tab["chunk_kept"].astype(bool)].copy()
     else:
@@ -510,6 +563,7 @@ def run_plot_chunk_residuals(
             name=name,
             out_path=obj_dir / f"{name or gid}_residuals_by_spectrum.png",
             clip_sigma=chunk_outlier_sigma,
+            clip_max_delta_kms=chunk_max_delta_kms,
         )
 
         summary = _summarize_chunks_per_object(obj_df)
@@ -523,7 +577,7 @@ def run_plot_chunk_residuals(
             out_path=obj_dir / f"{name or gid}_chunk_weighted_mean.png",
             title_suffix=(
                 "per-chunk weighted mean across spectra"
-                + (f" ({chunk_outlier_sigma:g}σ LOO clip)" if chunk_outlier_sigma else "")
+                + _clip_title_note(chunk_outlier_sigma, chunk_max_delta_kms)
             ),
         )
         n_objects += 1
@@ -573,6 +627,12 @@ def main() -> None:
         default=10.0,
         help="Iterative leave-one-out clip: exclude chunk RVs > N×RMS(other chunks) per spectrum (0=off)",
     )
+    ap.add_argument(
+        "--chunk-max-delta-kms",
+        type=float,
+        default=30.0,
+        help="Iterative clip: exclude chunk RVs > N km/s from weighted mean per spectrum (0=off)",
+    )
     ap.add_argument("--log-level", default="INFO")
     args = ap.parse_args()
     logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
@@ -586,12 +646,14 @@ def main() -> None:
             logger.warning("overlap_stars.csv not found; using all mask-applicable objects")
 
     clip_sigma = float(args.chunk_outlier_sigma) if args.chunk_outlier_sigma > 0 else None
+    clip_delta = float(args.chunk_max_delta_kms) if args.chunk_max_delta_kms > 0 else None
     stats = run_plot_chunk_residuals(
         diagnostics_glob=args.diagnostics_glob,
         out_dir=args.out_dir,
         summary_dir=args.summary_dir,
         gaia_ids=gaia_ids,
         chunk_outlier_sigma=clip_sigma,
+        chunk_max_delta_kms=clip_delta,
     )
     logger.info("Wrote chunk residual plots to %s (%s)", args.out_dir, stats)
 

--- a/validation/plot_chunk_residuals.py
+++ b/validation/plot_chunk_residuals.py
@@ -439,57 +439,120 @@ def _plot_chunk_weighted_mean(
     plt.close(fig)
 
 
+def _combined_object_bias_err(stat: np.ndarray, intrinsic: np.ndarray) -> np.ndarray:
+    s = np.where(np.isfinite(stat), stat, 0.0)
+    i = np.where(np.isfinite(intrinsic), intrinsic, 0.0)
+    e = np.sqrt(s**2 + i**2)
+    e = np.where(e > 0, e, np.nan)
+    return e
+
+
+def apply_sample_object_bias_clip(
+    bias_df: pd.DataFrame,
+    *,
+    nsigma: float = 5.0,
+    max_delta_kms: float = 10.0,
+) -> pd.DataFrame:
+    """Per chunk_key, clip per-object bias values before full-sample aggregation."""
+    if bias_df.empty:
+        return bias_df
+    out = bias_df.copy()
+    out["sample_kept"] = True
+    stat_col = out["statistical_err_kms"].astype(float).values
+    int_col = out["intrinsic_scatter_kms"].astype(float).values
+    err = _combined_object_bias_err(stat_col, int_col)
+
+    for _, g in out.groupby("chunk_key"):
+        idx = g.index.to_numpy()
+        rv = g["weighted_mean_residual_kms"].astype(float).to_numpy()
+        e = err[g.index]
+        keep = iterative_spectrum_chunk_clip_mask(
+            rv, e, nsigma=nsigma, max_delta_kms=max_delta_kms
+        )
+        out.loc[idx, "sample_kept"] = keep
+    return out
+
+
 def _plot_sample_per_object_bias(
-    all_summaries: dict[str, pd.DataFrame],
+    bias_df: pd.DataFrame,
     names: dict[str, str],
     out_path: Path,
+    *,
+    sample_sigma: float | None,
+    sample_max_delta_kms: float | None,
 ) -> None:
-    if not all_summaries:
+    if bias_df.empty:
         return
-    chunk_set: set[str] = set()
-    for sdf in all_summaries.values():
-        chunk_set.update(sdf["chunk_key"].astype(str).tolist())
+    chunk_set = set(bias_df["chunk_key"].astype(str).tolist())
     chunks = _ordered_chunks(list(chunk_set))
     chunk_to_x = {ck: i for i, ck in enumerate(chunks)}
-    cmap = plt.cm.tab20(np.linspace(0, 1, max(len(all_summaries), 1)))
+    gids = sorted(bias_df["gaia_dr3_id"].astype(str).unique())
+    cmap = plt.cm.tab20(np.linspace(0, 1, max(len(gids), 1)))
+    gid_to_j = {gid: j for j, gid in enumerate(gids)}
 
     fig, ax = plt.subplots(figsize=(max(10, len(chunks) * 0.25), 6))
-    overall_rows = []
-    for j, (gid, sdf) in enumerate(sorted(all_summaries.items())):
+    kept = bias_df[bias_df["sample_kept"].astype(bool)] if "sample_kept" in bias_df.columns else bias_df
+    excluded = bias_df[~bias_df["sample_kept"].astype(bool)] if "sample_kept" in bias_df.columns else bias_df.iloc[0:0]
+
+    for _, r in kept.iterrows():
+        gid = str(r["gaia_dr3_id"])
+        ck = str(r["chunk_key"])
+        if ck not in chunk_to_x:
+            continue
+        j = gid_to_j.get(gid, 0)
+        x = chunk_to_x[ck] + (j - len(gids) / 2) * 0.02
         label = names.get(gid, gid[:12])
-        for _, r in sdf.iterrows():
+        ax.scatter(
+            x,
+            float(r["weighted_mean_residual_kms"]),
+            s=28,
+            alpha=0.8,
+            c=[cmap[j % len(cmap)]],
+            label=label if chunk_to_x[ck] == 0 else None,
+        )
+
+    if len(excluded):
+        for _, r in excluded.iterrows():
             ck = str(r["chunk_key"])
             if ck not in chunk_to_x:
                 continue
-            x = chunk_to_x[ck] + (j - len(all_summaries) / 2) * 0.02
+            gid = str(r["gaia_dr3_id"])
+            j = gid_to_j.get(gid, 0)
+            x = chunk_to_x[ck] + (j - len(gids) / 2) * 0.02
             ax.scatter(
                 x,
                 float(r["weighted_mean_residual_kms"]),
-                s=28,
-                alpha=0.8,
-                c=[cmap[j % len(cmap)]],
-                label=label if chunk_to_x[ck] == 0 else None,
+                marker="x",
+                s=24,
+                c="0.55",
+                alpha=0.45,
+                linewidths=0.8,
             )
-        overall_rows.append(sdf)
+        ax.scatter(
+            [],
+            [],
+            marker="x",
+            c="0.55",
+            label=_clip_legend_label(sample_sigma, sample_max_delta_kms),
+        )
 
-    if overall_rows:
-        comb = pd.concat(overall_rows, ignore_index=True)
-        ox, oy, ostat, oint = [], [], [], []
-        for ck in chunks:
-            g = comb[comb["chunk_key"] == ck]
-            if g.empty:
-                continue
-            mu, stat, intrinsic = _weighted_mean_and_errors(
-                g["weighted_mean_residual_kms"].astype(float).values,
-                np.sqrt(
-                    g["statistical_err_kms"].astype(float) ** 2
-                    + g["intrinsic_scatter_kms"].astype(float) ** 2
-                ),
-            )
-            ox.append(chunk_to_x[ck])
-            oy.append(mu)
-            ostat.append(stat if np.isfinite(stat) else 0.0)
-            oint.append(intrinsic if np.isfinite(intrinsic) else 0.0)
+    ox, oy, ostat, oint = [], [], [], []
+    for ck in chunks:
+        g = kept[kept["chunk_key"].astype(str) == ck]
+        if g.empty:
+            continue
+        mu, stat, intrinsic = _weighted_mean_and_errors(
+            g["weighted_mean_residual_kms"].astype(float).values,
+            _combined_object_bias_err(
+                g["statistical_err_kms"].astype(float).values,
+                g["intrinsic_scatter_kms"].astype(float).values,
+            ),
+        )
+        ox.append(chunk_to_x[ck])
+        oy.append(mu)
+        ostat.append(stat if np.isfinite(stat) else 0.0)
+        oint.append(intrinsic if np.isfinite(intrinsic) else 0.0)
+    if ox:
         ox = np.asarray(ox, float)
         oy = np.asarray(oy, float)
         ostat = np.asarray(ostat, float)
@@ -502,7 +565,8 @@ def _plot_sample_per_object_bias(
     ax.set_xticklabels(chunks, rotation=90, fontsize=6)
     ax.set_xlabel("chunk_key")
     ax.set_ylabel("per-object weighted mean chunk bias (km/s)")
-    ax.set_title("Sample: per-object chunk bias (points) and cross-object weighted mean (diamonds)")
+    clip_note = _clip_title_note(sample_sigma, sample_max_delta_kms)
+    ax.set_title(f"Sample: per-object chunk bias and cross-object mean{clip_note}")
     ax.legend(fontsize=6, loc="upper right", ncol=2)
     fig.tight_layout()
     fig.savefig(out_path, dpi=130)
@@ -517,6 +581,8 @@ def run_plot_chunk_residuals(
     gaia_ids: set[str] | None = None,
     chunk_outlier_sigma: float | None = 10.0,
     chunk_max_delta_kms: float | None = 30.0,
+    sample_outlier_sigma: float | None = 5.0,
+    sample_max_delta_kms: float | None = 10.0,
 ) -> dict[str, int]:
     out_dir.mkdir(parents=True, exist_ok=True)
     tab = _load_chunk_rows(diagnostics_glob)
@@ -582,13 +648,6 @@ def run_plot_chunk_residuals(
         )
         n_objects += 1
 
-    _plot_sample_per_object_bias(
-        summaries,
-        names,
-        out_dir / "sample_per_object_chunk_bias.png",
-    )
-
-    # Combined per-object bias table (one row per object per chunk)
     bias_rows = []
     for gid, sdf in summaries.items():
         for _, r in sdf.iterrows():
@@ -599,14 +658,37 @@ def run_plot_chunk_residuals(
                     **r.to_dict(),
                 }
             )
-    if bias_rows:
-        pd.DataFrame(bias_rows).to_csv(out_dir / "per_object_chunk_bias.csv", index=False)
+    bias_df = pd.DataFrame(bias_rows) if bias_rows else pd.DataFrame()
+    n_sample_excluded = 0
+    sample_clip_enabled = (
+        (sample_outlier_sigma is not None and sample_outlier_sigma > 0)
+        or (sample_max_delta_kms is not None and sample_max_delta_kms > 0)
+    )
+    if not bias_df.empty and sample_clip_enabled:
+        bias_df = apply_sample_object_bias_clip(
+            bias_df,
+            nsigma=float(sample_outlier_sigma or 0.0),
+            max_delta_kms=float(sample_max_delta_kms or 0.0),
+        )
+        n_sample_excluded = int((~bias_df["sample_kept"].astype(bool)).sum())
+
+    if not bias_df.empty:
+        bias_df.to_csv(out_dir / "per_object_chunk_bias.csv", index=False)
+
+    _plot_sample_per_object_bias(
+        bias_df,
+        names,
+        out_dir / "sample_per_object_chunk_bias.png",
+        sample_sigma=sample_outlier_sigma,
+        sample_max_delta_kms=sample_max_delta_kms,
+    )
 
     return {
         "n_objects": n_objects,
         "n_rows": int(len(tab_plot)),
         "n_rows_total": int(len(tab)),
         "n_chunks_excluded": n_excluded,
+        "n_sample_bias_excluded": n_sample_excluded,
         "n_chunks_max": int(tab_plot["chunk_key"].nunique()) if len(tab_plot) else 0,
     }
 
@@ -633,6 +715,18 @@ def main() -> None:
         default=30.0,
         help="Iterative clip: exclude chunk RVs > N km/s from weighted mean per spectrum (0=off)",
     )
+    ap.add_argument(
+        "--sample-outlier-sigma",
+        type=float,
+        default=5.0,
+        help="Full-sample clip: per chunk, exclude object biases > N×RMS(other objects) (0=off)",
+    )
+    ap.add_argument(
+        "--sample-max-delta-kms",
+        type=float,
+        default=10.0,
+        help="Full-sample clip: per chunk, exclude object biases > N km/s from weighted mean (0=off)",
+    )
     ap.add_argument("--log-level", default="INFO")
     args = ap.parse_args()
     logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
@@ -647,6 +741,8 @@ def main() -> None:
 
     clip_sigma = float(args.chunk_outlier_sigma) if args.chunk_outlier_sigma > 0 else None
     clip_delta = float(args.chunk_max_delta_kms) if args.chunk_max_delta_kms > 0 else None
+    sample_sigma = float(args.sample_outlier_sigma) if args.sample_outlier_sigma > 0 else None
+    sample_delta = float(args.sample_max_delta_kms) if args.sample_max_delta_kms > 0 else None
     stats = run_plot_chunk_residuals(
         diagnostics_glob=args.diagnostics_glob,
         out_dir=args.out_dir,
@@ -654,6 +750,8 @@ def main() -> None:
         gaia_ids=gaia_ids,
         chunk_outlier_sigma=clip_sigma,
         chunk_max_delta_kms=clip_delta,
+        sample_outlier_sigma=sample_sigma,
+        sample_max_delta_kms=sample_delta,
     )
     logger.info("Wrote chunk residual plots to %s (%s)", args.out_dir, stats)
 

--- a/validation/plot_chunk_residuals.py
+++ b/validation/plot_chunk_residuals.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""
+Per-object mask-CCF chunk residual diagnostics (cool / mask-applicable stars only).
+
+For each object with stellar-mask-applicable exposures:
+
+1. ``*_residuals_by_spectrum.png`` — RV_chunk − RV_exposure for every chunk and spectrum.
+2. ``*_chunk_weighted_mean.png`` — per-chunk weighted mean residual across spectra with
+   statistical and intrinsic-scatter error bars.
+3. ``sample_per_object_chunk_bias.png`` — per-chunk points = each object's weighted mean bias;
+   overlay = sample-wide weighted mean across objects (stat + intrinsic error bars).
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  python -m validation.plot_chunk_residuals \\
+    --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' \\
+    --out-dir validation_output/chunk_residuals
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from glob import glob as glob_paths
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from darkhunter_rv.method_evaluation import exposure_method_flags, median_mask_ccf_peak_snr  # noqa: E402
+from darkhunter_rv.method_regions import region_mask_applicable  # noqa: E402
+from darkhunter_rv.summary_paths import parse_object_id_from_summary, discover_summary_files  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_gaia_id_from_path(path: str | Path) -> str | None:
+    m = re.search(r"Gaia_DR3_(\d{18,19})", str(path))
+    return m.group(1) if m else None
+
+
+def _chunk_sort_key(chunk_key: str) -> tuple[int, int]:
+    parts = str(chunk_key).split("_")
+    try:
+        order = int(parts[0])
+    except ValueError:
+        order = 9999
+    sub = int(parts[1]) if len(parts) > 1 else 0
+    return (order, sub)
+
+
+def _ordered_chunks(chunk_keys: list[str]) -> list[str]:
+    return sorted(set(chunk_keys), key=_chunk_sort_key)
+
+
+def _weighted_mean_and_errors(
+    values: np.ndarray,
+    errs: np.ndarray,
+) -> tuple[float, float, float]:
+    """Return (weighted_mean, statistical_err, intrinsic_scatter)."""
+    ok = np.isfinite(values) & np.isfinite(errs) & (errs > 0) & (errs < 1e20)
+    if not np.any(ok):
+        v = values[np.isfinite(values)]
+        if len(v) == 0:
+            return float("nan"), float("nan"), float("nan")
+        return float(np.mean(v)), float("nan"), float(np.std(v, ddof=1)) if len(v) > 1 else 0.0
+    v = values[ok].astype(float)
+    e = errs[ok].astype(float)
+    w = 1.0 / (e**2)
+    mu = float(np.sum(w * v) / np.sum(w))
+    stat = float(1.0 / np.sqrt(np.sum(w)))
+    if len(v) > 1:
+        resid = v - mu
+        var_int = max(0.0, float(np.var(resid, ddof=1)) - stat**2)
+        intrinsic = float(np.sqrt(var_int))
+    else:
+        intrinsic = 0.0
+    return mu, stat, intrinsic
+
+
+def _load_chunk_rows(diagnostics_glob: str) -> pd.DataFrame:
+    rows: list[dict] = []
+    for path in sorted(glob_paths(diagnostics_glob)):
+        gaia_id = _parse_gaia_id_from_path(path)
+        if not gaia_id:
+            continue
+        df = pd.read_csv(path)
+        if df.empty:
+            continue
+        chunk_rows = [
+            r for _, r in df.iterrows() if str(r.get("chunk_key", "")) != "all"
+        ]
+        if not chunk_rows:
+            continue
+        flags = exposure_method_flags(chunk_rows)
+        teff = float(chunk_rows[0].get("teff", np.nan))
+        snr_med = float(flags.get("median_mask_ccf_peak_snr", np.nan))
+        log_snr = float(np.log10(snr_med)) if np.isfinite(snr_med) and snr_med > 0 else np.nan
+        if not bool(region_mask_applicable(np.array([teff]), np.array([log_snr]))[0]):
+            continue
+        exposure_rv = float(chunk_rows[0].get("exposure_rv_kms", np.nan))
+        if not np.isfinite(exposure_rv):
+            exposure_rv = float(flags.get("mask_rv_kms", np.nan))
+        stem = Path(path).stem.replace("_diagnostics", "")
+        file_label = str(chunk_rows[0].get("file", stem))
+        mjd = float(chunk_rows[0].get("mjd", np.nan))
+        for r in chunk_rows:
+            if str(r.get("method", "")) != "mask_ccf":
+                continue
+            ck = str(r.get("chunk_key", ""))
+            rv = float(r.get("rv_kms", np.nan))
+            if not np.isfinite(rv) or not np.isfinite(exposure_rv):
+                continue
+            resid = float(r.get("residual_to_exposure_kms", np.nan))
+            if not np.isfinite(resid):
+                resid = rv - exposure_rv
+            rows.append(
+                {
+                    "gaia_dr3_id": gaia_id,
+                    "file": file_label,
+                    "mjd": mjd,
+                    "teff": teff,
+                    "log10_median_mask_ccf_peak_snr": log_snr,
+                    "chunk_key": ck,
+                    "chunk_order": _chunk_sort_key(ck)[0],
+                    "rv_kms": rv,
+                    "rv_err_kms": float(r.get("rv_err_kms", np.nan)),
+                    "exposure_rv_kms": exposure_rv,
+                    "residual_kms": resid,
+                    "used_in_exposure_stack": bool(r.get("used_in_exposure_stack", False)),
+                    "qc_pass": bool(r.get("qc_pass", True)),
+                    "diagnostics_path": str(path),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _load_name_lookup(repo_root: Path) -> dict[str, str]:
+    names: dict[str, str] = {}
+    lit = repo_root / "calibration" / "literature_rv_master.csv"
+    if lit.is_file():
+        df = pd.read_csv(lit)
+        for _, r in df.iterrows():
+            gid = str(r.get("gaia_dr3_id", ""))
+            nm = str(r.get("name", "")).strip()
+            if gid and nm and gid not in names:
+                names[gid] = nm
+    overlap = repo_root / "validation_output" / "rv_phase_a_baseline" / "overlap_stars.csv"
+    if overlap.is_file():
+        df = pd.read_csv(overlap)
+        for _, r in df.iterrows():
+            gid = str(r.get("gaia_dr3_id", ""))
+            nm = str(r.get("name", "")).strip()
+            if gid and nm:
+                names[gid] = nm
+    return names
+
+
+def _object_name(gaia_id: str, summary_dir: Path | None, name_lookup: dict[str, str]) -> str:
+    if gaia_id in name_lookup:
+        return name_lookup[gaia_id]
+    if summary_dir is not None:
+        for sp in discover_summary_files(summary_dir):
+            if parse_object_id_from_summary(sp) == gaia_id:
+                stem = sp.stem.replace("_summary", "")
+                if stem.startswith("Gaia_DR3_"):
+                    tag = stem.replace(f"Gaia_DR3_{gaia_id}", "").strip("_")
+                    if tag:
+                        return tag
+                return stem
+    return gaia_id
+
+
+def _plot_residuals_by_spectrum(
+    obj_df: pd.DataFrame,
+    *,
+    gaia_id: str,
+    name: str,
+    out_path: Path,
+) -> None:
+    chunks = _ordered_chunks(obj_df["chunk_key"].astype(str).tolist())
+    chunk_to_x = {ck: i for i, ck in enumerate(chunks)}
+    spectra = obj_df.groupby("file", sort=False)
+    n_spec = spectra.ngroups
+    cmap = plt.cm.viridis(np.linspace(0.15, 0.85, max(n_spec, 1)))
+
+    fig, ax = plt.subplots(figsize=(max(8, len(chunks) * 0.22), 5))
+    for i, (file_label, g) in enumerate(spectra):
+        xs = [chunk_to_x[str(ck)] for ck in g["chunk_key"]]
+        ys = g["residual_kms"].astype(float).values
+        stacked = g["used_in_exposure_stack"].astype(bool).values
+        ax.scatter(
+            xs,
+            ys,
+            s=22 if np.all(stacked) else 14,
+            alpha=0.75 if np.all(stacked) else 0.35,
+            c=[cmap[i]],
+            edgecolors="none",
+            label=Path(str(file_label)).stem[-24:],
+        )
+    ax.axhline(0.0, color="gray", ls=":", lw=0.8)
+    ax.set_xticks(range(len(chunks)))
+    ax.set_xticklabels(chunks, rotation=90, fontsize=6)
+    ax.set_xlabel("chunk_key")
+    ax.set_ylabel("RV_chunk − RV_exposure (km/s)")
+    ax.set_title(f"{name} — chunk residuals by spectrum (mask-applicable)")
+    if n_spec <= 12:
+        ax.legend(fontsize=6, loc="upper right", ncol=2)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def _summarize_chunks_per_object(obj_df: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    for ck, g in obj_df.groupby("chunk_key"):
+        mu, stat, intrinsic = _weighted_mean_and_errors(
+            g["residual_kms"].astype(float).values,
+            g["rv_err_kms"].astype(float).values,
+        )
+        rows.append(
+            {
+                "chunk_key": str(ck),
+                "chunk_order": _chunk_sort_key(str(ck))[0],
+                "n_spectra": int(g["file"].nunique()),
+                "weighted_mean_residual_kms": mu,
+                "statistical_err_kms": stat,
+                "intrinsic_scatter_kms": intrinsic,
+            }
+        )
+    out = pd.DataFrame(rows)
+    if out.empty:
+        return out
+    return out.sort_values(["chunk_order", "chunk_key"]).reset_index(drop=True)
+
+
+def _plot_chunk_weighted_mean(
+    summary: pd.DataFrame,
+    *,
+    gaia_id: str,
+    name: str,
+    out_path: Path,
+    title_suffix: str,
+) -> None:
+    if summary.empty:
+        return
+    chunks = summary["chunk_key"].astype(str).tolist()
+    x = np.arange(len(chunks))
+    mu = summary["weighted_mean_residual_kms"].astype(float).values
+    stat = summary["statistical_err_kms"].astype(float).values
+    intrinsic = summary["intrinsic_scatter_kms"].astype(float).values
+    stat = np.where(np.isfinite(stat), stat, 0.0)
+    intrinsic = np.where(np.isfinite(intrinsic), intrinsic, 0.0)
+
+    fig, ax = plt.subplots(figsize=(max(8, len(chunks) * 0.22), 5))
+    ax.axhline(0.0, color="gray", ls=":", lw=0.8)
+    ax.errorbar(
+        x,
+        mu,
+        yerr=stat,
+        fmt="o",
+        color="#2166ac",
+        ecolor="#2166ac",
+        capsize=2,
+        label="statistical σ",
+        zorder=3,
+    )
+    ax.errorbar(
+        x,
+        mu,
+        yerr=intrinsic,
+        fmt="none",
+        ecolor="#b2182b",
+        capsize=4,
+        elinewidth=1.5,
+        label="intrinsic scatter σ",
+        zorder=2,
+    )
+    ax.set_xticks(x)
+    ax.set_xticklabels(chunks, rotation=90, fontsize=6)
+    ax.set_xlabel("chunk_key")
+    ax.set_ylabel("weighted mean residual (km/s)")
+    ax.set_title(f"{name} — {title_suffix}")
+    ax.legend(fontsize=8)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def _plot_sample_per_object_bias(
+    all_summaries: dict[str, pd.DataFrame],
+    names: dict[str, str],
+    out_path: Path,
+) -> None:
+    if not all_summaries:
+        return
+    chunk_set: set[str] = set()
+    for sdf in all_summaries.values():
+        chunk_set.update(sdf["chunk_key"].astype(str).tolist())
+    chunks = _ordered_chunks(list(chunk_set))
+    chunk_to_x = {ck: i for i, ck in enumerate(chunks)}
+    cmap = plt.cm.tab20(np.linspace(0, 1, max(len(all_summaries), 1)))
+
+    fig, ax = plt.subplots(figsize=(max(10, len(chunks) * 0.25), 6))
+    overall_rows = []
+    for j, (gid, sdf) in enumerate(sorted(all_summaries.items())):
+        label = names.get(gid, gid[:12])
+        for _, r in sdf.iterrows():
+            ck = str(r["chunk_key"])
+            if ck not in chunk_to_x:
+                continue
+            x = chunk_to_x[ck] + (j - len(all_summaries) / 2) * 0.02
+            ax.scatter(
+                x,
+                float(r["weighted_mean_residual_kms"]),
+                s=28,
+                alpha=0.8,
+                c=[cmap[j % len(cmap)]],
+                label=label if chunk_to_x[ck] == 0 else None,
+            )
+        overall_rows.append(sdf)
+
+    if overall_rows:
+        comb = pd.concat(overall_rows, ignore_index=True)
+        ox, oy, ostat, oint = [], [], [], []
+        for ck in chunks:
+            g = comb[comb["chunk_key"] == ck]
+            if g.empty:
+                continue
+            mu, stat, intrinsic = _weighted_mean_and_errors(
+                g["weighted_mean_residual_kms"].astype(float).values,
+                np.sqrt(
+                    g["statistical_err_kms"].astype(float) ** 2
+                    + g["intrinsic_scatter_kms"].astype(float) ** 2
+                ),
+            )
+            ox.append(chunk_to_x[ck])
+            oy.append(mu)
+            ostat.append(stat if np.isfinite(stat) else 0.0)
+            oint.append(intrinsic if np.isfinite(intrinsic) else 0.0)
+        ox = np.asarray(ox, float)
+        oy = np.asarray(oy, float)
+        ostat = np.asarray(ostat, float)
+        oint = np.asarray(oint, float)
+        ax.errorbar(ox, oy, yerr=ostat, fmt="D", color="black", ms=6, capsize=2, label="sample mean (stat)", zorder=5)
+        ax.errorbar(ox, oy, yerr=oint, fmt="none", ecolor="black", capsize=5, elinewidth=2, label="sample mean (intrinsic)", zorder=4)
+
+    ax.axhline(0.0, color="gray", ls=":", lw=0.8)
+    ax.set_xticks(range(len(chunks)))
+    ax.set_xticklabels(chunks, rotation=90, fontsize=6)
+    ax.set_xlabel("chunk_key")
+    ax.set_ylabel("per-object weighted mean chunk bias (km/s)")
+    ax.set_title("Sample: per-object chunk bias (points) and cross-object weighted mean (diamonds)")
+    ax.legend(fontsize=6, loc="upper right", ncol=2)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def run_plot_chunk_residuals(
+    *,
+    diagnostics_glob: str,
+    out_dir: Path,
+    summary_dir: Path | None = None,
+    gaia_ids: set[str] | None = None,
+) -> dict[str, int]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    tab = _load_chunk_rows(diagnostics_glob)
+    if tab.empty:
+        logger.warning("No mask-applicable chunk rows matched %s", diagnostics_glob)
+        return {"n_objects": 0, "n_rows": 0}
+
+    if gaia_ids:
+        tab = tab[tab["gaia_dr3_id"].astype(str).isin(gaia_ids)]
+
+    name_lookup = _load_name_lookup(_REPO_ROOT)
+    names: dict[str, str] = {}
+    summaries: dict[str, pd.DataFrame] = {}
+    n_objects = 0
+
+    for gid, obj_df in tab.groupby("gaia_dr3_id"):
+        gid = str(gid)
+        name = _object_name(gid, summary_dir, name_lookup)
+        names[gid] = name
+        obj_dir = out_dir / gid
+        obj_dir.mkdir(parents=True, exist_ok=True)
+        obj_df.to_csv(obj_dir / "chunk_residuals_long.csv", index=False)
+
+        _plot_residuals_by_spectrum(
+            obj_df,
+            gaia_id=gid,
+            name=name,
+            out_path=obj_dir / f"{name or gid}_residuals_by_spectrum.png",
+        )
+
+        summary = _summarize_chunks_per_object(obj_df)
+        summary.to_csv(obj_dir / "chunk_weighted_summary.csv", index=False)
+        summaries[gid] = summary
+
+        _plot_chunk_weighted_mean(
+            summary,
+            gaia_id=gid,
+            name=name,
+            out_path=obj_dir / f"{name or gid}_chunk_weighted_mean.png",
+            title_suffix="per-chunk weighted mean across spectra",
+        )
+        n_objects += 1
+
+    _plot_sample_per_object_bias(
+        summaries,
+        names,
+        out_dir / "sample_per_object_chunk_bias.png",
+    )
+
+    # Combined per-object bias table (one row per object per chunk)
+    bias_rows = []
+    for gid, sdf in summaries.items():
+        for _, r in sdf.iterrows():
+            bias_rows.append(
+                {
+                    "gaia_dr3_id": gid,
+                    "name": names.get(gid, gid),
+                    **r.to_dict(),
+                }
+            )
+    if bias_rows:
+        pd.DataFrame(bias_rows).to_csv(out_dir / "per_object_chunk_bias.csv", index=False)
+
+    return {"n_objects": n_objects, "n_rows": int(len(tab)), "n_chunks_max": int(tab["chunk_key"].nunique())}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--diagnostics-glob", default="output/Gaia_DR3_*_diagnostics.csv")
+    ap.add_argument("--summary-dir", type=Path, default=_REPO_ROOT / "output")
+    ap.add_argument("--out-dir", type=Path, default=_REPO_ROOT / "validation_output" / "chunk_residuals")
+    ap.add_argument(
+        "--overlap-only",
+        action="store_true",
+        help="Restrict to stars in calibration/literature overlap (phase A overlap_stars.csv if present)",
+    )
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    gaia_ids: set[str] | None = None
+    if args.overlap_only:
+        overlap_csv = _REPO_ROOT / "validation_output" / "rv_phase_a_baseline" / "overlap_stars.csv"
+        if overlap_csv.is_file():
+            gaia_ids = set(pd.read_csv(overlap_csv)["gaia_dr3_id"].astype(str))
+        else:
+            logger.warning("overlap_stars.csv not found; using all mask-applicable objects")
+
+    stats = run_plot_chunk_residuals(
+        diagnostics_glob=args.diagnostics_glob,
+        out_dir=args.out_dir,
+        summary_dir=args.summary_dir,
+        gaia_ids=gaia_ids,
+    )
+    logger.info("Wrote chunk residual plots to %s (%s)", args.out_dir, stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/plot_chunk_residuals.py
+++ b/validation/plot_chunk_residuals.py
@@ -63,6 +63,81 @@ def _ordered_chunks(chunk_keys: list[str]) -> list[str]:
     return sorted(set(chunk_keys), key=_chunk_sort_key)
 
 
+def _exposure_rv_weighted(rv: np.ndarray, err: np.ndarray) -> float:
+    ok = np.isfinite(rv) & np.isfinite(err) & (err > 0) & (err < 1e20)
+    if not np.any(ok):
+        v = rv[np.isfinite(rv)]
+        return float(np.mean(v)) if len(v) else float("nan")
+    v = rv[ok].astype(float)
+    e = err[ok].astype(float)
+    w = 1.0 / (e**2)
+    return float(np.sum(w * v) / np.sum(w))
+
+
+def iterative_loo_sigma_clip_mask(
+    rv: np.ndarray,
+    *,
+    nsigma: float = 10.0,
+    max_iter: int = 100,
+) -> np.ndarray:
+    """
+    Per-spectrum iterative leave-one-out clip: drop chunk *i* when
+    |RV_i − mean(RV_{j≠i})| > nsigma × RMS(RV_{j≠i}) until convergence.
+    """
+    rv = np.asarray(rv, float)
+    n = len(rv)
+    keep = np.ones(n, dtype=bool)
+    if n < 2:
+        return keep
+    for _ in range(max_iter):
+        removed_any = False
+        active = np.where(keep)[0]
+        if len(active) < 2:
+            break
+        for i in active:
+            others = rv[keep & (np.arange(n) != i)]
+            if len(others) < 1:
+                continue
+            mu = float(np.mean(others))
+            rms = float(np.std(others, ddof=1)) if len(others) > 1 else 0.0
+            if not np.isfinite(rms) or rms <= 0:
+                continue
+            if abs(float(rv[i]) - mu) > nsigma * rms:
+                keep[i] = False
+                removed_any = True
+        if not removed_any:
+            break
+    return keep
+
+
+def apply_spectrum_chunk_outlier_clip(
+    tab: pd.DataFrame,
+    *,
+    nsigma: float = 10.0,
+) -> pd.DataFrame:
+    """Mark chunk_kept per spectrum; recompute exposure_rv_kms and residual_kms from kept chunks."""
+    if tab.empty:
+        return tab
+    out = tab.copy()
+    out["chunk_kept"] = True
+    out["exposure_rv_kms_pipeline"] = out["exposure_rv_kms"]
+    out["residual_kms_pipeline"] = out["residual_kms"]
+
+    for file_label, g in out.groupby("file", sort=False):
+        idx = g.index.to_numpy()
+        rv = g["rv_kms"].astype(float).to_numpy()
+        err = g["rv_err_kms"].astype(float).to_numpy()
+        keep = iterative_loo_sigma_clip_mask(rv, nsigma=nsigma)
+        out.loc[idx, "chunk_kept"] = keep
+        if not np.any(keep):
+            continue
+        exp_rv = _exposure_rv_weighted(rv[keep], err[keep])
+        out.loc[idx[keep], "exposure_rv_kms"] = exp_rv
+        out.loc[idx[keep], "residual_kms"] = rv[keep] - exp_rv
+
+    return out
+
+
 def _weighted_mean_and_errors(
     values: np.ndarray,
     errs: np.ndarray,
@@ -187,10 +262,21 @@ def _plot_residuals_by_spectrum(
     gaia_id: str,
     name: str,
     out_path: Path,
+    clip_sigma: float | None,
 ) -> None:
-    chunks = _ordered_chunks(obj_df["chunk_key"].astype(str).tolist())
+    kept_df = obj_df[obj_df["chunk_kept"].astype(bool)] if "chunk_kept" in obj_df.columns else obj_df
+    excluded_df = (
+        obj_df[~obj_df["chunk_kept"].astype(bool)]
+        if "chunk_kept" in obj_df.columns
+        else obj_df.iloc[0:0]
+    )
+    chunks = _ordered_chunks(kept_df["chunk_key"].astype(str).tolist())
+    if excluded_df is not None and len(excluded_df):
+        chunks = _ordered_chunks(
+            chunks + excluded_df["chunk_key"].astype(str).tolist()
+        )
     chunk_to_x = {ck: i for i, ck in enumerate(chunks)}
-    spectra = obj_df.groupby("file", sort=False)
+    spectra = kept_df.groupby("file", sort=False)
     n_spec = spectra.ngroups
     cmap = plt.cm.viridis(np.linspace(0.15, 0.85, max(n_spec, 1)))
 
@@ -198,22 +284,34 @@ def _plot_residuals_by_spectrum(
     for i, (file_label, g) in enumerate(spectra):
         xs = [chunk_to_x[str(ck)] for ck in g["chunk_key"]]
         ys = g["residual_kms"].astype(float).values
-        stacked = g["used_in_exposure_stack"].astype(bool).values
         ax.scatter(
             xs,
             ys,
-            s=22 if np.all(stacked) else 14,
-            alpha=0.75 if np.all(stacked) else 0.35,
+            s=22,
+            alpha=0.8,
             c=[cmap[i]],
             edgecolors="none",
             label=Path(str(file_label)).stem[-24:],
+        )
+    if len(excluded_df):
+        ex_x = [chunk_to_x[str(ck)] for ck in excluded_df["chunk_key"]]
+        ax.scatter(
+            ex_x,
+            excluded_df["residual_kms_pipeline"].astype(float).values,
+            marker="x",
+            s=28,
+            c="0.55",
+            alpha=0.45,
+            linewidths=0.8,
+            label="excluded (>{}σ LOO)".format(clip_sigma) if clip_sigma else "excluded",
         )
     ax.axhline(0.0, color="gray", ls=":", lw=0.8)
     ax.set_xticks(range(len(chunks)))
     ax.set_xticklabels(chunks, rotation=90, fontsize=6)
     ax.set_xlabel("chunk_key")
     ax.set_ylabel("RV_chunk − RV_exposure (km/s)")
-    ax.set_title(f"{name} — chunk residuals by spectrum (mask-applicable)")
+    clip_note = f", {clip_sigma:g}σ LOO clip" if clip_sigma else ""
+    ax.set_title(f"{name} — chunk residuals by spectrum (mask-applicable{clip_note})")
     if n_spec <= 12:
         ax.legend(fontsize=6, loc="upper right", ncol=2)
     fig.tight_layout()
@@ -373,6 +471,7 @@ def run_plot_chunk_residuals(
     out_dir: Path,
     summary_dir: Path | None = None,
     gaia_ids: set[str] | None = None,
+    chunk_outlier_sigma: float | None = 10.0,
 ) -> dict[str, int]:
     out_dir.mkdir(parents=True, exist_ok=True)
     tab = _load_chunk_rows(diagnostics_glob)
@@ -383,24 +482,34 @@ def run_plot_chunk_residuals(
     if gaia_ids:
         tab = tab[tab["gaia_dr3_id"].astype(str).isin(gaia_ids)]
 
+    n_excluded = 0
+    if chunk_outlier_sigma is not None and chunk_outlier_sigma > 0:
+        tab = apply_spectrum_chunk_outlier_clip(tab, nsigma=chunk_outlier_sigma)
+        n_excluded = int((~tab["chunk_kept"].astype(bool)).sum())
+        tab_plot = tab[tab["chunk_kept"].astype(bool)].copy()
+    else:
+        tab_plot = tab
+
     name_lookup = _load_name_lookup(_REPO_ROOT)
     names: dict[str, str] = {}
     summaries: dict[str, pd.DataFrame] = {}
     n_objects = 0
 
-    for gid, obj_df in tab.groupby("gaia_dr3_id"):
+    for gid, obj_all in tab.groupby("gaia_dr3_id"):
         gid = str(gid)
         name = _object_name(gid, summary_dir, name_lookup)
         names[gid] = name
         obj_dir = out_dir / gid
         obj_dir.mkdir(parents=True, exist_ok=True)
-        obj_df.to_csv(obj_dir / "chunk_residuals_long.csv", index=False)
+        obj_all.to_csv(obj_dir / "chunk_residuals_long.csv", index=False)
+        obj_df = obj_all[obj_all["chunk_kept"].astype(bool)].copy() if "chunk_kept" in obj_all.columns else obj_all
 
         _plot_residuals_by_spectrum(
-            obj_df,
+            obj_all,
             gaia_id=gid,
             name=name,
             out_path=obj_dir / f"{name or gid}_residuals_by_spectrum.png",
+            clip_sigma=chunk_outlier_sigma,
         )
 
         summary = _summarize_chunks_per_object(obj_df)
@@ -412,7 +521,10 @@ def run_plot_chunk_residuals(
             gaia_id=gid,
             name=name,
             out_path=obj_dir / f"{name or gid}_chunk_weighted_mean.png",
-            title_suffix="per-chunk weighted mean across spectra",
+            title_suffix=(
+                "per-chunk weighted mean across spectra"
+                + (f" ({chunk_outlier_sigma:g}σ LOO clip)" if chunk_outlier_sigma else "")
+            ),
         )
         n_objects += 1
 
@@ -436,7 +548,13 @@ def run_plot_chunk_residuals(
     if bias_rows:
         pd.DataFrame(bias_rows).to_csv(out_dir / "per_object_chunk_bias.csv", index=False)
 
-    return {"n_objects": n_objects, "n_rows": int(len(tab)), "n_chunks_max": int(tab["chunk_key"].nunique())}
+    return {
+        "n_objects": n_objects,
+        "n_rows": int(len(tab_plot)),
+        "n_rows_total": int(len(tab)),
+        "n_chunks_excluded": n_excluded,
+        "n_chunks_max": int(tab_plot["chunk_key"].nunique()) if len(tab_plot) else 0,
+    }
 
 
 def main() -> None:
@@ -448,6 +566,12 @@ def main() -> None:
         "--overlap-only",
         action="store_true",
         help="Restrict to stars in calibration/literature overlap (phase A overlap_stars.csv if present)",
+    )
+    ap.add_argument(
+        "--chunk-outlier-sigma",
+        type=float,
+        default=10.0,
+        help="Iterative leave-one-out clip: exclude chunk RVs > N×RMS(other chunks) per spectrum (0=off)",
     )
     ap.add_argument("--log-level", default="INFO")
     args = ap.parse_args()
@@ -461,11 +585,13 @@ def main() -> None:
         else:
             logger.warning("overlap_stars.csv not found; using all mask-applicable objects")
 
+    clip_sigma = float(args.chunk_outlier_sigma) if args.chunk_outlier_sigma > 0 else None
     stats = run_plot_chunk_residuals(
         diagnostics_glob=args.diagnostics_glob,
         out_dir=args.out_dir,
         summary_dir=args.summary_dir,
         gaia_ids=gaia_ids,
+        chunk_outlier_sigma=clip_sigma,
     )
     logger.info("Wrote chunk residual plots to %s (%s)", args.out_dir, stats)
 

--- a/validation/reassess_relative_calibration.py
+++ b/validation/reassess_relative_calibration.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""
+Re-assess APF–APF relative calibration after chunk bias debias and stat+intrinsic weighting.
+
+Uses per-object chunk biases from ``validation_output/chunk_residuals/per_object_chunk_bias.csv``
+(produced by ``validation.plot_chunk_residuals``).
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  python -m validation.reassess_relative_calibration \\
+    --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' \\
+    --bias-csv validation_output/chunk_residuals/per_object_chunk_bias.csv \\
+    --out-dir validation_output/chunk_calibration_assessment
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from validation.chunk_calibration import (  # noqa: E402
+    build_calibrated_exposure_table,
+    relative_pair_table,
+    summarize_relative_gate,
+)
+from validation.plot_chunk_residuals import (  # noqa: E402
+    DEFAULT_CHUNK_MAX_DELTA_KMS,
+    DEFAULT_CHUNK_OUTLIER_SIGMA,
+    DEFAULT_MIN_CHUNK_MEASUREMENTS,
+    _load_name_lookup,
+    _object_name,
+)
+from validation.rv_overlap_lib import PhaseAGoals, per_star_gate_table  # noqa: E402
+
+logger = logging.getLogger(__name__)
+PRECISION_GOAL_KMS = 0.1
+
+
+def _plot_relative_histogram(
+    pairs_before: pd.DataFrame,
+    pairs_after: pd.DataFrame,
+    out_path: Path,
+    *,
+    goal_kms: float,
+) -> None:
+    fig, ax = plt.subplots(figsize=(7, 4))
+    if len(pairs_before):
+        ax.hist(
+            pairs_before["abs_delta_rv_kms"].astype(float),
+            bins=min(30, max(10, len(pairs_before))),
+            alpha=0.55,
+            label="pipeline",
+            color="#4c72b0",
+        )
+    if len(pairs_after):
+        ax.hist(
+            pairs_after["abs_delta_rv_kms"].astype(float),
+            bins=min(30, max(10, len(pairs_after))),
+            alpha=0.55,
+            label="chunk-calibrated",
+            color="#c44e52",
+        )
+    ax.axvline(goal_kms, color="gray", ls="--", label=f"goal {goal_kms} km/s")
+    ax.set_xlabel("|ΔRV| APF–APF (km/s)")
+    ax.set_ylabel("Count")
+    ax.set_title("Relative gate: pipeline vs chunk-calibrated")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def _plot_chunk_scatter_compare(epochs: pd.DataFrame, out_path: Path) -> None:
+    ok = np.isfinite(epochs["chunk_scatter_calibrated_kms"].astype(float))
+    if not ok.any():
+        return
+    fig, ax = plt.subplots(figsize=(5, 5))
+    ax.scatter(
+        epochs.loc[ok, "rv_pipeline_kms"],
+        epochs.loc[ok, "rv_calibrated_kms"],
+        s=20,
+        alpha=0.7,
+    )
+    lims = [
+        np.nanmin([epochs["rv_pipeline_kms"].min(), epochs["rv_calibrated_kms"].min()]),
+        np.nanmax([epochs["rv_pipeline_kms"].max(), epochs["rv_calibrated_kms"].max()]),
+    ]
+    pad = 5.0
+    ax.plot([lims[0] - pad, lims[1] + pad], [lims[0] - pad, lims[1] + pad], "k--", lw=1)
+    ax.set_xlabel("pipeline exposure RV (km/s)")
+    ax.set_ylabel("chunk-calibrated RV (km/s)")
+    ax.set_title("Exposure RV: pipeline vs calibrated")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def _write_report(
+    path: Path,
+    *,
+    summary_before: dict,
+    summary_after: dict,
+    epochs: pd.DataFrame,
+    goals: PhaseAGoals,
+) -> None:
+    sc = epochs["chunk_scatter_calibrated_kms"].astype(float)
+    sc_ok = sc[np.isfinite(sc)]
+    lines = [
+        "# Chunk calibration relative-gate reassessment",
+        "",
+        "## Method",
+        "- Per-spectrum outlier clip (7σ LOO, ±20 km/s) as in chunk residual study",
+        "- Per chunk: subtract object bias (`weighted_mean_residual_kms`); fallback to sample mean",
+        "- Weight ∝ 1 / (σ_stat² + σ_intrinsic²) from bias table",
+        f"- Minimum {DEFAULT_MIN_CHUNK_MEASUREMENTS} chunks with valid bias per exposure",
+        "",
+        f"## Relative gate (APF–APF, ≤{goals.pair_window_days} d)",
+        "",
+        "### Pipeline (pre-chunk-calibration)",
+        f"- Pairs: {summary_before.get('n_pairs', 0)}",
+        f"- Median |ΔRV|: {summary_before.get('median_abs_delta_rv_kms', float('nan')):.3f} km/s",
+        f"- p90 |ΔRV|: {summary_before.get('p90_abs_delta_rv_kms', float('nan')):.3f} km/s",
+        f"- RMS ΔRV: {summary_before.get('rms_delta_rv_kms', float('nan')):.3f} km/s",
+        f"- Fraction < {goals.relative_goal_kms} km/s: {100*summary_before.get('frac_below_goal', 0):.1f}%",
+        "",
+        "### Chunk-calibrated",
+        f"- Pairs: {summary_after.get('n_pairs', 0)}",
+        f"- Median |ΔRV|: {summary_after.get('median_abs_delta_rv_kms', float('nan')):.3f} km/s",
+        f"- p90 |ΔRV|: {summary_after.get('p90_abs_delta_rv_kms', float('nan')):.3f} km/s",
+        f"- RMS ΔRV: {summary_after.get('rms_delta_rv_kms', float('nan')):.3f} km/s",
+        f"- Fraction < {goals.relative_goal_kms} km/s: {100*summary_after.get('frac_below_goal', 0):.1f}%",
+        "",
+        "## Per-exposure chunk scatter (calibrated stack)",
+    ]
+    if len(sc_ok):
+        lines.extend(
+            [
+                f"- Median: {float(np.median(sc_ok)):.3f} km/s",
+                f"- p90: {float(np.percentile(sc_ok, 90)):.3f} km/s",
+                f"- Fraction < {PRECISION_GOAL_KMS} km/s: {100*float(np.mean(sc_ok < PRECISION_GOAL_KMS)):.1f}%",
+            ]
+        )
+    lines.append("")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_assessment(
+    *,
+    diagnostics_glob: str,
+    bias_csv: Path,
+    out_dir: Path,
+    summary_dir: Path,
+    pair_window_days: float,
+    goal_kms: float,
+    clip_sigma: float,
+    clip_max_delta_kms: float,
+    min_chunks: int,
+) -> dict:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    epochs = build_calibrated_exposure_table(
+        diagnostics_glob,
+        bias_csv,
+        clip_sigma=clip_sigma,
+        clip_max_delta_kms=clip_max_delta_kms,
+        min_chunks=min_chunks,
+    )
+    if epochs.empty:
+        return {"n_epochs": 0}
+
+    name_lookup = _load_name_lookup(REPO_ROOT)
+    epochs["name"] = [
+        _object_name(str(g), summary_dir, name_lookup) for g in epochs["gaia_dr3_id"].astype(str)
+    ]
+    epochs.to_csv(out_dir / "calibrated_exposure_epochs.csv", index=False)
+
+    pairs_before = relative_pair_table(
+        epochs,
+        rv_col="rv_pipeline_kms",
+        err_col=None,
+        pair_window_days=pair_window_days,
+    )
+    pairs_after = relative_pair_table(
+        epochs,
+        rv_col="rv_calibrated_kms",
+        err_col="rv_err_calibrated_kms",
+        pair_window_days=pair_window_days,
+    )
+    pairs_before.to_csv(out_dir / "relative_pairs_pipeline.csv", index=False)
+    pairs_after.to_csv(out_dir / "relative_pairs_calibrated.csv", index=False)
+
+    summary_before = summarize_relative_gate(pairs_before, goal_kms=goal_kms)
+    summary_after = summarize_relative_gate(pairs_after, goal_kms=goal_kms)
+    pd.DataFrame([{"stage": "pipeline", **summary_before}, {"stage": "chunk_calibrated", **summary_after}]).to_csv(
+        out_dir / "relative_gate_summary.csv", index=False
+    )
+
+    per_star = per_star_gate_table(pairs_after, absolute_threshold_kms=1e9)
+    if len(per_star):
+        per_star.to_csv(out_dir / "per_star_relative_calibrated.csv", index=False)
+
+    (out_dir / "plots").mkdir(parents=True, exist_ok=True)
+    _plot_relative_histogram(
+        pairs_before, pairs_after, out_dir / "plots" / "relative_delta_rv_histogram.png", goal_kms=goal_kms
+    )
+    _plot_chunk_scatter_compare(epochs, out_dir / "plots" / "exposure_rv_pipeline_vs_calibrated.png")
+
+    goals = PhaseAGoals(pair_window_days=pair_window_days, relative_goal_kms=goal_kms)
+    _write_report(
+        out_dir / "REPORT.md",
+        summary_before=summary_before,
+        summary_after=summary_after,
+        epochs=epochs,
+        goals=goals,
+    )
+    manifest = {
+        "n_epochs": int(len(epochs)),
+        "n_epochs_calibrated": int(epochs["rv_calibrated_kms"].notna().sum()),
+        "relative_gate_pipeline": summary_before,
+        "relative_gate_calibrated": summary_after,
+        "clip_sigma": clip_sigma,
+        "clip_max_delta_kms": clip_max_delta_kms,
+        "min_chunks": min_chunks,
+    }
+    (out_dir / "assessment_manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--diagnostics-glob", default="output/Gaia_DR3_*_diagnostics.csv")
+    ap.add_argument(
+        "--bias-csv",
+        type=Path,
+        default=REPO_ROOT / "validation_output" / "chunk_residuals" / "per_object_chunk_bias.csv",
+    )
+    ap.add_argument("--summary-dir", type=Path, default=REPO_ROOT / "output")
+    ap.add_argument(
+        "--out-dir",
+        type=Path,
+        default=REPO_ROOT / "validation_output" / "chunk_calibration_assessment",
+    )
+    ap.add_argument("--pair-window-days", type=float, default=7.0)
+    ap.add_argument("--relative-goal-kms", type=float, default=PRECISION_GOAL_KMS)
+    ap.add_argument("--chunk-outlier-sigma", type=float, default=DEFAULT_CHUNK_OUTLIER_SIGMA)
+    ap.add_argument("--chunk-max-delta-kms", type=float, default=DEFAULT_CHUNK_MAX_DELTA_KMS)
+    ap.add_argument("--min-chunks", type=int, default=DEFAULT_MIN_CHUNK_MEASUREMENTS)
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    if not args.bias_csv.is_file():
+        logger.error("Bias CSV not found: %s (run plot_chunk_residuals first)", args.bias_csv)
+        sys.exit(1)
+
+    manifest = run_assessment(
+        diagnostics_glob=args.diagnostics_glob,
+        bias_csv=args.bias_csv,
+        out_dir=args.out_dir,
+        summary_dir=args.summary_dir,
+        pair_window_days=args.pair_window_days,
+        goal_kms=args.relative_goal_kms,
+        clip_sigma=args.chunk_outlier_sigma,
+        clip_max_delta_kms=args.chunk_max_delta_kms,
+        min_chunks=args.min_chunks,
+    )
+    logger.info("Assessment written to %s", args.out_dir)
+    logger.info(
+        "pipeline median|ΔRV|=%.3f km/s → calibrated %.3f km/s",
+        manifest.get("relative_gate_pipeline", {}).get("median_abs_delta_rv_kms", float("nan")),
+        manifest.get("relative_gate_calibrated", {}).get("median_abs_delta_rv_kms", float("nan")),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/rv_overlap_lib.py
+++ b/validation/rv_overlap_lib.py
@@ -1,0 +1,468 @@
+"""Shared utilities for literature/APF overlap inventory and calibration gates (Phase A)."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from glob import glob as glob_paths
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+import pandas as pd
+
+from darkhunter_rv.summary_paths import discover_summary_files, parse_object_id_from_summary
+from validation.diagnose_legacy_campaign import parse_summary_file
+
+BJD_TO_MJD_OFFSET = 2400000.5
+PAIR_TYPES = ("apf_literature", "apf_apf", "literature_literature")
+ABSOLUTE_GATE_KMS = 1.0
+RELATIVE_GOAL_KMS = 0.1
+
+
+@dataclass
+class PhaseAGoals:
+    pair_window_days: float = 7.0
+    absolute_gate_kms: float = ABSOLUTE_GATE_KMS
+    relative_goal_kms: float = RELATIVE_GOAL_KMS
+
+    @classmethod
+    def from_yaml_path(cls, path: Path) -> PhaseAGoals:
+        if not path.is_file():
+            return cls()
+        try:
+            import yaml
+        except ImportError:
+            return cls()
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        return cls(
+            pair_window_days=float(data.get("pair_window_days", 7.0)),
+            absolute_gate_kms=float(data.get("absolute_gate_kms", ABSOLUTE_GATE_KMS)),
+            relative_goal_kms=float(data.get("relative_goal_kms", RELATIVE_GOAL_KMS)),
+        )
+
+
+def bjd_to_mjd(bjd: float) -> float:
+    return float(bjd) - BJD_TO_MJD_OFFSET
+
+
+def mjd_to_bjd(mjd: float) -> float:
+    return float(mjd) + BJD_TO_MJD_OFFSET
+
+
+def _parse_gaia_from_basename(basename: str) -> str | None:
+    m = re.search(r"Gaia_DR3_(\d{18,19})", basename)
+    return m.group(1) if m else None
+
+
+def load_literature_epochs(master_path: Path) -> pd.DataFrame:
+    df = pd.read_csv(master_path)
+    df["gaia_dr3_id"] = df["gaia_dr3_id"].astype(str)
+    df["bjd"] = pd.to_numeric(df["bjd"], errors="coerce")
+    df["rv_kms"] = pd.to_numeric(df["rv_kms"], errors="coerce")
+    df["rv_err_kms"] = pd.to_numeric(df["rv_err_kms"], errors="coerce")
+    df["mjd"] = df["bjd"].apply(lambda x: bjd_to_mjd(x) if np.isfinite(x) else np.nan)
+    df["epoch_id"] = (
+        df["reference_key"].astype(str)
+        + ":"
+        + df["obs_index"].astype(str)
+    )
+    return df
+
+
+def _diagnostics_path_for_basename(diagnostics_by_stem: dict[str, Path], basename: str) -> Path | None:
+    stem = Path(basename).stem
+    if stem in diagnostics_by_stem:
+        return diagnostics_by_stem[stem]
+    m = re.search(r"Gaia_DR3_\d+_epoch_\d+", stem)
+    if m and m.group(0) in diagnostics_by_stem:
+        return diagnostics_by_stem[m.group(0)]
+    return None
+
+
+def _exposure_from_diagnostics(path: Path) -> dict[str, float]:
+    out: dict[str, float] = {
+        "exposure_rv_kms": np.nan,
+        "exposure_rv_err_kms": np.nan,
+        "chunk_scatter_kms": np.nan,
+        "teff": np.nan,
+        "log10_median_mask_ccf_peak_snr": np.nan,
+    }
+    if not path.is_file():
+        return out
+    df = pd.read_csv(path)
+    if df.empty:
+        return out
+    if "exposure_rv_kms" in df.columns and df["exposure_rv_kms"].notna().any():
+        out["exposure_rv_kms"] = float(df["exposure_rv_kms"].dropna().iloc[0])
+    if "exposure_rv_err_kms" in df.columns and df["exposure_rv_err_kms"].notna().any():
+        out["exposure_rv_err_kms"] = float(df["exposure_rv_err_kms"].dropna().iloc[0])
+    row0 = df.iloc[0]
+    for col in ("chunk_scatter_kms", "teff"):
+        if col in df.columns and pd.notna(row0.get(col)):
+            out[col] = float(row0[col])
+    mask = df[df["method"] == "mask_ccf"] if "method" in df.columns else df
+    if "ccf_peak_snr" in mask.columns:
+        snrs = pd.to_numeric(mask["ccf_peak_snr"], errors="coerce").dropna()
+        if len(snrs):
+            med = float(np.median(snrs))
+            if med > 0:
+                out["log10_median_mask_ccf_peak_snr"] = float(np.log10(med))
+    return out
+
+
+def load_apf_epochs(
+    summary_dir: Path,
+    *,
+    diagnostics_glob: str | None = None,
+    bias_correction_applied: bool = True,
+    prefer_diagnostics_rv: bool = True,
+) -> pd.DataFrame:
+    diagnostics_by_stem: dict[str, Path] = {}
+    if diagnostics_glob:
+        for p in sorted(glob_paths(diagnostics_glob)):
+            diagnostics_by_stem[Path(p).stem.replace("_diagnostics", "")] = Path(p)
+
+    rows: list[dict[str, Any]] = []
+    for summary_path in discover_summary_files(summary_dir):
+        gaia_id = parse_object_id_from_summary(summary_path)
+        if not gaia_id:
+            continue
+        name = summary_path.stem.replace("_summary", "").replace(f"Gaia_DR3_{gaia_id}", "").strip("_")
+        for rec in parse_summary_file(summary_path):
+            if not np.isfinite(rec.get("rv", np.nan)):
+                continue
+            basename = rec["basename"]
+            diag = _diagnostics_path_for_basename(diagnostics_by_stem, basename)
+            diag_fields = _exposure_from_diagnostics(diag) if diag else _exposure_from_diagnostics(Path())
+            rv = float(rec["rv"])
+            rv_err = float(rec["rv_err"]) if np.isfinite(rec.get("rv_err", np.nan)) else np.nan
+            if prefer_diagnostics_rv and np.isfinite(diag_fields["exposure_rv_kms"]):
+                rv = float(diag_fields["exposure_rv_kms"])
+                if np.isfinite(diag_fields["exposure_rv_err_kms"]):
+                    rv_err = float(diag_fields["exposure_rv_err_kms"])
+            rows.append(
+                {
+                    "gaia_dr3_id": str(gaia_id),
+                    "name": name or f"Gaia_DR3_{gaia_id}",
+                    "basename": basename,
+                    "mjd": float(rec["mjd"]),
+                    "bjd": mjd_to_bjd(float(rec["mjd"])),
+                    "rv_kms": rv,
+                    "rv_err_kms": rv_err,
+                    "rms_kms": float(rec.get("rms", np.nan)),
+                    "summary_path": str(summary_path),
+                    "diagnostics_path": str(diag) if diag else "",
+                    "bias_correction_applied": bool(bias_correction_applied),
+                    "chunk_scatter_kms": diag_fields["chunk_scatter_kms"],
+                    "teff": diag_fields["teff"],
+                    "log10_median_mask_ccf_peak_snr": diag_fields["log10_median_mask_ccf_peak_snr"],
+                    "epoch_id": f"apf:{basename}",
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def min_cross_epoch_delta_days(left: pd.DataFrame, right: pd.DataFrame) -> float:
+    if left.empty or right.empty:
+        return float("nan")
+    lm = left["mjd"].astype(float).values
+    rm = right["mjd"].astype(float).values
+    return float(np.min(np.abs(lm[:, None] - rm[None, :])))
+
+
+def build_overlap_stars(literature: pd.DataFrame, apf: pd.DataFrame) -> pd.DataFrame:
+    lit_ids = set(literature["gaia_dr3_id"].astype(str))
+    apf_ids = set(apf["gaia_dr3_id"].astype(str))
+    overlap = sorted(lit_ids & apf_ids)
+    rows = []
+    for gid in overlap:
+        lg = literature[literature["gaia_dr3_id"] == gid]
+        ag = apf[apf["gaia_dr3_id"] == gid]
+        name = ""
+        if "name" in lg.columns and lg["name"].notna().any():
+            name = str(lg["name"].dropna().iloc[0])
+        elif len(ag):
+            name = str(ag["name"].iloc[0])
+        rows.append(
+            {
+                "gaia_dr3_id": gid,
+                "name": name,
+                "n_literature_epochs": int(len(lg)),
+                "n_apf_epochs": int(len(ag)),
+                "n_literature_references": int(lg["reference_key"].nunique()) if "reference_key" in lg.columns else 0,
+                "literature_mjd_min": float(lg["mjd"].min()) if len(lg) else np.nan,
+                "literature_mjd_max": float(lg["mjd"].max()) if len(lg) else np.nan,
+                "apf_mjd_min": float(ag["mjd"].min()) if len(ag) else np.nan,
+                "apf_mjd_max": float(ag["mjd"].max()) if len(ag) else np.nan,
+                "min_apf_literature_delta_days": min_cross_epoch_delta_days(ag, lg),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def pair_counts_by_window(
+    literature: pd.DataFrame,
+    apf: pd.DataFrame,
+    overlap_stars: pd.DataFrame,
+    windows_days: Iterable[float],
+) -> pd.DataFrame:
+    rows = []
+    for w in windows_days:
+        pairs = find_pair_candidates(literature, apf, overlap_stars, window_days=float(w))
+        rows.append(
+            {
+                "window_days": float(w),
+                "n_apf_literature": int((pairs["pair_type"] == "apf_literature").sum()) if len(pairs) else 0,
+                "n_apf_apf": int((pairs["pair_type"] == "apf_apf").sum()) if len(pairs) else 0,
+                "n_literature_literature": int((pairs["pair_type"] == "literature_literature").sum()) if len(pairs) else 0,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _pair_row(
+    pair_type: str,
+    gaia_dr3_id: str,
+    name: str,
+    left: dict[str, Any],
+    right: dict[str, Any],
+    delta_days: float,
+) -> dict[str, Any]:
+    return {
+        "pair_type": pair_type,
+        "gaia_dr3_id": gaia_dr3_id,
+        "name": name,
+        "delta_days": float(delta_days),
+        "left_epoch_id": left.get("epoch_id", ""),
+        "right_epoch_id": right.get("epoch_id", ""),
+        "left_mjd": float(left.get("mjd", np.nan)),
+        "right_mjd": float(right.get("mjd", np.nan)),
+        "left_rv_kms": float(left.get("rv_kms", np.nan)),
+        "right_rv_kms": float(right.get("rv_kms", np.nan)),
+        "left_rv_err_kms": float(left.get("rv_err_kms", np.nan)),
+        "right_rv_err_kms": float(right.get("rv_err_kms", np.nan)),
+        "left_reference_key": left.get("reference_key", ""),
+        "right_reference_key": right.get("reference_key", ""),
+        "left_instrument": left.get("instrument", "APF"),
+        "right_instrument": right.get("instrument", "APF"),
+        "left_bias_correction_applied": left.get("bias_correction_applied", np.nan),
+        "right_bias_correction_applied": right.get("bias_correction_applied", np.nan),
+    }
+
+
+def find_pair_candidates(
+    literature: pd.DataFrame,
+    apf: pd.DataFrame,
+    overlap_stars: pd.DataFrame,
+    *,
+    window_days: float = 7.0,
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    star_names = {
+        str(r["gaia_dr3_id"]): str(r.get("name", ""))
+        for _, r in overlap_stars.iterrows()
+    }
+    for gid in overlap_stars["gaia_dr3_id"].astype(str):
+        lg = literature[literature["gaia_dr3_id"] == gid].to_dict("records")
+        ag = apf[apf["gaia_dr3_id"] == gid].to_dict("records")
+        name = star_names.get(gid, "")
+
+        for a, b in combinations(lg, 2):
+            dt = abs(float(a["mjd"]) - float(b["mjd"]))
+            if dt <= window_days:
+                rows.append(_pair_row("literature_literature", gid, name, a, b, dt))
+
+        for a, b in combinations(ag, 2):
+            dt = abs(float(a["mjd"]) - float(b["mjd"]))
+            if dt <= window_days and a.get("epoch_id") != b.get("epoch_id"):
+                rows.append(_pair_row("apf_apf", gid, name, a, b, dt))
+
+        for a in ag:
+            for b in lg:
+                dt = abs(float(a["mjd"]) - float(b["mjd"]))
+                if dt <= window_days:
+                    rows.append(_pair_row("apf_literature", gid, name, a, b, dt))
+
+    if not rows:
+        return pd.DataFrame(columns=[
+            "pair_type", "gaia_dr3_id", "name", "delta_days",
+            "left_epoch_id", "right_epoch_id", "left_mjd", "right_mjd",
+            "left_rv_kms", "right_rv_kms", "left_rv_err_kms", "right_rv_err_kms",
+            "left_reference_key", "right_reference_key",
+            "left_instrument", "right_instrument",
+            "left_bias_correction_applied", "right_bias_correction_applied",
+        ])
+    return pd.DataFrame(rows)
+
+
+def enrich_pairs_with_deltas(pairs: pd.DataFrame) -> pd.DataFrame:
+    if pairs.empty:
+        return pairs
+    out = pairs.copy()
+    out["delta_rv_kms"] = out["left_rv_kms"].astype(float) - out["right_rv_kms"].astype(float)
+    out["abs_delta_rv_kms"] = out["delta_rv_kms"].abs()
+    le = out["left_rv_err_kms"].astype(float).fillna(0.0)
+    re = out["right_rv_err_kms"].astype(float).fillna(0.0)
+    out["combined_err_kms"] = np.sqrt(le**2 + re**2)
+    out.loc[(le <= 0) & (re <= 0), "combined_err_kms"] = np.nan
+    return out
+
+
+def summarize_absolute_gate(
+    pairs: pd.DataFrame,
+    *,
+    threshold_kms: float = ABSOLUTE_GATE_KMS,
+) -> dict[str, Any]:
+    sub = pairs[pairs["pair_type"] == "apf_literature"].copy()
+    if sub.empty:
+        return {"n_pairs": 0, "threshold_kms": threshold_kms}
+    abs_dv = sub["abs_delta_rv_kms"].astype(float)
+    passed = abs_dv < threshold_kms
+    return {
+        "n_pairs": int(len(sub)),
+        "n_stars": int(sub["gaia_dr3_id"].nunique()),
+        "threshold_kms": float(threshold_kms),
+        "pass_rate": float(passed.mean()),
+        "n_pass": int(passed.sum()),
+        "n_fail": int((~passed).sum()),
+        "median_abs_delta_rv_kms": float(np.median(abs_dv)),
+        "p90_abs_delta_rv_kms": float(np.percentile(abs_dv, 90)),
+        "max_abs_delta_rv_kms": float(np.max(abs_dv)),
+        "rms_delta_rv_kms": float(np.sqrt(np.mean(sub["delta_rv_kms"].astype(float) ** 2))),
+    }
+
+
+def summarize_relative_gate(
+    pairs: pd.DataFrame,
+    *,
+    goal_kms: float = RELATIVE_GOAL_KMS,
+) -> dict[str, Any]:
+    sub = pairs[pairs["pair_type"] == "apf_apf"].copy()
+    if sub.empty:
+        return {"n_pairs": 0, "goal_kms": goal_kms}
+    abs_dv = sub["abs_delta_rv_kms"].astype(float)
+    return {
+        "n_pairs": int(len(sub)),
+        "n_stars": int(sub["gaia_dr3_id"].nunique()),
+        "goal_kms": float(goal_kms),
+        "frac_below_goal": float(np.mean(abs_dv < goal_kms)),
+        "median_abs_delta_rv_kms": float(np.median(abs_dv)),
+        "p90_abs_delta_rv_kms": float(np.percentile(abs_dv, 90)),
+        "max_abs_delta_rv_kms": float(np.max(abs_dv)),
+        "rms_delta_rv_kms": float(np.sqrt(np.mean(sub["delta_rv_kms"].astype(float) ** 2))),
+    }
+
+
+def per_star_gate_table(pairs: pd.DataFrame, *, absolute_threshold_kms: float) -> pd.DataFrame:
+    rows = []
+    for gid, g in pairs.groupby("gaia_dr3_id"):
+        name = str(g["name"].iloc[0]) if "name" in g.columns else ""
+        abs_g = g[g["pair_type"] == "apf_literature"]
+        rel_g = g[g["pair_type"] == "apf_apf"]
+        row: dict[str, Any] = {"gaia_dr3_id": str(gid), "name": name}
+        if len(abs_g):
+            ad = abs_g["abs_delta_rv_kms"].astype(float)
+            row.update(
+                {
+                    "n_apf_literature_pairs": int(len(abs_g)),
+                    "abs_pass_rate": float((ad < absolute_threshold_kms).mean()),
+                    "abs_median_delta_kms": float(np.median(ad)),
+                    "abs_max_delta_kms": float(np.max(ad)),
+                }
+            )
+        else:
+            row.update(
+                {
+                    "n_apf_literature_pairs": 0,
+                    "abs_pass_rate": np.nan,
+                    "abs_median_delta_kms": np.nan,
+                    "abs_max_delta_kms": np.nan,
+                }
+            )
+        if len(rel_g):
+            rd = rel_g["abs_delta_rv_kms"].astype(float)
+            row.update(
+                {
+                    "n_apf_apf_pairs": int(len(rel_g)),
+                    "rel_median_delta_kms": float(np.median(rd)),
+                    "rel_p90_delta_kms": float(np.percentile(rd, 90)),
+                    "rel_rms_delta_kms": float(
+                        np.sqrt(np.mean(rel_g["delta_rv_kms"].astype(float) ** 2))
+                    ),
+                }
+            )
+        else:
+            row.update(
+                {
+                    "n_apf_apf_pairs": 0,
+                    "rel_median_delta_kms": np.nan,
+                    "rel_p90_delta_kms": np.nan,
+                    "rel_rms_delta_kms": np.nan,
+                }
+            )
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+@dataclass
+class PhaseARunManifest:
+    run_id: str
+    created_utc: str
+    master_path: str
+    summary_dir: str
+    diagnostics_glob: str
+    bias_correction_applied: bool
+    goals: dict[str, float] = field(default_factory=dict)
+    inventory: dict[str, Any] = field(default_factory=dict)
+    absolute_gate: dict[str, Any] = field(default_factory=dict)
+    relative_gate: dict[str, Any] = field(default_factory=dict)
+    output_files: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "created_utc": self.created_utc,
+            "master_path": self.master_path,
+            "summary_dir": self.summary_dir,
+            "diagnostics_glob": self.diagnostics_glob,
+            "bias_correction_applied": self.bias_correction_applied,
+            "goals": self.goals,
+            "inventory": self.inventory,
+            "absolute_gate": self.absolute_gate,
+            "relative_gate": self.relative_gate,
+            "output_files": self.output_files,
+        }
+
+    def write_json(self, path: Path) -> None:
+        path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+
+
+def inventory_summary_counts(
+    literature: pd.DataFrame,
+    apf: pd.DataFrame,
+    overlap_stars: pd.DataFrame,
+    pairs: pd.DataFrame,
+) -> dict[str, int]:
+    return {
+        "n_literature_stars": int(literature["gaia_dr3_id"].nunique()),
+        "n_apf_stars": int(apf["gaia_dr3_id"].nunique()),
+        "n_overlap_stars": int(len(overlap_stars)),
+        "n_literature_epochs": int(len(literature)),
+        "n_apf_epochs": int(len(apf)),
+        "n_pair_candidates": int(len(pairs)),
+        "n_apf_literature_pairs": int((pairs["pair_type"] == "apf_literature").sum()) if len(pairs) else 0,
+        "n_apf_apf_pairs": int((pairs["pair_type"] == "apf_apf").sum()) if len(pairs) else 0,
+        "n_literature_literature_pairs": int((pairs["pair_type"] == "literature_literature").sum()) if len(pairs) else 0,
+    }

--- a/validation/rv_phase_a_baseline.py
+++ b/validation/rv_phase_a_baseline.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""
+Phase A baseline: literature/APF overlap inventory, calibration gates, and diagnostic plots.
+
+Absolute calibration: APF vs literature pairs within --pair-window-days (default 7), target |ΔRV| < 1 km/s.
+Relative calibration: APF vs APF pairs on the same star, target improving toward 0.1 km/s after debias.
+
+Re-run after pipeline changes and compare against ``calibration/phase_a_baseline/reference_manifest.json``.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  python -m validation.rv_phase_a_baseline \\
+    --master calibration/literature_rv_master.csv \\
+    --summary-dir output \\
+    --diagnostics-glob 'output/Gaia_DR3_*_diagnostics.csv' \\
+    --out-dir validation_output/rv_phase_a_baseline \\
+    --bias-correction-applied
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from validation.rv_overlap_lib import (  # noqa: E402
+    PhaseAGoals,
+    PhaseARunManifest,
+    build_overlap_stars,
+    enrich_pairs_with_deltas,
+    file_sha256,
+    find_pair_candidates,
+    inventory_summary_counts,
+    load_apf_epochs,
+    load_literature_epochs,
+    pair_counts_by_window,
+    per_star_gate_table,
+    summarize_absolute_gate,
+    summarize_relative_gate,
+)
+
+logger = logging.getLogger(__name__)
+_GOALS_PATH = _REPO_ROOT / "calibration" / "phase_a_baseline" / "goals.yaml"
+_REFERENCE_MANIFEST = _REPO_ROOT / "calibration" / "phase_a_baseline" / "reference_manifest.json"
+
+
+def _plot_inventory_counts(counts: dict[str, int], out_path: Path) -> None:
+    labels = ["Literature stars", "APF stars", "Overlap stars"]
+    keys = ["n_literature_stars", "n_apf_stars", "n_overlap_stars"]
+    vals = [counts.get(k, 0) for k in keys]
+    fig, ax = plt.subplots(figsize=(6, 4))
+    bars = ax.bar(labels, vals, color=["#4c72b0", "#55a868", "#c44e52"])
+    ax.set_ylabel("Count")
+    ax.set_title("Phase A: star inventory")
+    for bar, v in zip(bars, vals):
+        ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height(), str(v), ha="center", va="bottom")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+
+
+def _plot_pair_type_counts(pairs: pd.DataFrame, out_path: Path) -> None:
+    if pairs.empty:
+        return
+    vc = pairs["pair_type"].value_counts()
+    fig, ax = plt.subplots(figsize=(6, 4))
+    labels = [str(x) for x in vc.index]
+    ax.bar(labels, vc.values, color=["#c44e52", "#55a868", "#4c72b0"])
+    ax.set_ylabel("Pair count")
+    ax.set_title(f"Pair candidates (window applied)")
+    plt.setp(ax.get_xticklabels(), rotation=15, ha="right")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+
+
+def _plot_histogram(
+    values: np.ndarray,
+    out_path: Path,
+    *,
+    title: str,
+    xlabel: str,
+    thresholds: list[tuple[float, str, str]],
+) -> None:
+    if len(values) == 0:
+        return
+    fig, ax = plt.subplots(figsize=(6, 4))
+    ax.hist(values, bins=min(30, max(10, len(values))), color="#4c72b0", alpha=0.85, edgecolor="white")
+    for thr, label, color in thresholds:
+        ax.axvline(thr, color=color, ls="--", lw=1.5, label=label)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel("Count")
+    ax.set_title(title)
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+
+
+def _plot_abs_vs_days(pairs: pd.DataFrame, out_path: Path, threshold_kms: float) -> None:
+    sub = pairs[pairs["pair_type"] == "apf_literature"]
+    if sub.empty:
+        return
+    fig, ax = plt.subplots(figsize=(6, 4))
+    passed = sub["abs_delta_rv_kms"].astype(float) < threshold_kms
+    ax.scatter(
+        sub.loc[~passed, "delta_days"],
+        sub.loc[~passed, "abs_delta_rv_kms"],
+        c="#c44e52",
+        label=f"fail (≥{threshold_kms} km/s)",
+        alpha=0.8,
+        s=36,
+    )
+    ax.scatter(
+        sub.loc[passed, "delta_days"],
+        sub.loc[passed, "abs_delta_rv_kms"],
+        c="#55a868",
+        label=f"pass (<{threshold_kms} km/s)",
+        alpha=0.8,
+        s=36,
+    )
+    ax.axhline(threshold_kms, color="gray", ls=":", lw=1)
+    ax.set_xlabel("Δt (days)")
+    ax.set_ylabel("|ΔRV| (km/s)")
+    ax.set_title("Absolute gate: APF vs literature")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+
+
+def _plot_apf_vs_literature_scatter(pairs: pd.DataFrame, out_path: Path) -> None:
+    sub = pairs[pairs["pair_type"] == "apf_literature"]
+    if sub.empty:
+        return
+    x = sub["right_rv_kms"].astype(float)
+    y = sub["left_rv_kms"].astype(float)
+    fig, ax = plt.subplots(figsize=(5.5, 5.5))
+    ax.scatter(x, y, s=40, alpha=0.75, c="#4c72b0")
+    lims = [np.nanmin([x.min(), y.min()]), np.nanmax([x.max(), y.max()])]
+    pad = 5.0
+    lo, hi = lims[0] - pad, lims[1] + pad
+    ax.plot([lo, hi], [lo, hi], "k--", lw=1, label="1:1")
+    ax.set_xlim(lo, hi)
+    ax.set_ylim(lo, hi)
+    ax.set_xlabel("Literature RV (km/s)")
+    ax.set_ylabel("APF RV (km/s)")
+    ax.set_title("Absolute calibration: APF vs literature")
+    ax.legend()
+    ax.set_aspect("equal", adjustable="box")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+
+
+def _plot_per_star_pass(per_star: pd.DataFrame, out_path: Path) -> None:
+    sub = per_star[per_star["n_apf_literature_pairs"] > 0].copy()
+    if sub.empty:
+        return
+    sub = sub.sort_values("abs_pass_rate")
+    labels = [f"{r['name'] or r['gaia_dr3_id'][:8]}" for _, r in sub.iterrows()]
+    fig, ax = plt.subplots(figsize=(7, max(3, 0.35 * len(sub))))
+    ax.barh(labels, sub["abs_pass_rate"].astype(float), color="#4c72b0")
+    ax.axvline(1.0, color="gray", ls=":", lw=1)
+    ax.set_xlabel("Absolute gate pass rate")
+    ax.set_title("Per-star APF–literature pass rate")
+    ax.set_xlim(0, 1.05)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+
+
+def _plot_min_apf_lit_delta(overlap: pd.DataFrame, window_days: float, out_path: Path) -> None:
+    if overlap.empty or "min_apf_literature_delta_days" not in overlap.columns:
+        return
+    sub = overlap.sort_values("min_apf_literature_delta_days")
+    labels = [f"{r['name'] or str(r['gaia_dr3_id'])[:10]}" for _, r in sub.iterrows()]
+    vals = sub["min_apf_literature_delta_days"].astype(float).values
+    fig, ax = plt.subplots(figsize=(7, max(3, 0.4 * len(sub))))
+    colors = ["#55a868" if v <= window_days else "#c44e52" for v in vals]
+    ax.barh(labels, vals, color=colors)
+    ax.axvline(window_days, color="gray", ls="--", label=f"gate window {window_days} d")
+    ax.set_xlabel("Min |ΔMJD| APF vs literature (days)")
+    ax.set_title("Closest APF–literature epoch separation per overlap star")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+
+
+def _plot_epoch_timeline(literature: pd.DataFrame, apf: pd.DataFrame, overlap: pd.DataFrame, out_path: Path) -> None:
+    if overlap.empty:
+        return
+    ids = set(overlap["gaia_dr3_id"].astype(str))
+    fig, ax = plt.subplots(figsize=(8, 5))
+    all_rv: list[float] = []
+    for gid in sorted(ids):
+        lg = literature[literature["gaia_dr3_id"] == gid]
+        ag = apf[apf["gaia_dr3_id"] == gid]
+        if len(lg):
+            ax.scatter(lg["mjd"], lg["rv_kms"], marker="s", s=30, alpha=0.7, c="#c44e52")
+            all_rv.extend(lg["rv_kms"].astype(float).tolist())
+        if len(ag):
+            ax.scatter(ag["mjd"], ag["rv_kms"], marker="o", s=30, alpha=0.7, c="#4c72b0")
+            all_rv.extend(ag["rv_kms"].astype(float).tolist())
+    if all_rv:
+        ylo, yhi = float(np.nanmin(all_rv)), float(np.nanmax(all_rv))
+        pad = max(5.0, 0.05 * (yhi - ylo + 1e-6))
+        ax.set_ylim(ylo - pad, yhi + pad)
+    for gid in sorted(ids):
+        name = str(overlap.loc[overlap["gaia_dr3_id"] == gid, "name"].iloc[0])
+        lg = literature[literature["gaia_dr3_id"] == gid]
+        ag = apf[apf["gaia_dr3_id"] == gid]
+        x = float(lg["mjd"].median()) if len(lg) else float(ag["mjd"].median())
+        ax.text(x, ax.get_ylim()[1], name or gid[:10], fontsize=7, ha="center", va="bottom")
+    ax.scatter([], [], marker="s", c="#c44e52", label="Literature")
+    ax.scatter([], [], marker="o", c="#4c72b0", label="APF")
+    ax.set_xlabel("MJD")
+    ax.set_ylabel("RV (km/s)")
+    ax.set_title("Overlap stars: epoch timeline")
+    ax.legend(loc="best")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+
+
+def _write_report_md(
+    path: Path,
+    *,
+    counts: dict[str, int],
+    abs_summary: dict,
+    rel_summary: dict,
+    goals: PhaseAGoals,
+    bias_applied: bool,
+) -> None:
+    lines = [
+        "# Phase A baseline report",
+        "",
+        "## Inventory",
+        f"- Literature stars: {counts.get('n_literature_stars', 0)}",
+        f"- APF stars: {counts.get('n_apf_stars', 0)}",
+        f"- Overlap stars: {counts.get('n_overlap_stars', 0)}",
+        f"- APF–literature pairs (≤{goals.pair_window_days} d): {counts.get('n_apf_literature_pairs', 0)}",
+        f"- APF–APF pairs: {counts.get('n_apf_apf_pairs', 0)}",
+        "",
+        "## Absolute calibration (APF vs literature)",
+        f"- Bias correction flagged as applied: **{bias_applied}**",
+        f"- Threshold: |ΔRV| < {goals.absolute_gate_kms} km/s",
+    ]
+    if abs_summary.get("n_pairs", 0):
+        lines.extend(
+            [
+                f"- Pass rate: {100 * abs_summary['pass_rate']:.1f}% ({abs_summary['n_pass']}/{abs_summary['n_pairs']})",
+                f"- Median |ΔRV|: {abs_summary['median_abs_delta_rv_kms']:.3f} km/s",
+                f"- p90 |ΔRV|: {abs_summary['p90_abs_delta_rv_kms']:.3f} km/s",
+                f"- RMS ΔRV: {abs_summary['rms_delta_rv_kms']:.3f} km/s",
+            ]
+        )
+    else:
+        lines.append("- No APF–literature pairs in window.")
+        lines.append(
+            "- Likely cause: literature epochs predate APF coverage on overlap stars; "
+            "see `plots/min_apf_literature_delta_days.png` and `pair_counts_by_window.csv`."
+        )
+    lines.extend(["", "## Relative calibration (APF–APF)", f"- Goal (post-debias target): {goals.relative_goal_kms} km/s"])
+    if rel_summary.get("n_pairs", 0):
+        lines.extend(
+            [
+                f"- Median |ΔRV|: {rel_summary['median_abs_delta_rv_kms']:.3f} km/s",
+                f"- p90 |ΔRV|: {rel_summary['p90_abs_delta_rv_kms']:.3f} km/s",
+                f"- RMS ΔRV: {rel_summary['rms_delta_rv_kms']:.3f} km/s",
+                f"- Fraction below {goals.relative_goal_kms} km/s: {100 * rel_summary['frac_below_goal']:.1f}%",
+            ]
+        )
+    else:
+        lines.append("- No APF–APF pairs in window.")
+    lines.extend(
+        [
+            "",
+            "## Regression",
+            "Compare `baseline_manifest.json` to `calibration/phase_a_baseline/reference_manifest.json`.",
+            "Re-run with `--no-bias-correction-applied` after a `--no-bias` pipeline campaign for the canonical absolute gate.",
+        ]
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_phase_a(
+    *,
+    master_path: Path,
+    summary_dir: Path,
+    diagnostics_glob: str | None,
+    out_dir: Path,
+    goals: PhaseAGoals,
+    bias_correction_applied: bool,
+    prefer_diagnostics_rv: bool,
+    run_id: str | None = None,
+) -> PhaseARunManifest:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    plots_dir = out_dir / "plots"
+    plots_dir.mkdir(parents=True, exist_ok=True)
+
+    literature = load_literature_epochs(master_path)
+    apf = load_apf_epochs(
+        summary_dir,
+        diagnostics_glob=diagnostics_glob,
+        bias_correction_applied=bias_correction_applied,
+        prefer_diagnostics_rv=prefer_diagnostics_rv,
+    )
+    overlap = build_overlap_stars(literature, apf)
+    pairs = find_pair_candidates(literature, apf, overlap, window_days=goals.pair_window_days)
+    pairs = enrich_pairs_with_deltas(pairs)
+
+    literature.to_csv(out_dir / "literature_epochs.csv", index=False)
+    apf.to_csv(out_dir / "apf_epochs.csv", index=False)
+    overlap.to_csv(out_dir / "overlap_stars.csv", index=False)
+    window_tab = pair_counts_by_window(
+        literature, apf, overlap, windows_days=[7, 30, 90, 180, 365]
+    )
+    window_tab.to_csv(out_dir / "pair_counts_by_window.csv", index=False)
+    pairs.to_csv(out_dir / "pair_candidates.csv", index=False)
+
+    abs_summary = summarize_absolute_gate(pairs, threshold_kms=goals.absolute_gate_kms)
+    rel_summary = summarize_relative_gate(pairs, goal_kms=goals.relative_goal_kms)
+    per_star = per_star_gate_table(pairs, absolute_threshold_kms=goals.absolute_gate_kms)
+    per_star.to_csv(out_dir / "per_star_gates.csv", index=False)
+
+    pd.DataFrame([abs_summary]).to_csv(out_dir / "absolute_gate_summary.csv", index=False)
+    pd.DataFrame([rel_summary]).to_csv(out_dir / "relative_gate_summary.csv", index=False)
+
+    counts = inventory_summary_counts(literature, apf, overlap, pairs)
+
+    _plot_inventory_counts(counts, plots_dir / "inventory_star_counts.png")
+    _plot_pair_type_counts(pairs, plots_dir / "pair_type_counts.png")
+    _plot_histogram(
+        pairs.loc[pairs["pair_type"] == "apf_literature", "abs_delta_rv_kms"].astype(float).values,
+        plots_dir / "absolute_delta_rv_histogram.png",
+        title="Absolute gate |ΔRV| (APF − literature)",
+        xlabel="|ΔRV| (km/s)",
+        thresholds=[(goals.absolute_gate_kms, f"gate {goals.absolute_gate_kms} km/s", "crimson")],
+    )
+    _plot_histogram(
+        pairs.loc[pairs["pair_type"] == "apf_apf", "abs_delta_rv_kms"].astype(float).values,
+        plots_dir / "relative_delta_rv_histogram.png",
+        title="Relative gate |ΔRV| (APF − APF)",
+        xlabel="|ΔRV| (km/s)",
+        thresholds=[(goals.relative_goal_kms, f"goal {goals.relative_goal_kms} km/s", "darkgreen")],
+    )
+    _plot_histogram(
+        pairs.loc[pairs["pair_type"] == "literature_literature", "abs_delta_rv_kms"].astype(float).values,
+        plots_dir / "literature_literature_delta_histogram.png",
+        title="Diagnostic: |ΔRV| literature–literature",
+        xlabel="|ΔRV| (km/s)",
+        thresholds=[],
+    )
+    _plot_abs_vs_days(pairs, plots_dir / "absolute_delta_rv_vs_delta_days.png", goals.absolute_gate_kms)
+    _plot_apf_vs_literature_scatter(pairs, plots_dir / "apf_vs_literature_scatter.png")
+    _plot_per_star_pass(per_star, plots_dir / "per_star_absolute_pass_rate.png")
+    _plot_epoch_timeline(literature, apf, overlap, plots_dir / "overlap_epoch_timeline.png")
+    _plot_min_apf_lit_delta(overlap, goals.pair_window_days, plots_dir / "min_apf_literature_delta_days.png")
+
+    _write_report_md(
+        out_dir / "REPORT.md",
+        counts=counts,
+        abs_summary=abs_summary,
+        rel_summary=rel_summary,
+        goals=goals,
+        bias_applied=bias_correction_applied,
+    )
+
+    rid = run_id or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    manifest = PhaseARunManifest(
+        run_id=rid,
+        created_utc=datetime.now(timezone.utc).isoformat(),
+        master_path=str(master_path.resolve()),
+        summary_dir=str(summary_dir.resolve()),
+        diagnostics_glob=diagnostics_glob or "",
+        bias_correction_applied=bias_correction_applied,
+        goals={
+            "pair_window_days": goals.pair_window_days,
+            "absolute_gate_kms": goals.absolute_gate_kms,
+            "relative_goal_kms": goals.relative_goal_kms,
+        },
+        inventory=counts,
+        absolute_gate=abs_summary,
+        relative_gate=rel_summary,
+        output_files={},
+    )
+    manifest.inventory["pair_counts_by_window"] = window_tab.to_dict(orient="records")
+    key_outputs = [
+        "overlap_stars.csv",
+        "pair_candidates.csv",
+        "absolute_gate_summary.csv",
+        "relative_gate_summary.csv",
+        "per_star_gates.csv",
+        "baseline_manifest.json",
+        "REPORT.md",
+    ]
+    manifest.write_json(out_dir / "baseline_manifest.json")
+    for name in key_outputs:
+        p = out_dir / name
+        if p.is_file():
+            manifest.output_files[name] = file_sha256(p)
+    manifest.write_json(out_dir / "baseline_manifest.json")
+    return manifest
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--master", type=Path, default=_REPO_ROOT / "calibration" / "literature_rv_master.csv")
+    ap.add_argument("--summary-dir", type=Path, default=_REPO_ROOT / "output")
+    ap.add_argument("--diagnostics-glob", default="output/Gaia_DR3_*_diagnostics.csv")
+    ap.add_argument("--out-dir", type=Path, default=_REPO_ROOT / "validation_output" / "rv_phase_a_baseline")
+    ap.add_argument("--goals", type=Path, default=_GOALS_PATH)
+    ap.add_argument("--pair-window-days", type=float, default=None)
+    ap.add_argument("--run-id", default=None)
+    ap.add_argument(
+        "--bias-correction-applied",
+        action="store_true",
+        default=None,
+        help="APF RVs include order bias correction (default: true if neither bias flag set)",
+    )
+    ap.add_argument(
+        "--no-bias-correction-applied",
+        action="store_true",
+        help="APF RVs are from a --no-bias pipeline run",
+    )
+    ap.add_argument("--summary-only-rv", action="store_true", help="Use summary RVs instead of diagnostics exposure_rv")
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    goals = PhaseAGoals.from_yaml_path(args.goals)
+    if args.pair_window_days is not None:
+        goals.pair_window_days = float(args.pair_window_days)
+
+    if args.no_bias_correction_applied:
+        bias_applied = False
+    elif args.bias_correction_applied:
+        bias_applied = True
+    else:
+        bias_applied = True
+        logger.warning(
+            "Assuming bias_correction_applied=True. Re-run pipeline with --no-bias and pass "
+            "--no-bias-correction-applied for the canonical absolute gate baseline."
+        )
+
+    manifest = run_phase_a(
+        master_path=args.master,
+        summary_dir=args.summary_dir,
+        diagnostics_glob=args.diagnostics_glob or None,
+        out_dir=args.out_dir,
+        goals=goals,
+        bias_correction_applied=bias_applied,
+        prefer_diagnostics_rv=not args.summary_only_rv,
+        run_id=args.run_id,
+    )
+    logger.info("Phase A baseline written to %s", args.out_dir)
+    logger.info(
+        "overlap=%d apf_lit_pairs=%d pass_rate=%.1f%% rel_pairs=%d",
+        manifest.inventory.get("n_overlap_stars", 0),
+        manifest.absolute_gate.get("n_pairs", 0),
+        100.0 * manifest.absolute_gate.get("pass_rate", 0.0),
+        manifest.relative_gate.get("n_pairs", 0),
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Chunk campaign framework**: layout YAMLs, `measurement_cache.csv`, parametric grid search, bias regression, full campaign driver (`chunk_campaign`), and reassess-relative-calibration hook.
- **σ_RV evaluation**: per-spectrum formal error + intrinsic scatter weights; composite score (35% median σ_RV + 35% p90 σ_RV + 30% relative gate).
- **Adaptive stacking**: whole-layout + per-order greedy candidates; cache-based apples-to-apples baselines; outputs `adaptive_stack_common_cohort.csv`, paired cohort tables.
- **Pipeline / fits**: weighted wRMS in star summaries; `--chunk-layout` support; `parse_chunk_key` / merge bias lookup fixes.
- **Keplerian fits**: `--fit-jitter` profiles intrinsic scatter jointly with orbit (alternating EM + Gaussian NLL); plot error bars use formal err + fitted jitter; `refit_all_per_object.sh` enables jitter by default (`FIT_JITTER=1`).

## Follow-up issues

- #54 — measurement_cache dedup (`subchunks_3` vs `n3_equal`)
- #55 — resume campaign (n3_telluric, Stage B, subchunks_8)
- #56 — adaptive composite objective + cache-aligned bias
- #57 — deploy winning layout to production

## Server deploy (ziggy)

```bash
cd /data2/darkhunter/dark-hunter_rv
git fetch origin
git checkout step/01-benchmark-cool-precision
git pull origin step/01-benchmark-cool-precision
export PYTHONPATH=.
```

### (1) Single star — `Gaia_DR3_1702370142434513152`

```bash
REPO=/data2/darkhunter/dark-hunter_rv
PY=/home/marley/anaconda2/envs/gaia-env/bin/python
OUT=$REPO/output
SPEC=/data2/gaia_stars/apf_reductions
GID=1702370142434513152

cd $REPO && export PYTHONPATH=$REPO DARKHUNTER_OUTPUT_DIR=$OUT

# Pipeline all epochs
find "$SPEC" -type f -name "Gaia_DR3_${GID}_epoch_*.txt" -print0 \
  | xargs -0 $PY -m darkhunter_rv.pipeline --instrument APF --plots --plots-focus

# Keplerian fit + plots
$PY fit_apf_rv_keplerian.py \
  --summary "$OUT/Gaia_DR3_${GID}_summary.txt" \
  --reports-dir "$OUT/Gaia_DR3_${GID}" \
  --use-gaia-nss --fit-jitter --force --min-points 7
```

Or one-liner via refit script:

```bash
cd /data2/darkhunter/dark-hunter_rv
STAR_ID=1702370142434513152 FIT_FORCE=1 FIT_JITTER=1 bash scripts/refit_all_per_object.sh
```

### (2) Full catalog + website (screen)

```bash
screen -dmS darkhunter_full_refresh bash -lc '
  REPO=/data2/darkhunter/dark-hunter_rv
  cd "$REPO"
  git fetch origin && git checkout step/01-benchmark-cool-precision && git pull
  bash scripts/full_website_refresh.sh
'
# attach: screen -r darkhunter_full_refresh
```

Per-object refit only (skips observability bootstrap):

```bash
screen -dmS darkhunter_per_object bash -lc '
  REPO=/data2/darkhunter/dark-hunter_rv
  cd "$REPO" && git pull
  FIT_JITTER=1 FIT_FORCE=1 bash scripts/refit_all_per_object.sh
'
```

### (3) Chunk campaign validation (screen; needs ~3 GB free disk)

```bash
screen -dmS chunk_campaign bash -lc '
  cd /data2/darkhunter/dark-hunter_rv
  git pull && export PYTHONPATH=.
  python -m validation.chunk_campaign --run-pipeline --out-dir validation_output/chunk_campaign
  python -m validation.chunk_adaptive_stack --campaign-dir validation_output/chunk_campaign
'
```

## Test plan

- [x] `pytest tests/test_fit_apf_rv_keplerian.py tests/test_weighted_template_fft.py tests/validation/test_chunk_*.py` (55 passed locally)
- [ ] Server: `STAR_ID=1702370142434513152 FIT_JITTER=1 bash scripts/refit_all_per_object.sh`
- [ ] Keplerian plot error bars ~0.24 km/s for 1702370142434513152 (not 50 km/s)
- [ ] Resume chunk campaign when disk allows (#55)