### PR TITLE
Parallel catalog RV refit with nice and per-star website sync

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -78,6 +78,24 @@ Use **`--include-offset-calibration`** to force reprocessing of offset-training 
 3. Install `bias_statistics.txt` next to `InstrumentProfile.bias_file` (APF: repo root).
 4. Offsets: `python -m validation.compute_method_rv_offsets --diagnostics-list … --output method_rv_offsets.txt`
 
+## Production RV refit (full catalog, parallel)
+
+Re-measure every star with `subchunks_4` + debias, Keplerian fit, and **per-star website update** (plots, summary, `data.csv` row). Low CPU priority; parallel workers use `flock` on `data.csv`.
+
+```bash
+cd /data2/darkhunter/dark-hunter_rv
+git pull
+
+screen -dmS darkhunter_parallel_refit bash -lc '
+  REPO=/data2/darkhunter/dark-hunter_rv
+  cd "$REPO"
+  JOBS=4 NICE_LEVEL=10 PIPELINE_FORCE=1 FIT_FORCE=1 FIT_JITTER=1 \
+    bash scripts/refit_all_per_object_parallel.sh
+'
+```
+
+Attach with `screen -r darkhunter_parallel_refit`. Logs: `logs/refit_all_per_object_parallel.log` and `logs/refit_parallel/<gaia_id>.log`. Tune `JOBS` (default half of CPU count, max 8) and `NICE_LEVEL` (default 10).
+
 ## Production RV refit (one star: re-measure + Keplerian fit)
 
 Re-run the pipeline with the **production chunk layout** (`subchunks_4`), **committed debias table**, and mask-CCF summary RVs, then fit:

