### PR TITLE
Fix APF visibility seasons (12° twilight, airmass 1.7, single window)

### DIFF
--- a/darkhunter_rv/apf_observability.py
+++ b/darkhunter_rv/apf_observability.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 from astropy import units as u
@@ -14,21 +14,36 @@ from astropy.time import Time
 from darkhunter_rv.gaia_utils import parse_gaia_metadata_from_star_summary
 from darkhunter_rv.summary_paths import parse_object_id_from_summary
 
-# APF at Lick Observatory (approximate IERS values).
+# APF at Lick Observatory.
 LICK_LOCATION = EarthLocation(lat=37.3413 * u.deg, lon=-121.6438 * u.deg, height=1280 * u.m)
 
-TWILIGHT_SUN_ALT_DEG = -18.0
-MAX_AIRMASS = 2.5
-MIN_OBS_MINUTES = 15
+TWILIGHT_SUN_ALT_DEG = -12.0
+TWILIGHT_BUFFER_MINUTES = 30
+MAX_AIRMASS = 1.7
+MIN_OBS_MINUTES = 30
 STEP_MINUTES = 5
-HORIZON_DAYS = 90
+HORIZON_DAYS = 183  # ~6 months
+PLOT_HORIZON_DAYS = HORIZON_DAYS
+
+
+def _altitude_deg_for_airmass(airmass: float) -> float:
+    if airmass <= 1.0:
+        return 90.0
+    z_rad = float(np.arccos(np.clip(1.0 / airmass, -1.0, 1.0)))
+    return float(90.0 - np.rad2deg(z_rad))
+
+
+ALTITUDE_MIN_DEG = _altitude_deg_for_airmass(MAX_AIRMASS)
 
 
 def _airmass_from_altitude_deg(alt_deg: float) -> float:
     if not np.isfinite(alt_deg) or alt_deg <= 0:
         return float("inf")
     z_rad = np.deg2rad(90.0 - float(alt_deg))
-    return float(1.0 / np.cos(z_rad))
+    cos_z = float(np.cos(z_rad))
+    if cos_z <= 0:
+        return float("inf")
+    return 1.0 / cos_z
 
 
 def _target_coord_from_summary(summary_path: Path) -> Optional[SkyCoord]:
@@ -72,9 +87,195 @@ def _sun_alt_deg(time: Time, location: EarthLocation) -> float:
     return float(sun_aa.alt.deg)
 
 
