### PR TITLE
Always build RV data plots from summaries

### DIFF
--- a/docs/website.md
+++ b/docs/website.md
@@ -51,7 +51,7 @@ Ensure Apache serves `/var/www/html/darkhunter/rv/` (existing `Alias` or symlink
 
 ## Populate / refresh star assets
 
-`populate_website.sh` runs Keplerian fits (pipeline + literature epochs, excluding legacy sentinels such as −9999 km/s), writes:
+`populate_website.sh` runs Keplerian fits (pipeline + literature epochs, excluding legacy sentinels such as −9999 km/s). The **RV Curve** plot (`*_rv_plot.png`) is always built from the summary via `scripts/plot_rv_from_summaries.py`, including when the Keplerian fit is skipped or fails. Writes:
 
 | File | Description |
 |------|-------------|
@@ -150,6 +150,13 @@ Plots/staging only (no refit):
 ```bash
 WEB_ROOT=/var/www/html/darkhunter/rv RUN_FITS=0 RUN_RV_PLOTS=1 MIN_POINTS=5 \
   bash scripts/populate_website.sh
+```
+
+Audit missing summaries / RV data plots / fits:
+
+```bash
+cd /data2/darkhunter/dark-hunter_rv
+PYTHONPATH=. python3 scripts/audit_pipeline_coverage.py --only-issues
 ```
 
 **Symptoms without a full deploy:** RV thumbnails under **M2 sin i** (stray `<img>` in `data.csv`), correct RV plots only in **RV Curve** (new `script.js`), no **H-beta** (PNGs missing or not built).

--- a/scripts/audit_pipeline_coverage.py
+++ b/scripts/audit_pipeline_coverage.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Report gaps between spectra, summaries, Keplerian fits, and website RV assets."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+from darkhunter_rv.rv_keplerian_plots import our_telescope_points
+from darkhunter_rv.summary_paths import (
+    count_pipeline_rows,
+    discover_summary_files,
+    discover_summary_path,
+    parse_object_id_from_summary,
+)
+from darkhunter_rv.website_table_csv import gaia_id_from_row
+from fit_apf_rv_keplerian import parse_summary
+
+MIN_RV_PLOT_POINTS = 2
+
+
+def _discover_spectra(spec_root: Path) -> dict[str, int]:
+    """Gaia id -> spectrum file count under SPEC_ROOT."""
+    counts: dict[str, int] = {}
+    if not spec_root.is_dir():
+        return counts
+    patterns = (
+        "Gaia_DR3_*_epoch_*.txt",
+        "Gaia_DR3_*_*_ap1.flm",
+        "Gaia_DR3_*_*_ap1.txt",
+    )
+    for pat in patterns:
+        for p in spec_root.rglob(pat):
+            if not p.is_file():
+                continue
+            stem = p.name
+            if stem.startswith("Gaia_DR3_"):
+                parts = stem.split("_")
+                if len(parts) >= 3 and parts[1] == "DR3":
+                    gid = parts[2]
+                    if gid.isdigit():
+                        counts[gid] = counts.get(gid, 0) + 1
+    return counts
+
+
+def _table_gaia_ids(data_csv: Path) -> list[str]:
+    if not data_csv.is_file():
+        return []
+    with data_csv.open(newline="", encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+    if not rows or "GAIA NAME" not in rows[0]:
+        return []
+    i = rows[0].index("GAIA NAME")
+    out: list[str] = []
+    for r in rows[1:]:
+        if not r:
+            continue
+        gid = gaia_id_from_row(r[i] if i < len(r) else "")
+        if gid:
+            out.append(gid)
+    return out
+
+
+def _audit_one(
+    gid: str,
+    *,
+    spec_counts: dict[str, int],
+    out_dir: Path,
+    reports_dir: Path,
+    web_root: Path,
+    min_points: int,
+) -> dict[str, str]:
+    n_spec = spec_counts.get(gid, 0)
+    summ = discover_summary_path(out_dir, gid)
+    summ_flat = out_dir / f"Gaia_DR3_{gid}_summary.txt"
+    has_summary = summ is not None and summ.is_file()
+    n_rows = count_pipeline_rows(summ) if has_summary and summ else 0
+    n_finite = 0
+    n_plot_points = 0
+    if has_summary and summ:
+        try:
+            parsed = parse_summary(summ)
+            n_finite = len(parsed)
+            n_plot_points = len(our_telescope_points(parsed))
+        except Exception:
+            n_finite = 0
+            n_plot_points = 0
+
+    fit_json = reports_dir / f"{gid}_keplerian_fit.json"
+    fit_png = reports_dir / f"{gid}_keplerian_fit.png"
+    rv_plot = out_dir / f"Gaia_DR3_{gid}" / f"Gaia_DR3_{gid}_rv_plot.png"
+    web_fit = web_root / "stars" / f"Gaia_DR3_{gid}" / "Gaia" / "RV_Fit" / f"{gid}_keplerian_fit.png"
+    web_rv_plot = (
+        web_root / "stars" / f"Gaia_DR3_{gid}" / "Gaia" / "Plots" / f"Gaia_DR3_{gid}_rv_plot.png"
+    )
+    web_summ = web_root / "stars" / f"Gaia_DR3_{gid}" / "Gaia" / f"{gid}_summary.txt"
+
+    issues: list[str] = []
+    if n_spec == 0:
+        issues.append("no_spectra")
+    if not has_summary:
+        issues.append("no_summary")
+    elif summ and summ.resolve() != summ_flat.resolve() and not summ_flat.is_file():
+        issues.append("summary_nested_only")
+    if has_summary and n_finite < min_points:
+        issues.append(f"few_rv_points({n_finite}<{min_points})")
+    if has_summary and n_finite >= min_points and not fit_json.is_file():
+        issues.append("no_fit_json")
+    if has_summary and not fit_png.is_file():
+        issues.append("no_fit_png")
+    if has_summary and n_plot_points >= MIN_RV_PLOT_POINTS and not rv_plot.is_file():
+        issues.append("no_rv_data_plot")
+    if web_summ.is_file() and not web_rv_plot.is_file() and n_plot_points >= MIN_RV_PLOT_POINTS:
+        issues.append("website_summary_no_rv_plot")
+    if web_summ.is_file() and not web_fit.is_file():
+        issues.append("website_summary_no_rv_fit")
+
+    return {
+        "gaia_id": gid,
+        "n_spectra": str(n_spec),
+        "has_summary": "1" if has_summary else "0",
+        "pipeline_rows": str(n_rows),
+        "finite_rv_epochs": str(n_finite),
+        "plot_rv_epochs": str(n_plot_points),
+        "has_rv_data_plot": "1" if rv_plot.is_file() else "0",
+        "has_fit_json": "1" if fit_json.is_file() else "0",
+        "has_fit_png": "1" if fit_png.is_file() else "0",
+        "has_website_rv_plot": "1" if web_rv_plot.is_file() else "0",
+        "has_website_rv_fit": "1" if web_fit.is_file() else "0",
+        "issues": ";".join(issues),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Audit spectra → summary → fit → website coverage.")
+    ap.add_argument("--data-csv", default="/var/www/html/darkhunter/rv/tables/data.csv")
+    ap.add_argument("--spec-root", default="/data2/gaia_stars/apf_reductions")
+    ap.add_argument("--output-dir", default=None, help="Pipeline output (default: REPO/output)")
+    ap.add_argument("--reports-dir", default=None)
+    ap.add_argument("--web-root", default="/var/www/html/darkhunter/rv")
+    ap.add_argument("--min-points", type=int, default=5)
+    ap.add_argument("--out-csv", default=None, help="Write audit table (default: rv_fit_reports/qc/pipeline_audit.csv)")
+    ap.add_argument("--only-issues", action="store_true", help="Write only rows with issues")
+    args = ap.parse_args()
+
+    repo = Path(__file__).resolve().parents[1]
+    out_dir = Path(args.output_dir) if args.output_dir else repo / "output"
+    reports_dir = Path(args.reports_dir) if args.reports_dir else repo / "rv_fit_reports"
+    spec_root = Path(args.spec_root)
+    web_root = Path(args.web_root)
+    data_csv = Path(args.data_csv)
+
+    spec_counts = _discover_spectra(spec_root)
+    table_ids = _table_gaia_ids(data_csv)
+    summary_ids: set[str] = set()
+    for p in discover_summary_files(out_dir):
+        sid = parse_object_id_from_summary(p)
+        if sid:
+            summary_ids.add(sid)
+
+    all_ids = sorted(set(table_ids) | set(spec_counts) | summary_ids)
+
+    rows = [
+        _audit_one(
+            gid,
+            spec_counts=spec_counts,
+            out_dir=out_dir,
+            reports_dir=reports_dir,
+            web_root=web_root,
+            min_points=args.min_points,
+        )
+        for gid in all_ids
+    ]
+
+    out_csv = Path(args.out_csv) if args.out_csv else reports_dir / "qc" / "pipeline_audit.csv"
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    fields = list(rows[0].keys()) if rows else []
+    with out_csv.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        for row in rows:
+            if args.only_issues and not row["issues"]:
+                continue
+            w.writerow(row)
+
+    n_issue = sum(1 for r in rows if r["issues"])
+    n_no_summ = sum(1 for r in rows if "no_summary" in r["issues"])
+    n_no_rv_plot = sum(
+        1
+        for r in rows
+        if "no_rv_data_plot" in r["issues"] or "website_summary_no_rv_plot" in r["issues"]
+    )
+    print(
+        f"audit: {len(rows)} stars, {n_issue} with issues, "
+        f"{n_no_summ} missing summary, {n_no_rv_plot} missing RV data plot assets"
+    )
+    print(f"wrote {out_csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/batch_fits_plots_sync.sh
+++ b/scripts/batch_fits_plots_sync.sh
@@ -151,8 +151,8 @@ else
   echo "=== Keplerian fits (skipped: RUN_FITS=0) ==="
 fi
 
-if [[ "$RUN_RV_PLOTS" == "1" && "$RUN_FITS" != "1" ]]; then
-  echo "=== Summary-based RV data plots (no fits) ==="
+if [[ "$RUN_RV_PLOTS" == "1" ]]; then
+  echo "=== Summary-based RV data plots ==="
   plot_args=(
     scripts/plot_rv_from_summaries.py
     --summary-dir "$OUT"

--- a/scripts/lib/refit_one_object.sh
+++ b/scripts/lib/refit_one_object.sh
@@ -26,6 +26,7 @@ FIT_FORCE="${FIT_FORCE:-1}"
 FIT_JITTER="${FIT_JITTER:-1}"
 PIPELINE_UPDATE="${PIPELINE_UPDATE:-0}"
 RUN_HBETA="${RUN_HBETA:-1}"
+RUN_RV_PLOTS="${RUN_RV_PLOTS:-1}"
 QUERY_GAIA_ONLINE="${QUERY_GAIA_ONLINE:-0}"
 REFIT_PARALLEL_LOG_DIR="${REFIT_PARALLEL_LOG_DIR:-$REPO/logs/refit_parallel}"
 
@@ -114,6 +115,14 @@ if [[ "$FIT_JITTER" == "1" ]]; then
 fi
 if ! "$PY" "${fit_args[@]}"; then
   echo "[WARN] fit failed for Gaia_DR3_${gid} (continuing to website if assets exist)"
+fi
+
+if [[ "$RUN_RV_PLOTS" == "1" ]]; then
+  "$PY" scripts/plot_rv_from_summaries.py \
+    --summary-dir "$OUT" \
+    --plots-root "$OUT" \
+    --star-id "$gid" \
+    || echo "[WARN] RV data plot failed for Gaia_DR3_${gid} (continuing)"
 fi
 
 if [[ "$RUN_HBETA" == "1" ]]; then

--- a/scripts/plot_rv_from_summaries.py
+++ b/scripts/plot_rv_from_summaries.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import re
 from pathlib import Path
 
 import matplotlib
@@ -14,51 +13,11 @@ import numpy as np
 from astropy.time import Time
 
 from darkhunter_rv.rv_keplerian_plots import our_telescope_points, plot_rv_data_only
-from darkhunter_rv.rv_point_filters import rv_value_is_valid
-from fit_apf_rv_keplerian import RVPoint, _pipeline_telescope_from_filename, parse_object_id_from_summary
+from darkhunter_rv.summary_paths import discover_summary_files, parse_object_id_from_summary
+from fit_apf_rv_keplerian import parse_summary
 
 
-def parse_gaia_id(path: Path) -> str | None:
-    return parse_object_id_from_summary(path)
-
-
-def parse_points(summary_path: Path) -> list[RVPoint]:
-    text = summary_path.read_text(encoding="utf-8", errors="replace")
-    lines = text.split("[PIPELINE RESULTS]", 1)[-1].splitlines() if "[PIPELINE RESULTS]" in text else text.splitlines()
-    points: list[RVPoint] = []
-    for raw in lines:
-        s = raw.strip()
-        if not s or s.startswith("#") or (s.startswith("[") and s.endswith("]")):
-            continue
-        parts = s.split()
-        if len(parts) < 5:
-            continue
-        if len(parts) >= 6 and parts[-1] in ("True", "False"):
-            parts = parts[:-1]
-        if len(parts) < 5:
-            continue
-        try:
-            rv = float(parts[2])
-            if not rv_value_is_valid(rv):
-                continue
-            points.append(
-                RVPoint(
-                    file=parts[0],
-                    mjd=float(parts[1]),
-                    rv=rv,
-                    rv_err=max(float(parts[3]), 1e-4),
-                    rms=max(abs(float(parts[4])), 1e-4),
-                    telescope=_pipeline_telescope_from_filename(parts[0]),
-                    is_literature=False,
-                )
-            )
-        except ValueError:
-            continue
-    points.sort(key=lambda p: p.mjd)
-    return points
-
-
-def minimal_report(points: list[RVPoint], *, summary_path: Path | None = None) -> dict:
+def minimal_report(points, *, summary_path: Path | None = None) -> dict:
     t = np.array([p.mjd for p in points], dtype=float)
     t_ref = float(np.median(t)) if t.size else float(Time.now().mjd)
     obs = None
@@ -78,7 +37,7 @@ def minimal_report(points: list[RVPoint], *, summary_path: Path | None = None) -
 
 
 def build_plot(summary_path: Path, out_png: Path) -> bool:
-    points = our_telescope_points(parse_points(summary_path))
+    points = our_telescope_points(parse_summary(summary_path))
     if len(points) < 2:
         return False
     plot_rv_data_only(summary_path, points, minimal_report(points, summary_path=summary_path), out_png)
@@ -87,7 +46,7 @@ def build_plot(summary_path: Path, out_png: Path) -> bool:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Build RV data plots from Gaia summary files only.")
-    ap.add_argument("--summary-dir", required=True, help="Directory containing Gaia_DR3_*_summary.txt")
+    ap.add_argument("--summary-dir", required=True, help="Pipeline output root (flat or nested summaries)")
     ap.add_argument("--plots-root", required=True, help="Output root for per-star plot subdirs")
     ap.add_argument("--star-id", default=None, help="Optional single Gaia source id")
     args = ap.parse_args()
@@ -95,8 +54,9 @@ def main() -> int:
     summary_dir = Path(args.summary_dir)
     plots_root = Path(args.plots_root)
 
-    pattern = f"Gaia_DR3_{args.star_id}_summary.txt" if args.star_id else "Gaia_DR3_*_summary.txt"
-    files = sorted(summary_dir.glob(pattern))
+    files = discover_summary_files(summary_dir)
+    if args.star_id:
+        files = [p for p in files if parse_object_id_from_summary(p) == str(args.star_id)]
     if not files:
         print("No summary files found.")
         return 2
@@ -104,7 +64,7 @@ def main() -> int:
     built = 0
     skipped = 0
     for summ in files:
-        sid = parse_gaia_id(summ)
+        sid = parse_object_id_from_summary(summ)
         if not sid:
             skipped += 1
             continue

--- a/tests/test_plot_rv_from_summaries.py
+++ b/tests/test_plot_rv_from_summaries.py
@@ -1,0 +1,34 @@
+"""Tests for summary-only RV data plots (no network)."""
+
+from pathlib import Path
+
+from scripts import plot_rv_from_summaries as rvplot
+
+
+def _write_summary(path: Path, *, n_epochs: int = 3) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows = "\n".join(
+        f"Gaia_DR3_111_epoch_{i}.txt {60000 + i} {-10.0 + i * 0.1} 0.02 0.4 False"
+        for i in range(1, n_epochs + 1)
+    )
+    path.write_text(
+        "[GAIA METADATA]\nSource_ID: 111\nRA: 1.0\nDec: 2.0\n"
+        f"\n[PIPELINE RESULTS]\n# hdr\n{rows}\n"
+    )
+
+
+def test_build_plot_nested_summary(tmp_path: Path) -> None:
+    summ = tmp_path / "Gaia_DR3_111" / "Gaia_DR3_111_summary.txt"
+    _write_summary(summ, n_epochs=4)
+    out_png = tmp_path / "plots" / "Gaia_DR3_111" / "Gaia_DR3_111_rv_plot.png"
+    assert rvplot.build_plot(summ, out_png) is True
+    assert out_png.is_file()
+    assert out_png.stat().st_size > 1000
+
+
+def test_build_plot_skips_single_epoch(tmp_path: Path) -> None:
+    summ = tmp_path / "Gaia_DR3_111_summary.txt"
+    _write_summary(summ, n_epochs=1)
+    out_png = tmp_path / "Gaia_DR3_111_rv_plot.png"
+    assert rvplot.build_plot(summ, out_png) is False
+    assert not out_png.is_file()


### PR DESCRIPTION
## Summary
- Fix missing **RV Curve** plots (`Gaia_DR3_<id>_rv_plot.png`) for stars with valid summary RVs when Keplerian fits are skipped or fail.
- `batch_fits_plots_sync.sh` and `refit_one_object.sh` now always run `plot_rv_from_summaries.py` when `RUN_RV_PLOTS=1` (previously skipped whenever `RUN_FITS=1`, including cron).
- `plot_rv_from_summaries.py` uses `discover_summary_files` and `parse_summary` so nested summaries match the fit pipeline.
- Add `scripts/audit_pipeline_coverage.py` to flag missing summaries, RV data plots, and fit assets.

## Test plan
- [x] `PYTHONPATH=. python3 -m pytest tests/test_plot_rv_from_summaries.py -q`
- [ ] On ziggy after merge: `RUN_RV_PLOTS=1 bash scripts/batch_fits_plots_sync.sh` (or `FIT_FORCE=1` refit) and confirm `output/Gaia_DR3_<id>/Gaia_DR3_<id>_rv_plot.png` appears for stars that previously had summary-only gaps.
- [ ] `PYTHONPATH=. python3 scripts/audit_pipeline_coverage.py --only-issues` — `no_rv_data_plot` / `website_summary_no_rv_plot` counts should drop after a plot pass.


Made with [Cursor](https://cursor.com)