--- a/scripts/lib/refit_one_object.sh
+++ b/scripts/lib/refit_one_object.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Pipeline → Keplerian fit → Hβ plots → website sync for one Gaia_DR3_<id>.
+# Called by refit_all_per_object.sh and refit_all_per_object_parallel.sh.
+
+set -euo pipefail
+
+gid="${1:?Gaia source id required}"
+
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+OUT="${OUT:-$REPO/output}"
+WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
+SPEC_ROOT="${SPEC_ROOT:-/data2/gaia_stars/apf_reductions}"
+if [[ -n "${PY:-}" ]] && command -v "$PY" >/dev/null 2>&1; then
+  :
+elif [[ -x /home/marley/anaconda2/envs/gaia-env/bin/python ]]; then
+  PY=/home/marley/anaconda2/envs/gaia-env/bin/python
+else
+  PY=python3
+fi
+CHUNK_LAYOUT="${CHUNK_LAYOUT:-$REPO/calibration/chunk_layouts/subchunks_4.yaml}"
+PIPELINE_FORCE="${PIPELINE_FORCE:-0}"
+MASK_PRIMARY="${MASK_PRIMARY:-1}"
+REPORTS_DIR="${REPORTS_DIR:-$REPO/rv_fit_reports}"
+MIN_POINTS="${MIN_POINTS:-5}"
+FIT_FORCE="${FIT_FORCE:-1}"
+FIT_JITTER="${FIT_JITTER:-1}"
+PIPELINE_UPDATE="${PIPELINE_UPDATE:-0}"
+RUN_HBETA="${RUN_HBETA:-1}"
+QUERY_GAIA_ONLINE="${QUERY_GAIA_ONLINE:-0}"
+REFIT_PARALLEL_LOG_DIR="${REFIT_PARALLEL_LOG_DIR:-$REPO/logs/refit_parallel}"
+
+cd "$REPO"
+# shellcheck source=scripts/lib/website_sync_one_star.sh
+source "$REPO/scripts/lib/website_sync_one_star.sh"
+
+export PYTHONPATH="$REPO"
+export DARKHUNTER_OUTPUT_DIR="$OUT"
+export WEB_ROOT OUT SPEC_ROOT REPORTS_DIR PY MIN_POINTS
+export WEBSITE_STARS_DIR="${WEBSITE_STARS_DIR:-$WEB_ROOT/stars}"
+export DATA_CSV="${DATA_CSV:-$WEB_ROOT/tables/data.csv}"
+
+run_cmd() { "$@"; }
+
+mkdir -p "$OUT" "$REPORTS_DIR" "$REFIT_PARALLEL_LOG_DIR"
+LOG="$REFIT_PARALLEL_LOG_DIR/${gid}.log"
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== Gaia_DR3_${gid} worker pid=$$ $(date '+%Y-%m-%dT%H:%M:%S%z') ==="
+
+if [[ ! -f "$DATA_CSV" ]]; then
+  echo "[ERROR] $DATA_CSV missing" >&2
+  exit 2
+fi
+if [[ ! -f "$REPO/bias_statistics.txt" ]]; then
+  echo "[WARN] $REPO/bias_statistics.txt missing — mask RVs will not be debiased" >&2
+fi
+
+SPEC_FILES=()
+while IFS= read -r f; do
+  [[ -n "$f" ]] && SPEC_FILES+=("$f")
+done < <(
+  find "$SPEC_ROOT" -type f \( \
+    -name "Gaia_DR3_${gid}_epoch_*.txt" -o \
+    -name "Gaia_DR3_${gid}_*_ap1.flm" -o \
+    -name "Gaia_DR3_${gid}_*_ap1.txt" \
+  \) 2>/dev/null | sort
+)
+if [[ "${#SPEC_FILES[@]}" -eq 0 ]]; then
+  echo "[WARN] no spectra for Gaia_DR3_${gid}; skip"
+  exit 1
+fi
+
+pipeline_args=(--instrument APF --plots --plots-focus)
+if [[ -f "$CHUNK_LAYOUT" ]]; then
+  pipeline_args+=(--chunk-layout "$CHUNK_LAYOUT")
+fi
+if [[ "$PIPELINE_FORCE" == "1" ]]; then
+  pipeline_args+=(--force)
+elif [[ "$PIPELINE_UPDATE" == "1" ]]; then
+  pipeline_args+=(--update)
+fi
+if [[ "$MASK_PRIMARY" == "1" ]]; then
+  pipeline_args+=(--no-run-all-methods)
+fi
+
+echo "pipeline: ${#SPEC_FILES[@]} spectrum file(s)"
+if ! "$PY" -m darkhunter_rv.pipeline "${pipeline_args[@]}" "${SPEC_FILES[@]}"; then
+  echo "[WARN] pipeline errors for Gaia_DR3_${gid} (continuing to fit if summary exists)"
+fi
+
+summ="$OUT/Gaia_DR3_${gid}_summary.txt"
+if [[ ! -f "$summ" ]]; then
+  echo "[WARN] no summary after pipeline; skip fit/website"
+  exit 1
+fi
+
+fit_args=(
+  fit_apf_rv_keplerian.py
+  --summary "$summ"
+  --output-dir "$OUT"
+  --reports-dir "$REPORTS_DIR"
+  --use-gaia-nss
+  --min-points "$MIN_POINTS"
+  --data-csv "$DATA_CSV"
+)
+if [[ "$FIT_FORCE" == "1" ]]; then
+  fit_args+=(--force)
+fi
+if [[ "$QUERY_GAIA_ONLINE" == "1" ]]; then
+  fit_args+=(--query-gaia-online)
+fi
+if [[ "$FIT_JITTER" == "1" ]]; then
+  fit_args+=(--fit-jitter)
+fi
+if ! "$PY" "${fit_args[@]}"; then
+  echo "[WARN] fit failed for Gaia_DR3_${gid} (continuing to website if assets exist)"
+fi
+
+if [[ "$RUN_HBETA" == "1" ]]; then
+  "$PY" scripts/build_hbeta_website_plots.py \
+    --summary-dir "$OUT" \
+    --plots-root "$OUT" \
+    --spec-root "$SPEC_ROOT" \
+    --star-id "$gid" \
+    || echo "[WARN] Hβ plot failed for Gaia_DR3_${gid} (continuing)"
+fi
+
+if website_sync_one_star "$gid"; then
+  echo "[OK] Gaia_DR3_${gid} pipeline + fit + website complete"
+  exit 0
+fi
+echo "[WARN] website sync failed for Gaia_DR3_${gid}"
+exit 1