-def _is_circumpolar_at_lick(coord: SkyCoord) -> bool:
-    """Northern circumpolar at Lick: dec > 90 - lat."""
-    return float(coord.dec.deg) > (90.0 - float(LICK_LOCATION.lat.deg) - 0.05)
+@dataclass
+class NightRecord:
+    """One local night at Lick between 12° twilights."""
+
+    evening_twilight_mjd: float
+    morning_twilight_mjd: float
+    calendar_date: str
+    strict_ok: bool
+    up_during_night: bool
+
+
+def _mjd_to_iso_date(mjd: float) -> str:
+    return Time(float(mjd), format="mjd", scale="utc").datetime.strftime("%Y-%m-%d")
+
+
+def _sun_alts_deg(mjds: np.ndarray) -> np.ndarray:
+    """Vectorized sun altitude (deg) at Lick via ERFA."""
+    import erfa
+
+    out = np.empty(len(mjds), dtype=float)
+    for i, mjd in enumerate(mjds):
+        out[i] = _sun_alt_deg(Time(float(mjd), format="mjd", scale="utc"), LICK_LOCATION)
+    return out
+
+
+def _target_alts_deg(coord: SkyCoord, mjds: np.ndarray) -> np.ndarray:
+    times = Time(mjds, format="mjd", scale="utc")
+    aa = coord.transform_to(AltAz(obstime=times, location=LICK_LOCATION))
+    return np.asarray(aa.alt.deg, dtype=float)
+
+
+def _sample_nights(
+    coord: SkyCoord,
+    start_mjd: float,
+    end_mjd: float,
+) -> List[NightRecord]:
+    """Walk 5-min steps, segment into nautical-twilight nights, evaluate each."""
+    step_days = STEP_MINUTES / (24.0 * 60.0)
+    min_steps = max(1, int(round(MIN_OBS_MINUTES / STEP_MINUTES)))
+    buffer_days = TWILIGHT_BUFFER_MINUTES / (24.0 * 60.0)
+
+    mjds = np.arange(start_mjd, end_mjd + step_days, step_days, dtype=float)
+    if mjds.size == 0:
+        return []
+
+    chunk = 4000
+    sun_alts = np.concatenate(
+        [_sun_alts_deg(mjds[i : i + chunk]) for i in range(0, len(mjds), chunk)]
+    )
+    target_alts = np.concatenate(
+        [_target_alts_deg(coord, mjds[i : i + chunk]) for i in range(0, len(mjds), chunk)]
+    )
+
+    nights: List[NightRecord] = []
+    in_night = False
+    evening_mjd: Optional[float] = None
+    strict_streak = 0
+    strict_ok = False
+    up_during_night = False
+
+    def _close_night(morn_mjd: float) -> None:
+        nonlocal strict_ok, up_during_night, strict_streak
+        if evening_mjd is None:
+            return
+        nights.append(
+            NightRecord(
+                evening_twilight_mjd=evening_mjd,
+                morning_twilight_mjd=morn_mjd,
+                calendar_date=_mjd_to_iso_date(evening_mjd),
+                strict_ok=strict_ok,
+                up_during_night=up_during_night,
+            )
+        )
+        strict_ok = False
+        up_during_night = False
+        strict_streak = 0
+
+    for i in range(len(mjds)):
+        t = float(mjds[i])
+        sun_alt = float(sun_alts[i])
+        target_alt = float(target_alts[i])
+        prev_sun = float(sun_alts[i - 1]) if i > 0 else sun_alt + 1.0
+        am = _airmass_from_altitude_deg(target_alt)
+
+        if not in_night and prev_sun > TWILIGHT_SUN_ALT_DEG >= sun_alt:
+            in_night = True
+            evening_mjd = t
+            strict_ok = False
+            up_during_night = False
+            strict_streak = 0
+
+        if in_night:
+            if sun_alt < 0.0 and target_alt > 0.0:
+                up_during_night = True
+
+            in_extended = evening_mjd is not None and t >= evening_mjd - buffer_days
+            if in_extended and np.isfinite(am) and am <= MAX_AIRMASS:
+                strict_streak += 1
+                if strict_streak >= min_steps:
+                    strict_ok = True
+            else:
+                strict_streak = 0
+
+            if prev_sun <= TWILIGHT_SUN_ALT_DEG < sun_alt:
+                _close_night(t)
+                in_night = False
+                evening_mjd = None
+
+    return nights
+
+
+def _is_circumpolar_for_apf(
+    coord: SkyCoord,
+    start_mjd: float,
+    end_mjd: float,
+) -> bool:
+    """
+    True only when the target stays above the airmass-1.7 limit whenever the
+    sun is below 12° twilight (observable every night at APF elevations).
+    """
+    step_days = 15.0 / (24.0 * 60.0)  # coarser grid for classification only
+    mjds = np.arange(start_mjd, end_mjd + step_days, step_days, dtype=float)
+    if mjds.size == 0:
+        return False
+    sun_alts = _sun_alts_deg(mjds)
+    night_mask = sun_alts <= TWILIGHT_SUN_ALT_DEG
+    if not np.any(night_mask):
+        return False
+    target_alts = _target_alts_deg(coord, mjds[night_mask])
+    min_alt = float(np.nanmin(target_alts))
+    return min_alt >= ALTITUDE_MIN_DEG - 0.5
+
+
+def _find_season_window(
+    nights: List[NightRecord],
+    today_mjd: float,
+) -> Optional[Tuple[str, str, float, float]]:
+    """
+    Return (start_date, end_date, start_mjd, end_mjd) for the current or next season.
+
+    A season is a contiguous block of nights when the target is up during the night.
+    The first night of a block must pass the strict twilight/airmass test; interior
+    nights only need to be above the horizon at some point during nautical night.
+    """
+    if not nights:
+        return None
+
+    runs: List[List[NightRecord]] = []
+    current: List[NightRecord] = []
+
+    for night in nights:
+        if not current:
+            if night.strict_ok:
+                current = [night]
+        elif night.up_during_night:
+            current.append(night)
+        else:
+            runs.append(current)
+            current = []
+            if night.strict_ok:
+                current = [night]
+
+    if current:
+        runs.append(current)
+
+    if not runs:
+        return None
+
+    def _run_span(run: List[NightRecord]) -> Tuple[str, str, float, float]:
+        start = run[0]
+        end = run[-1]
+        return (
+            start.calendar_date,
+            end.calendar_date,
+            start.evening_twilight_mjd,
+            end.morning_twilight_mjd,
+        )
+
+    # Prefer season containing today; else next season; else last season.
+    for run in runs:
+        start_mjd, end_mjd = run[0].evening_twilight_mjd, run[-1].morning_twilight_mjd
+        if start_mjd <= today_mjd <= end_mjd + 1.0:
+            return _run_span(run)
+
+    for run in runs:
+        if run[0].evening_twilight_mjd >= today_mjd - 1.0:
+            return _run_span(run)
+
+    return _run_span(runs[-1])
 
 
 @dataclass
@@ -93,29 +294,6 @@ class ObsWindow:
         }
 
 