--- a/scripts/lib/website_sync_one_star.sh
+++ b/scripts/lib/website_sync_one_star.sh
@@ -40,11 +40,20 @@ website_sync_one_star() {
   fi
 
   if [[ "${DRY_RUN:-0}" != "1" ]]; then
-    run_cmd "$PY" scripts/update_website_table_columns.py \
-      --data-csv "$DATA_CSV" \
-      --output-dir "$OUT" \
-      --reports-dir "$REPORTS_DIR" \
-      --gaia-id "$gid"
+    local csv_lock="${DATA_CSV}.lock"
+    if command -v flock >/dev/null 2>&1; then
+      run_cmd flock -w 600 "$csv_lock" "$PY" scripts/update_website_table_columns.py \
+        --data-csv "$DATA_CSV" \
+        --output-dir "$OUT" \
+        --reports-dir "$REPORTS_DIR" \
+        --gaia-id "$gid"
+    else
+      run_cmd "$PY" scripts/update_website_table_columns.py \
+        --data-csv "$DATA_CSV" \
+        --output-dir "$OUT" \
+        --reports-dir "$REPORTS_DIR" \
+        --gaia-id "$gid"
+    fi
     if [[ -d "$WEBSITE_STARS_DIR/Gaia_DR3_${gid}" ]]; then
       run_cmd rsync -rlptD --omit-dir-times \
         "$WEBSITE_STARS_DIR/Gaia_DR3_${gid}/" \

--- a/scripts/refit_all_per_object.sh
+++ b/scripts/refit_all_per_object.sh
@@ -9,10 +9,18 @@
 #   STAR_ID=1551542027851147904 bash scripts/refit_all_per_object.sh
 #   MIN_POINTS=5 FIT_FORCE=1 bash scripts/refit_all_per_object.sh
 #
-# Detached (recommended for full catalog):
+# Detached sequential (one star at a time):
 #   screen -dmS darkhunter_per_object bash -lc '
 #     REPO=/data2/darkhunter/dark-hunter_rv
-#     cd "$REPO" && git pull && bash scripts/refit_all_per_object.sh
+#     cd "$REPO" && PIPELINE_FORCE=1 bash scripts/refit_all_per_object.sh
+#   '
+#
+# Detached parallel (recommended for full catalog refit):
+#   screen -dmS darkhunter_parallel_refit bash -lc '
+#     REPO=/data2/darkhunter/dark-hunter_rv
+#     cd "$REPO"
+#     JOBS=4 NICE_LEVEL=10 PIPELINE_FORCE=1 FIT_FORCE=1 FIT_JITTER=1 \
+#       bash scripts/refit_all_per_object_parallel.sh
 #   '
 
 set -euo pipefail
@@ -46,17 +54,14 @@ cd "$REPO"
 source "$REPO/scripts/lib/spec_find_patterns.sh"
 # shellcheck source=scripts/lib/discover_gaia_star_ids.sh
 source "$REPO/scripts/lib/discover_gaia_star_ids.sh"
-# shellcheck source=scripts/lib/website_sync_one_star.sh
-source "$REPO/scripts/lib/website_sync_one_star.sh"
-
 mkdir -p "$(dirname "$LOG")" "$OUT" "$REPO/logs" "$REPORTS_DIR"
 export PYTHONPATH="$REPO"
 export DARKHUNTER_OUTPUT_DIR="$OUT"
 export WEB_ROOT OUT SPEC_ROOT REPORTS_DIR PY MIN_POINTS
 export WEBSITE_STARS_DIR="$WEB_ROOT/stars"
 export DATA_CSV="$WEB_ROOT/tables/data.csv"
-
-run_cmd() { "$@"; }
+export CHUNK_LAYOUT PIPELINE_FORCE MASK_PRIMARY FIT_FORCE FIT_JITTER
+export PIPELINE_UPDATE RUN_HBETA QUERY_GAIA_ONLINE
 
 if [[ ! -f "$DATA_CSV" ]]; then
   echo "[ERROR] $DATA_CSV missing — run scripts/bootstrap_website_tables.sh first." >&2
@@ -81,83 +86,21 @@ if [[ "${#STAR_IDS[@]}" -eq 0 ]]; then
 fi
 echo "stars_to_process=${#STAR_IDS[@]}"
 
-pipeline_args=(--instrument APF --plots --plots-focus)
-if [[ -f "$CHUNK_LAYOUT" ]]; then
-  pipeline_args+=(--chunk-layout "$CHUNK_LAYOUT")
-fi
-if [[ "$PIPELINE_FORCE" == "1" ]]; then
-  pipeline_args+=(--force)
-elif [[ "$PIPELINE_UPDATE" == "1" ]]; then
-  pipeline_args+=(--update)
-fi
-if [[ "$MASK_PRIMARY" == "1" ]]; then
-  pipeline_args+=(--no-run-all-methods)
-fi
+export REFIT_PARALLEL_LOG_DIR="$REPO/logs/refit_per_object"
 if [[ ! -f "$REPO/bias_statistics.txt" ]]; then
   echo "[WARN] $REPO/bias_statistics.txt missing — mask RVs will not be debiased" >&2
 fi
+mkdir -p "$REFIT_PARALLEL_LOG_DIR"
+worker="$REPO/scripts/lib/refit_one_object.sh"
+chmod +x "$worker"
 
 n_ok=0
 n_skip=0
 for gid in "${STAR_IDS[@]}"; do
   echo ""
-  echo "=== Gaia_DR3_${gid} ($(date -Is)) ==="
-
-  mapfile -d '' -t SPEC_FILES < <(
-    find "$SPEC_ROOT" -type f \( \
-      -name "Gaia_DR3_${gid}_epoch_*.txt" -o \
-      -name "Gaia_DR3_${gid}_*_ap1.flm" -o \
-      -name "Gaia_DR3_${gid}_*_ap1.txt" \
-    \) -print0 2>/dev/null
-  )
-  if [[ "${#SPEC_FILES[@]}" -eq 0 ]]; then
-    echo "[WARN] no spectra files for Gaia_DR3_${gid}; skip"
-    n_skip=$((n_skip + 1))
-    continue
-  fi
-  echo "pipeline: ${#SPEC_FILES[@]} spectrum file(s)"
-  printf '%s\0' "${SPEC_FILES[@]}" | xargs -0 -r "$PY" -m darkhunter_rv.pipeline "${pipeline_args[@]}" \
-    || echo "[WARN] pipeline errors for Gaia_DR3_${gid} (continuing)"
-
-  summ="$OUT/Gaia_DR3_${gid}_summary.txt"
-  if [[ ! -f "$summ" ]]; then
-    echo "[WARN] no summary after pipeline; skip fit/website"
-    n_skip=$((n_skip + 1))
-    continue
-  fi
-
-  fit_args=(
-    fit_apf_rv_keplerian.py
-    --summary "$summ"
-    --output-dir "$OUT"
-    --reports-dir "$REPORTS_DIR"
-    --use-gaia-nss
-    --min-points "$MIN_POINTS"
-    --data-csv "$DATA_CSV"
-  )
-  if [[ "$FIT_FORCE" == "1" ]]; then
-    fit_args+=(--force)
-  fi
-  if [[ "$QUERY_GAIA_ONLINE" == "1" ]]; then
-    fit_args+=(--query-gaia-online)
-  fi
-  if [[ "$FIT_JITTER" == "1" ]]; then
-    fit_args+=(--fit-jitter)
-  fi
-  "$PY" "${fit_args[@]}" || echo "[WARN] fit failed for Gaia_DR3_${gid} (continuing)"
-
-  if [[ "$RUN_HBETA" == "1" ]]; then
-    "$PY" scripts/build_hbeta_website_plots.py \
-      --summary-dir "$OUT" \
-      --plots-root "$OUT" \
-      --spec-root "$SPEC_ROOT" \
-      --star-id "$gid" \
-      || echo "[WARN] Hβ plot failed for Gaia_DR3_${gid} (continuing)"
-  fi
-
-  if website_sync_one_star "$gid"; then
+  echo "=== Gaia_DR3_${gid} ($(date '+%Y-%m-%dT%H:%M:%S%z')) ==="
+  if bash "$worker" "$gid"; then
     n_ok=$((n_ok + 1))
-    echo "[OK] website updated for Gaia_DR3_${gid}"
   else
     n_skip=$((n_skip + 1))
   fi

--- a/scripts/refit_all_per_object_parallel.sh
+++ b/scripts/refit_all_per_object_parallel.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Parallel per-object refit: pipeline (subchunks_4 + debias) → Keplerian fit → website per star.
+#
+# Each worker runs scripts/lib/refit_one_object.sh (pipeline, fit, Hβ, stage plots + data.csv row).
+# Uses flock on data.csv updates so parallel workers do not corrupt the website table.
+#
+# Usage (ziggy):
+#   cd /data2/darkhunter/dark-hunter_rv && git pull
+#   PIPELINE_FORCE=1 JOBS=4 bash scripts/refit_all_per_object_parallel.sh
+#
+# Detached screen (recommended — low CPU priority, 4 parallel stars):
+#   screen -dmS darkhunter_parallel_refit bash -lc '
+#     REPO=/data2/darkhunter/dark-hunter_rv
+#     cd "$REPO"
+#     JOBS=4 NICE_LEVEL=10 PIPELINE_FORCE=1 FIT_FORCE=1 FIT_JITTER=1 \
+#       bash scripts/refit_all_per_object_parallel.sh
+#   '
+#
+# Attach: screen -r darkhunter_parallel_refit
+# Per-star logs: logs/refit_parallel/<gaia_id>.log
+#
+# Env:
+#   JOBS          parallel workers (default: half of nproc, max 8)
+#   NICE_LEVEL    nice priority 0–19 (default 10)
+#   PIPELINE_FORCE=1  re-measure all epochs (default 1 here)
+#   STAR_ID       optional single-star mode
+
+set -euo pipefail
+
+REPO="${REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
+SPEC_ROOT="${SPEC_ROOT:-/data2/gaia_stars/apf_reductions}"
+STAR_ID="${STAR_ID:-}"
+PIPELINE_FORCE="${PIPELINE_FORCE:-1}"
+JOBS="${JOBS:-}"
+NICE_LEVEL="${NICE_LEVEL:-10}"
+LOG="${LOG:-$REPO/logs/refit_all_per_object_parallel.log}"
+
+cd "$REPO"
+# shellcheck source=scripts/lib/discover_gaia_star_ids.sh
+source "$REPO/scripts/lib/discover_gaia_star_ids.sh"
+
+if [[ -z "$JOBS" ]]; then
+  ncpu=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+  JOBS=$(( ncpu / 2 ))
+  [[ "$JOBS" -lt 1 ]] && JOBS=1
+  [[ "$JOBS" -gt 8 ]] && JOBS=8
+fi
+
+mkdir -p "$(dirname "$LOG")" "$REPO/logs/refit_parallel"
+export REPO SPEC_ROOT PIPELINE_FORCE REFIT_PARALLEL_LOG_DIR="$REPO/logs/refit_parallel"
+export OUT WEB_ROOT PY CHUNK_LAYOUT MASK_PRIMARY REPORTS_DIR MIN_POINTS
+export FIT_FORCE FIT_JITTER PIPELINE_UPDATE RUN_HBETA QUERY_GAIA_ONLINE
+export WEBSITE_STARS_DIR DATA_CSV
+
+exec > >(tee -a "$LOG") 2>&1
+echo "=== $(date '+%Y-%m-%dT%H:%M:%S%z') refit_all_per_object_parallel start pid=$$ ==="
+echo "repo=$REPO jobs=$JOBS nice=$NICE_LEVEL pipeline_force=$PIPELINE_FORCE spec_root=$SPEC_ROOT"
+
+STAR_IDS=()
+if [[ -n "$STAR_ID" ]]; then
+  STAR_IDS=("$STAR_ID")
+else
+  while IFS= read -r id; do
+    [[ -n "$id" ]] && STAR_IDS+=("$id")
+  done < <(discover_gaia_star_ids "$SPEC_ROOT")
+fi
+
+if [[ "${#STAR_IDS[@]}" -eq 0 ]]; then
+  echo "[ERROR] No Gaia_DR3_* stars under $SPEC_ROOT" >&2
+  exit 2
+fi
+echo "stars_to_process=${#STAR_IDS[@]}"
+
+worker="$REPO/scripts/lib/refit_one_object.sh"
+chmod +x "$worker"
+
+if ! command -v flock >/dev/null 2>&1 && [[ "$JOBS" -gt 1 ]]; then
+  echo "[ERROR] flock not found — set JOBS=1 or install util-linux flock" >&2
+  exit 2
+fi
+
+n_ok=0
+n_fail=0
+idx=0
+total=${#STAR_IDS[@]}
+
+for gid in "${STAR_IDS[@]}"; do
+  while [[ "$(jobs -rp | wc -l | tr -d ' ')" -ge "$JOBS" ]]; do
+    sleep 2
+  done
+  idx=$((idx + 1))
+  echo "[launch $idx/$total] Gaia_DR3_${gid}"
+  (
+    if nice -n "$NICE_LEVEL" bash "$worker" "$gid"; then
+      echo "[done OK] Gaia_DR3_${gid}"
+      exit 0
+    fi
+    echo "[done FAIL] Gaia_DR3_${gid}"
+    exit 1
+  ) &
+done
+
+while [[ "$(jobs -rp | wc -l | tr -d ' ')" -gt 0 ]]; do
+  if wait -n; then
+    n_ok=$((n_ok + 1))
+  else
+    n_fail=$((n_fail + 1))
+  fi
+done
+
+echo ""
+echo "=== $(date '+%Y-%m-%dT%H:%M:%S%z') refit_all_per_object_parallel done ok=$n_ok failed=$n_fail ==="
+echo "Master log: $LOG"
+echo "Per-star logs: $REPO/logs/refit_parallel/<gaia_id>.log"


### PR DESCRIPTION
## Summary
- `scripts/lib/refit_one_object.sh`: one star = pipeline (subchunks_4 + debias) → Keplerian fit → Hβ → website stage
- `scripts/refit_all_per_object_parallel.sh`: run N workers with `nice`, flock on `data.csv`
- Sequential `refit_all_per_object.sh` now uses the same worker

## Screen on ziggy
```bash
screen -dmS darkhunter_parallel_refit bash -lc '
  REPO=/data2/darkhunter/dark-hunter_rv
  cd "$REPO" && git pull
  JOBS=4 NICE_LEVEL=10 PIPELINE_FORCE=1 FIT_FORCE=1 FIT_JITTER=1 \
    bash scripts/refit_all_per_object_parallel.sh
'
```


Made with [Cursor](https://cursor.com)