-def _mjd_to_iso_date(mjd: float) -> str:
-    return Time(float(mjd), format="mjd", scale="utc").datetime.strftime("%Y-%m-%d")
-
-
-def _merge_windows(windows: List[ObsWindow], *, gap_days: float = 1.5) -> List[ObsWindow]:
-    if not windows:
-        return []
-    ordered = sorted(windows, key=lambda w: w.start_mjd)
-    merged: List[ObsWindow] = [ordered[0]]
-    for w in ordered[1:]:
-        prev = merged[-1]
-        if w.start_mjd - prev.end_mjd <= gap_days:
-            merged[-1] = ObsWindow(
-                start_mjd=prev.start_mjd,
-                end_mjd=max(prev.end_mjd, w.end_mjd),
-                start_date=prev.start_date,
-                end_date=w.end_date,
-            )
-        else:
-            merged.append(w)
-    return merged
-
-
 def compute_apf_observability(
     coord: SkyCoord,
     *,
@@ -123,77 +301,40 @@ def compute_apf_observability(
     horizon_days: int = HORIZON_DAYS,
 ) -> Dict[str, Any]:
     """
-    Find APF-visible intervals within horizon_days of start_mjd.
+    APF visibility season at Lick.
 
-    Observable when target airmass <= 2.5 for >= 15 minutes after astronomical twilight (-18°).
+    - Nautical twilight (-12°); target airmass ≤ 1.7 for ≥30 min within ±30 min of twilight
+      defines season entry (rising near sunrise) and quality on boundary nights.
+    - Between season start and end, any night the target is above the horizon counts.
+    - One window: next/current season start → when the target sets out of the window.
+    - Circumpolar: target stays above airmass 1.7 all nautical nights (very high dec).
     """
     now_mjd = float(Time.now().mjd) if start_mjd is None else float(start_mjd)
-    end_mjd = now_mjd + float(horizon_days)
+    plot_end_mjd = now_mjd + float(min(horizon_days, PLOT_HORIZON_DAYS))
+    scan_end_mjd = plot_end_mjd + 1.0
 
-    if _is_circumpolar_at_lick(coord):
-        start_date = _mjd_to_iso_date(now_mjd)
-        end_date = _mjd_to_iso_date(end_mjd)
-        win = ObsWindow(now_mjd, end_mjd, start_date, end_date)
+    if _is_circumpolar_for_apf(coord, now_mjd, scan_end_mjd):
+        win = ObsWindow(now_mjd, plot_end_mjd, "", "")
         return {
             "circumpolar": True,
             "windows": [win.to_dict()],
-            "next_window_start_date": start_date,
-            "next_window_end_date": end_date,
+            "next_window_start_date": "",
+            "next_window_end_date": "",
         }
 
-    step_days = STEP_MINUTES / (24.0 * 60.0)
-    min_steps = max(1, int(round(MIN_OBS_MINUTES / STEP_MINUTES)))
-    windows: List[ObsWindow] = []
-    t = now_mjd
-    run_start: Optional[float] = None
-    run_end: Optional[float] = None
-    streak = 0
-    night_active = False
+    nights = _sample_nights(coord, now_mjd - 2.0, scan_end_mjd)
+    season = _find_season_window(nights, now_mjd)
 
-    while t <= end_mjd + step_days:
-        time = Time(t, format="mjd", scale="utc")
-        sun_alt = _sun_alt_deg(time, LICK_LOCATION)
-        in_night = sun_alt <= TWILIGHT_SUN_ALT_DEG
-
-        observable = False
-        if in_night:
-            target_aa = coord.transform_to(AltAz(obstime=time, location=LICK_LOCATION))
-            am = _airmass_from_altitude_deg(float(target_aa.alt.deg))
-            observable = np.isfinite(am) and am <= MAX_AIRMASS
-
-        if in_night and observable:
-            if run_start is None:
-                run_start = t
-            streak += 1
-            run_end = t
-            night_active = True
-        else:
-            if night_active and run_start is not None and run_end is not None and streak >= min_steps:
-                windows.append(
-                    ObsWindow(
-                        start_mjd=run_start,
-                        end_mjd=run_end + step_days,
-                        start_date=_mjd_to_iso_date(run_start),
-                        end_date=_mjd_to_iso_date(run_end),
-                    )
-                )
-            run_start = None
-            run_end = None
-            streak = 0
-            night_active = False
-        t += step_days
-
-    merged = _merge_windows(windows)
-    if not merged:
+    if season is None:
         return {"circumpolar": False, "windows": []}
 
-    first = merged[0]
-    last = merged[-1]
+    start_date, end_date, start_mjd_win, end_mjd_win = season
+    win = ObsWindow(start_mjd_win, end_mjd_win, start_date, end_date)
     return {
         "circumpolar": False,
-        "windows": [w.to_dict() for w in merged],
-        "next_window_start_date": first.start_date,
-        "next_window_end_date": last.end_date,
+        "windows": [win.to_dict()],
+        "next_window_start_date": start_date,
+        "next_window_end_date": end_date,
     }
 
 
@@ -203,7 +344,7 @@ def observability_for_summary(summary_path: Path) -> Optional[Dict[str, Any]]:
     if sid is None or coord is None:
         return None
     result = compute_apf_observability(coord)
-    if not result.get("windows"):
+    if not result.get("windows") and not result.get("circumpolar"):
         return None
     result["gaia_source_id"] = sid
     return result

--- a/darkhunter_rv/rv_keplerian_plots.py
+++ b/darkhunter_rv/rv_keplerian_plots.py
@@ -106,9 +106,22 @@ def _observability_windows(report: dict) -> List[dict]:
         return []
     windows = obs_win.get("windows")
     if isinstance(windows, list) and windows:
-        return [w for w in windows if isinstance(w, dict) and w.get("start_date") and w.get("end_date")]
+        out: List[dict] = []
+        for w in windows:
+            if not isinstance(w, dict):
+                continue
+            if w.get("start_date") and w.get("end_date"):
+                out.append(w)
+            elif w.get("start_mjd") is not None and w.get("end_mjd") is not None:
+                out.append(w)
+        if out:
+            return out
     if obs_win.get("start_date") and obs_win.get("end_date"):
         return [obs_win]
+    if obs_win.get("circumpolar") and isinstance(windows, list) and windows:
+        w0 = windows[0]
+        if isinstance(w0, dict) and w0.get("start_mjd") is not None:
+            return [w0]
     return []
 
 
@@ -123,8 +136,12 @@ def _observability_span(report: dict) -> Tuple[Optional[float], Optional[float],
     ends: List[float] = []
     for w in windows:
         try:
-            starts.append(float(Time(w["start_date"], format="iso", scale="utc").mjd))
-            ends.append(float(Time(w["end_date"], format="iso", scale="utc").mjd) + 1.0)
+            if w.get("start_mjd") is not None and w.get("end_mjd") is not None:
+                starts.append(float(w["start_mjd"]))
+                ends.append(float(w["end_mjd"]) + 1.0)
+            elif w.get("start_date") and w.get("end_date"):
+                starts.append(float(Time(w["start_date"], format="iso", scale="utc").mjd))
+                ends.append(float(Time(w["end_date"], format="iso", scale="utc").mjd) + 1.0)
         except Exception:
             continue
     if not starts or not ends:
@@ -146,24 +163,33 @@ def _shade_apf_window(
     windows = _observability_windows(report)
     if not windows:
         return
+    now_mjd = float(report.get("now_mjd", Time.now().mjd))
+    plot_cap_mjd = now_mjd + 183.0
     label_parts: List[str] = []
     for w in windows:
         try:
-            obs_start = float(Time(w["start_date"], format="iso", scale="utc").mjd)
-            obs_end = float(Time(w["end_date"], format="iso", scale="utc").mjd) + 1.0
+            if w.get("start_mjd") is not None and w.get("end_mjd") is not None:
+                obs_start = float(w["start_mjd"])
+                obs_end = float(w["end_mjd"]) + 1.0
+            else:
+                obs_start = float(Time(w["start_date"], format="iso", scale="utc").mjd)
+                obs_end = float(Time(w["end_date"], format="iso", scale="utc").mjd) + 1.0
         except Exception:
             continue
         left = max(t_start, obs_start)
-        right = min(t_end, obs_end)
+        right = min(t_end, obs_end, plot_cap_mjd)
         if right <= left:
             continue
         ax.axvspan(left, right, color="tab:blue", alpha=0.12, zorder=0)
-        label_parts.append(f"{w['start_date']} to {w['end_date']}")
-    if annotate and label_parts:
+        if w.get("start_date") and w.get("end_date"):
+            label_parts.append(f"{w['start_date']} to {w['end_date']}")
+    msg = ""
+    if annotate:
         if obs_win.get("circumpolar"):
-            msg = "Circumpolar (airmass ≤ 2.5): " + "; ".join(label_parts[:2])
-        else:
-            msg = "APF window " + "; ".join(label_parts[:3])
+            msg = f"Circumpolar (airmass ≤ 1.7, next {int(plot_cap_mjd - now_mjd)} d)"
+        elif label_parts:
+            msg = "APF window " + label_parts[0]
+    if annotate and msg:
         ax.text(
             0.985,
             0.02,

--- a/docs/website.md
+++ b/docs/website.md
@@ -82,7 +82,7 @@ Ensure Apache serves `/var/www/html/darkhunter/rv/` (existing `Alias` or symlink
 | **(M2sin i)/(sin i) (Msun)** | Same f(M) and M1 with Gaia astrometric inclination |
 | **INCLINATION (deg)** | Astrometric i used for M2 at i (from Gaia NSS or derived from Thiele-Innes A,B,F,G when the database field is empty; empty if unknown or edge-on) |
 
-**RV fit plots:** blue shaded regions mark APF visibility at Lick (airmass ≤ 2.5 for ≥15 min after −18° twilight, out to 3 months). Built via `scripts/build_apf_observability_cache.py` and stored in `rv_fit_reports/observability_windows_cache.json`. Circumpolar targets are annotated on the plot.
+**RV fit plots:** blue shaded regions mark the current APF visibility season at Lick (nautical twilight −12°; airmass ≤ 1.7 for ≥30 min within ±30 min of twilight at season boundaries; interior nights when the target is up at all). One window per target, plotted out to 6 months. Built via `scripts/build_apf_observability_cache.py` and stored in `rv_fit_reports/observability_windows_cache.json`. Very high-declination circumpolar targets are annotated without date labels.
 
 ## Three commands (ziggy)
 

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -187,6 +187,11 @@ def load_observability_window(source_id: Optional[str], cache_path: Optional[Pat
             "windows": windows,
             "circumpolar": circumpolar,
         }
+        if circumpolar:
+            w0 = windows[0] if isinstance(windows[0], dict) else {}
+            out["start_date"] = w0.get("start_date", "") or ""
+            out["end_date"] = w0.get("end_date", "") or ""
+            return out
         if isinstance(s, str) and s and isinstance(e, str) and e:
             out["start_date"] = s
             out["end_date"] = e

--- a/tests/test_apf_observability.py
+++ b/tests/test_apf_observability.py
@@ -3,21 +3,45 @@ import pytest
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 
-from darkhunter_rv.apf_observability import compute_apf_observability
+from darkhunter_rv.apf_observability import (
+    ALTITUDE_MIN_DEG,
+    HORIZON_DAYS,
+    _is_circumpolar_for_apf,
+    compute_apf_observability,
+)
 
 
-def test_circumpolar_target_has_flag_and_window() -> None:
-    # Dec well above Lick latitude → circumpolar at APF.
-    coord = SkyCoord(ra=180.0 * u.deg, dec=70.0 * u.deg, frame="icrs")
+def test_circumpolar_requires_very_high_dec() -> None:
+    # Dec 70° is geometrically circumpolar at Lick but not at airmass 1.7 all night.
+    coord70 = SkyCoord(ra=180.0 * u.deg, dec=70.0 * u.deg, frame="icrs")
+    assert not _is_circumpolar_for_apf(coord70, 60000.0, 60000.0 + HORIZON_DAYS)
+
+    coord89 = SkyCoord(ra=180.0 * u.deg, dec=89.0 * u.deg, frame="icrs")
+    assert _is_circumpolar_for_apf(coord89, 60000.0, 60000.0 + 30)
+
+
+def test_circumpolar_output_has_no_dates() -> None:
+    coord = SkyCoord(ra=180.0 * u.deg, dec=89.0 * u.deg, frame="icrs")
     out = compute_apf_observability(coord, start_mjd=60000.0, horizon_days=30)
     assert out["circumpolar"] is True
     assert out["windows"]
-    assert out["next_window_start_date"]
-    assert out["next_window_end_date"]
+    assert out["next_window_start_date"] == ""
+    assert out["next_window_end_date"] == ""
 
 
-def test_mid_latitude_can_yield_windows_or_empty() -> None:
+def test_mid_latitude_single_season_window() -> None:
     coord = SkyCoord(ra=120.0 * u.deg, dec=20.0 * u.deg, frame="icrs")
     out = compute_apf_observability(coord, start_mjd=60000.0, horizon_days=90)
     assert out["circumpolar"] is False
-    assert "windows" in out
+    if out["windows"]:
+        assert len(out["windows"]) == 1
+        w = out["windows"][0]
+        assert w["start_date"] <= w["end_date"]
+        assert w["end_mjd"] > w["start_mjd"]
+
+
+def test_airmass_limit_is_17() -> None:
+    from darkhunter_rv.apf_observability import MAX_AIRMASS
+
+    assert MAX_AIRMASS == pytest.approx(1.7)
+    assert ALTITUDE_MIN_DEG == pytest.approx(36.3, abs=0.5)

--- a/tests/validation/test_chunk_measurement_cache.py
+++ b/tests/validation/test_chunk_measurement_cache.py
@@ -1,0 +1,77 @@
+"""Tests for chunk campaign measurement cache deduplication."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from validation.chunk_layout import build_edge_preset_layout, build_equal_subchunk_layout
+from validation.chunk_measurement_cache import (
+    CACHE_COLUMNS,
+    find_cache_layout_collisions,
+    ingest_diagnostics_csv,
+    rebuild_cache_from_diagnostics,
+)
+
+
+def _write_mini_diagnostics(path: Path, *, file_label: str, chunk_key: str, rv: float) -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "file": file_label,
+                "chunk_key": chunk_key,
+                "method": "mask_ccf",
+                "rv_kms": rv,
+                "rv_err_kms": 0.1,
+                "mjd": 60000.0,
+                "teff": 5500.0,
+                "qc_pass": True,
+            }
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+
+
+def test_ingest_keeps_subchunks_3_and_n3_equal_separately(tmp_path: Path) -> None:
+    """subchunks_3 and n3_equal share equal pixel edges but must not clobber each other."""
+    layout_a = build_equal_subchunk_layout(3)
+    layout_b = build_edge_preset_layout(3, "equal")
+    assert layout_a.name == "subchunks_3"
+    assert layout_b.name == "n3_equal"
+
+    diag_a = tmp_path / "diagnostics" / "subchunks_3" / "Gaia_DR3_1_epoch_1_diagnostics.csv"
+    diag_b = tmp_path / "diagnostics" / "n3_equal" / "Gaia_DR3_1_epoch_1_diagnostics.csv"
+    _write_mini_diagnostics(diag_a, file_label="/data/epoch_1.txt", chunk_key="9_0", rv=10.0)
+    _write_mini_diagnostics(diag_b, file_label="/data/epoch_1.txt", chunk_key="9_0", rv=20.0)
+
+    cache = pd.DataFrame(columns=CACHE_COLUMNS)
+    cache = ingest_diagnostics_csv(diag_a, layout=layout_a, cache=cache)
+    cache = ingest_diagnostics_csv(diag_b, layout=layout_b, cache=cache)
+
+    assert len(cache) == 2
+    by_layout = cache.set_index("layout_name")["rv_kms"].to_dict()
+    assert by_layout["subchunks_3"] == 10.0
+    assert by_layout["n3_equal"] == 20.0
+    # Same measurement_id under two layouts is expected (equal edges, distinct layout_name).
+    shared = find_cache_layout_collisions(cache)
+    assert len(shared) == 1
+    assert set(shared.iloc[0]["layout_names"]) == {"n3_equal", "subchunks_3"}
+
+
+def test_rebuild_cache_from_diagnostics(tmp_path: Path) -> None:
+    from validation.chunk_layout import save_chunk_layout
+
+    layout = build_equal_subchunk_layout(2)
+    save_chunk_layout(layout, tmp_path / "layouts" / "subchunks_2.yaml")
+    _write_mini_diagnostics(
+        tmp_path / "diagnostics" / "subchunks_2" / "Gaia_DR3_99_epoch_1_diagnostics.csv",
+        file_label="/data/epoch_1.txt",
+        chunk_key="12_0",
+        rv=5.0,
+    )
+    cache = rebuild_cache_from_diagnostics(tmp_path)
+    assert len(cache) == 1
+    assert cache.iloc[0]["layout_name"] == "subchunks_2"
+    assert cache.iloc[0]["rv_kms"] == 5.0

--- a/validation/chunk_adaptive_stack.py
+++ b/validation/chunk_adaptive_stack.py
@@ -68,7 +68,6 @@ PER_ORDER_LAYOUTS = (
     "subchunks_2",
     "subchunks_3",
     "subchunks_4",
-    "n3_equal",
     "n3_red_heavy",
     "n3_blue_heavy",
 )

--- a/validation/chunk_campaign.py
+++ b/validation/chunk_campaign.py
@@ -41,9 +41,12 @@ from validation.chunk_layout import (  # noqa: E402
 )
 from validation.chunk_measurement_cache import (  # noqa: E402
     diagnostics_glob_for_layout,
+    drop_layout_from_cache,
+    find_cache_layout_collisions,
     ingest_layout_diagnostics_dir,
     layout_files_complete,
     load_cache,
+    rebuild_cache_from_diagnostics,
     save_cache,
 )
 from validation.evaluate_chunk_layout import evaluate_layouts_from_glob  # noqa: E402
@@ -186,7 +189,7 @@ def write_next_steps(path: Path, *, best: pd.Series | None, stage_b_best: pd.Ser
         "- Broad grid: split N=2,3,4 and merge W=2,3,4 (full pipeline)",
         "- Edge presets: equal, blue-heavy, red-heavy, telluric-aware",
         "- Stage B coordinate-descent edge candidates",
-        "- Measurement cache: `measurement_cache.csv` (dedupe by measurement_id + file)",
+        "- Measurement cache: `measurement_cache.csv` (dedupe by layout_name + measurement_id + file)",
         "",
         "## Best layouts so far",
     ]
@@ -231,6 +234,8 @@ def run_campaign(
     edge_n_chunks: int,
     run_stage_b: bool,
     skip_pipeline_if_cached: bool,
+    only_layouts: list[str] | None = None,
+    force_layouts: set[str] | None = None,
 ) -> pd.DataFrame:
     campaign_dir.mkdir(parents=True, exist_ok=True)
     cache_path = campaign_dir / CACHE_NAME
@@ -247,10 +252,25 @@ def run_campaign(
             unique_layouts.append(lay)
             seen.add(lay.name)
 
+    if only_layouts:
+        want = set(only_layouts)
+        unique_layouts = [lay for lay in unique_layouts if lay.name in want]
+        if not unique_layouts:
+            logger.error("No layouts matched --only-layouts %s", sorted(want))
+            return pd.DataFrame()
+
+    force_layouts = force_layouts or set()
+
+    for layout in unique_layouts:
+        save_chunk_layout(layout, campaign_dir / "layouts" / f"{layout.name}.yaml")
+
     if run_pipeline:
         for layout in unique_layouts:
+            if layout.name in force_layouts:
+                cache = drop_layout_from_cache(cache, layout.name)
+                save_cache(cache, cache_path)
             todo = spectrum_files
-            if skip_pipeline_if_cached:
+            if skip_pipeline_if_cached and layout.name not in force_layouts:
                 done = layout_files_complete(cache, layout_name=layout.name, spectrum_files=spectrum_files)
                 todo = [f for f in spectrum_files if f not in done]
             if not todo:
@@ -366,10 +386,59 @@ def main() -> None:
     ap.add_argument("--run-stage-b", action="store_true", default=True)
     ap.add_argument("--no-stage-b", action="store_false", dest="run_stage_b")
     ap.add_argument("--skip-pipeline-if-cached", action="store_true", default=True)
+    ap.add_argument(
+        "--no-skip-pipeline-if-cached",
+        action="store_false",
+        dest="skip_pipeline_if_cached",
+        help="Re-run pipeline for every spectrum in each layout (ignore cache completeness).",
+    )
+    ap.add_argument(
+        "--only-layouts",
+        default="",
+        help="Comma-separated layout names to run/evaluate (default: full campaign grid).",
+    )
+    ap.add_argument(
+        "--force-layouts",
+        default="",
+        help="Comma-separated layouts to re-pipeline even if cached (drops their cache rows first).",
+    )
+    ap.add_argument(
+        "--repair-cache",
+        action="store_true",
+        help="Rebuild measurement_cache.csv from diagnostics/*/ on disk, then exit unless --run-pipeline.",
+    )
+    ap.add_argument(
+        "--repair-cache-layouts",
+        default="",
+        help="With --repair-cache: only rebuild these layouts (comma-separated); default all under layouts/.",
+    )
     ap.add_argument("--log-level", default="INFO")
     args = ap.parse_args()
     logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
     args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    cache_path = args.out_dir / CACHE_NAME
+    if args.repair_cache:
+        repair_layouts = [x.strip() for x in args.repair_cache_layouts.split(",") if x.strip()] or None
+        cache = rebuild_cache_from_diagnostics(args.out_dir, layout_names=repair_layouts)
+        save_cache(cache, cache_path)
+        collisions = find_cache_layout_collisions(cache)
+        logger.info(
+            "Rebuilt cache -> %s (%d rows, %d layout(s))",
+            cache_path,
+            len(cache),
+            cache["layout_name"].nunique() if len(cache) else 0,
+        )
+        if len(collisions):
+            logger.warning(
+                "Cross-layout cache collisions (same measurement_id+file, multiple layouts): %d",
+                len(collisions),
+            )
+        if not args.run_pipeline:
+            return
+
+    only_layouts = [x.strip() for x in args.only_layouts.split(",") if x.strip()] or None
+    force_layouts = {x.strip() for x in args.force_layouts.split(",") if x.strip()} or None
 
     list_path = args.spectrum_list or (args.out_dir / "spectrum_list.txt")
     if list_path.is_file():
@@ -389,6 +458,8 @@ def main() -> None:
         edge_n_chunks=args.edge_n_chunks,
         run_stage_b=args.run_stage_b,
         skip_pipeline_if_cached=args.skip_pipeline_if_cached,
+        only_layouts=only_layouts,
+        force_layouts=force_layouts,
     )
     logger.info("Campaign done -> %s", args.out_dir)
 

--- a/validation/chunk_layout.py
+++ b/validation/chunk_layout.py
@@ -85,8 +85,12 @@ def build_campaign_broad_grid() -> list[ChunkLayout]:
 
 
 def build_campaign_edge_grid(n_chunks: int = 3) -> list[ChunkLayout]:
-    """Edge preset variants after broad grid."""
-    presets = ("equal", "blue_heavy", "red_heavy", "telluric")
+    """
+    Edge preset variants after broad grid.
+
+    Omits ``equal`` — same pixel edges as ``subchunks_{n}`` from :func:`build_campaign_broad_grid`.
+    """
+    presets = ("blue_heavy", "red_heavy", "telluric")
     return [build_edge_preset_layout(n_chunks, p) for p in presets]
 
 

--- a/validation/chunk_measurement_cache.py
+++ b/validation/chunk_measurement_cache.py
@@ -95,7 +95,11 @@ def ingest_diagnostics_csv(
         return cache
     new_df = pd.DataFrame(rows)
     combined = pd.concat([cache, new_df], ignore_index=True)
-    combined = combined.drop_duplicates(subset=["measurement_id", "file"], keep="last")
+    # layout_name required: subchunks_3 and n3_equal share identical pixel edges → same measurement_id.
+    combined = combined.drop_duplicates(
+        subset=["layout_name", "measurement_id", "file"],
+        keep="last",
+    )
     return combined[CACHE_COLUMNS]
 
 
@@ -136,3 +140,58 @@ def layout_files_complete(
 def diagnostics_glob_for_layout(campaign_dir: Path, layout_name: str) -> str:
     d = campaign_dir / "diagnostics" / layout_name
     return str(d / "Gaia_DR3_*_diagnostics.csv")
+
+
+def drop_layout_from_cache(cache: pd.DataFrame, layout_name: str) -> pd.DataFrame:
+    """Remove all cache rows for one layout (before forced re-pipeline)."""
+    if cache.empty:
+        return cache
+    return cache[cache["layout_name"].astype(str) != str(layout_name)].reset_index(drop=True)
+
+
+def find_cache_layout_collisions(cache: pd.DataFrame) -> pd.DataFrame:
+    """
+    (measurement_id, file) keys present under more than one layout_name.
+
+    After the dedup fix this is normal when layouts share pixel edges (e.g. subchunks_3 vs n3_equal).
+    Use to audit cache coverage, not as an error flag.
+    """
+    if cache.empty:
+        return pd.DataFrame(columns=["measurement_id", "file", "layout_names", "n_layouts"])
+    grp = (
+        cache.groupby(["measurement_id", "file"], as_index=False)["layout_name"]
+        .agg(lambda s: sorted(set(str(x) for x in s.astype(str))))
+        .rename(columns={"layout_name": "layout_names"})
+    )
+    grp["n_layouts"] = grp["layout_names"].apply(len)
+    return grp[grp["n_layouts"] > 1].reset_index(drop=True)
+
+
+def rebuild_cache_from_diagnostics(
+    campaign_dir: Path,
+    *,
+    layout_names: list[str] | None = None,
+) -> pd.DataFrame:
+    """
+    Rebuild measurement_cache.csv from on-disk diagnostics/* directories.
+
+    Use after cache clobber (e.g. subchunks_3 rows replaced by n3_equal) when diagnostics
+    trees are still intact per layout.
+    """
+    from validation.chunk_layout import load_chunk_layout
+
+    campaign_dir = Path(campaign_dir)
+    layouts_dir = campaign_dir / "layouts"
+    cache = pd.DataFrame(columns=CACHE_COLUMNS)
+    if not layouts_dir.is_dir():
+        return cache
+    want = set(layout_names) if layout_names else None
+    for yaml_path in sorted(layouts_dir.glob("*.yaml")):
+        layout = load_chunk_layout(yaml_path)
+        if want is not None and layout.name not in want:
+            continue
+        diag_dir = campaign_dir / "diagnostics" / layout.name
+        if not diag_dir.is_dir():
+            continue
+        cache = ingest_layout_diagnostics_dir(diag_dir, layout=layout, cache=cache)
+    return cache


### PR DESCRIPTION
## Summary

Fixes incorrect APF shading where nearly all targets showed the same window starting today and many non-circumpolar stars were labeled circumpolar.

**New logic (Lick Observatory):**
- Nautical twilight at **−12°** (not −18°)
- **Airmass ≤ 1.7** for **≥30 minutes** within **±30 min** of twilight at season entry/boundary nights
- **Season window**: first qualifying night (rising near sunrise) through last night the target is up during nautical night (setting near sunset); interior nights count if the target is above the horizon at any point
- **One window** per target for plots/cache
- **Circumpolar** only when the target stays above the airmass-1.7 altitude whenever the sun is below −12° (very high declination; dec≈70° is no longer flagged)
- Plots shade up to **6 months**; circumpolar annotation has **no dates**

## Test plan

- [x] `pytest tests/test_apf_observability.py`
- [ ] Rebuild cache + refit on ziggy; spot-check southern vs high-dec targets

## Ziggy after merge

```bash
cd /data2/darkhunter/dark-hunter_rv && git pull
PYTHONPATH=. python3 scripts/build_apf_observability_cache.py \
  --data-csv /var/www/html/darkhunter/rv/tables/data.csv \
  --output-dir /data2/darkhunter/dark-hunter_rv/output
FIT_FORCE=1 MIN_POINTS=5 bash scripts/batch_fits_plots_sync.sh
```


Made with [Cursor](https://cursor.com)