### PR TITLE
Add subchunks_8 chunk optimization, external RV catalogs, and CCF validation

### DIFF
--- a/calibration/ccf_estimator_baseline/phase_a_reference.json
+++ b/calibration/ccf_estimator_baseline/phase_a_reference.json
@@ -1,0 +1,22 @@
+{
+  "phase": "A",
+  "estimator": "gauss_offset",
+  "created_utc": "2026-06-07T00:00:00+00:00",
+  "notes": "Seed baseline before CCF estimator study; update after first benchmark run.",
+  "metrics": {
+    "median_sigma_rv_kms": 0.35,
+    "p90_sigma_rv_kms": 0.55,
+    "median_chunk_scatter_kms": 0.28,
+    "bias_curve_rms_kms": 0.12,
+    "stellar_bias_cv_rmse_kms": 0.15,
+    "low_snr_finite_rate": 0.75
+  },
+  "tolerance": {
+    "median_sigma_rv_kms": 0.005,
+    "p90_sigma_rv_kms": 0.008,
+    "median_chunk_scatter_kms": 0.005,
+    "bias_curve_rms_kms": 0.003,
+    "stellar_bias_cv_rmse_kms": 0.003,
+    "low_snr_finite_rate": 0.02
+  }
+}

--- a/calibration/ccf_estimator_baseline/phase_c_reference.json
+++ b/calibration/ccf_estimator_baseline/phase_c_reference.json
@@ -1,0 +1,24 @@
+{
+  "phase": "C",
+  "estimator": "gauss_offset",
+  "created_utc": "2026-06-10T01:47:43.390657+00:00",
+  "metrics": {
+    "n_chunks": 19029.0,
+    "n_exposures": 114.0,
+    "median_sigma_rv_kms": 0.00868617693145017,
+    "p90_sigma_rv_kms": 0.01224242767012426,
+    "median_chunk_scatter_kms": 18.900525093859784,
+    "low_snr_finite_rate": 1.0,
+    "bias_curve_rms_kms": 20.304570455370044,
+    "stellar_bias_cv_rmse_kms": 21.998628639341902
+  },
+  "tolerance": {
+    "median_sigma_rv_kms": 0.005,
+    "p90_sigma_rv_kms": 0.008,
+    "median_chunk_scatter_kms": 0.005,
+    "bias_curve_rms_kms": 0.003,
+    "stellar_bias_cv_rmse_kms": 0.003,
+    "low_snr_finite_rate": 0.02
+  },
+  "notes": "Measured from chunk-campaign 114 spectra (2026-06-09 Phase C run)"
+}

--- a/calibration/chunk_layouts/subchunks_8.yaml
+++ b/calibration/chunk_layouts/subchunks_8.yaml
@@ -1,0 +1,3 @@
+name: subchunks_8
+subchunks: 8
+min_pixels: 5

--- a/darkhunter_rv/apogee_rv_query.py
+++ b/darkhunter_rv/apogee_rv_query.py
@@ -1,0 +1,188 @@
+"""Query APOGEE DR17 visit RVs from VizieR TAP."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Sequence
+
+import numpy as np
+
+from .cone_utils import filter_rows_in_cone
+from .rv_frame import NativeFrame, finalize_external_rv_record, site_key_for_apogee_telescope
+from .vizier_tap import execute_vizier_adql, parse_gaia_source_id, sql_in_ints, sql_max_err_clause
+
+logger = logging.getLogger(__name__)
+
+APOGEE_TELESCOPE_PREFIX = "APOGEE_DR17"
+APOGEE_CATALOG_TABLE = '"III/286/catalog"'
+APOGEE_ALLVIS_TABLE = '"III/286/allvis"'
+APOGEE_CONE_RADIUS_ARCSEC = 1.5
+APOGEE_CONE_RADIUS_DEG = APOGEE_CONE_RADIUS_ARCSEC / 3600.0
+
+_APOGEE_SQL_BY_GAIA = """
+SELECT c.GaiaEDR3 AS gaia_id, v.Tel AS apo_telescope, v.MJD AS mjd,
+       v.VHelio AS rv, v.e_RV AS rv_err, v.APOGEE AS apogee_id
+FROM {catalog} AS c
+JOIN {allvis} AS v ON c.APOGEE = v.APOGEE
+WHERE c.GaiaEDR3 IN ({ids})
+  AND v.VHelio IS NOT NULL
+  AND v.MJD IS NOT NULL
+{err_clause}"""
+
+_APOGEE_SQL_BY_BOX = """
+SELECT v.RAJ2000 AS ra, v.DEJ2000 AS dec, v.Tel AS apo_telescope, v.MJD AS mjd,
+       v.VHelio AS rv, v.e_RV AS rv_err, v.APOGEE AS apogee_id
+FROM {allvis} AS v
+WHERE v.RAJ2000 BETWEEN {ra} - {radius_deg} AND {ra} + {radius_deg}
+  AND v.DEJ2000 BETWEEN {dec} - {radius_deg} AND {dec} + {radius_deg}
+  AND v.VHelio IS NOT NULL
+  AND v.MJD IS NOT NULL
+{err_clause}"""
+
+
+def _float_or_nan(val: Any) -> float:
+    try:
+        if val in (None, "", "null", "nan"):
+            return float("nan")
+        return float(val)
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def apogee_rows_to_external_rvs(
+    rows: Sequence[dict[str, Any]],
+    *,
+    ra_deg: float | None,
+    dec_deg: float | None,
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        rv = _float_or_nan(row.get("rv"))
+        rv_err = _float_or_nan(row.get("rv_err"))
+        mjd = _float_or_nan(row.get("mjd"))
+        if not np.isfinite(rv) or not np.isfinite(mjd):
+            continue
+        apogee_id = str(row.get("apogee_id", "") or "").strip()
+        apo_tel = str(row.get("apo_telescope", "") or "").strip()
+        site = site_key_for_apogee_telescope(apo_tel)
+        flag = f"apogee={apogee_id}"
+        if apo_tel:
+            flag = f"{flag} tel={apo_tel.strip()}"
+        rec = finalize_external_rv_record(
+            {
+                "telescope": APOGEE_TELESCOPE_PREFIX,
+                "mjd": mjd,
+                "rv": rv,
+                "rv_err": rv_err if np.isfinite(rv_err) else 0.0,
+                "flag": flag,
+            },
+            ra_deg=ra_deg,
+            dec_deg=dec_deg,
+            native_frame=NativeFrame.BARYCENTRIC,
+            site_key=site,
+        )
+        if rec is not None:
+            out.append(rec)
+    out.sort(key=lambda r: (r["mjd"], r["flag"]))
+    return out
+
+
+def _query_apogee_by_gaia_ids(
+    gaia_ids: Sequence[int],
+    *,
+    max_rv_err: float | None,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    sql = _APOGEE_SQL_BY_GAIA.format(
+        catalog=APOGEE_CATALOG_TABLE,
+        allvis=APOGEE_ALLVIS_TABLE,
+        ids=sql_in_ints(list(gaia_ids)),
+        err_clause=sql_max_err_clause("v.e_RV", max_rv_err),
+    )
+    return execute_vizier_adql(sql, timeout=timeout)
+
+
+def _query_apogee_by_cone(
+    ra_deg: float,
+    dec_deg: float,
+    *,
+    max_rv_err: float | None,
+    radius_deg: float = APOGEE_CONE_RADIUS_DEG,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    sql = _APOGEE_SQL_BY_BOX.format(
+        allvis=APOGEE_ALLVIS_TABLE,
+        ra=ra_deg,
+        dec=dec_deg,
+        radius_deg=radius_deg,
+        err_clause=sql_max_err_clause("v.e_RV", max_rv_err),
+    )
+    rows = execute_vizier_adql(sql, timeout=timeout)
+    return filter_rows_in_cone(
+        rows, ra_deg, dec_deg, ra_key="ra", dec_key="dec", radius_deg=radius_deg
+    )
+
+
+def query_apogee_rvs_for_gaia_ids(
+    source_ids: Sequence[int],
+    *,
+    positions_by_id: dict[int, tuple[float, float]] | None = None,
+    max_rv_err: float | None = None,
+    cone_radius_deg: float = APOGEE_CONE_RADIUS_DEG,
+    chunk_size: int = 150,
+    timeout: float = 180.0,
+    progress: bool = False,
+) -> dict[int, list[dict[str, Any]]]:
+    """Return APOGEE DR17 visit RVs keyed by Gaia DR3 source_id."""
+    ids = sorted({int(sid) for sid in source_ids if sid})
+    if not ids:
+        return {}
+
+    positions = positions_by_id or {}
+    rows_by_sid: dict[int, list[dict[str, Any]]] = {}
+
+    n_chunks = (len(ids) + chunk_size - 1) // chunk_size
+    for chunk_i, start in enumerate(range(0, len(ids), chunk_size), start=1):
+        chunk = ids[start : start + chunk_size]
+        if progress:
+            print(
+                f"APOGEE GaiaEDR3 batch {chunk_i}/{n_chunks} ({len(chunk)} stars)...",
+                flush=True,
+            )
+        try:
+            id_rows = _query_apogee_by_gaia_ids(chunk, max_rv_err=max_rv_err, timeout=timeout)
+        except Exception as exc:
+            logger.warning("APOGEE source_id query failed: %s", exc)
+            id_rows = []
+
+        by_gaia: dict[int, list[dict[str, Any]]] = {sid: [] for sid in chunk}
+        for row in id_rows:
+            sid = parse_gaia_source_id(row.get("gaia_id"))
+            if sid is not None and sid in by_gaia:
+                by_gaia[sid].append(row)
+
+        for sid in chunk:
+            merged = by_gaia.get(sid, [])
+            if not merged:
+                pos = positions.get(sid)
+                if pos is not None:
+                    ra, dec = float(pos[0]), float(pos[1])
+                    if np.isfinite(ra) and np.isfinite(dec):
+                        try:
+                            merged = _query_apogee_by_cone(
+                                ra,
+                                dec,
+                                max_rv_err=max_rv_err,
+                                radius_deg=cone_radius_deg,
+                                timeout=timeout,
+                            )
+                        except Exception as exc:
+                            logger.warning("APOGEE cone query failed for Gaia %s: %s", sid, exc)
+                            merged = []
+            pos = positions.get(sid)
+            ra, dec = (pos[0], pos[1]) if pos else (None, None)
+            ext = apogee_rows_to_external_rvs(merged, ra_deg=ra, dec_deg=dec)
+            if ext:
+                rows_by_sid[sid] = ext
+
+    return rows_by_sid

--- a/darkhunter_rv/ccf_rv_estimators.py
+++ b/darkhunter_rv/ccf_rv_estimators.py
@@ -1,0 +1,501 @@
+"""Mask-CCF RV estimators: grid, parabolic, Gaussian, smoothed peak, bi-Gaussian."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+from scipy.ndimage import gaussian_filter1d
+from scipy.optimize import curve_fit, least_squares
+
+from darkhunter_rv import config, qc
+
+_DEFAULT_MIN_CCF_PEAK_SNR = 3.2
+_DEFAULT_MAX_GAUSS_OFFSET_FROM_GRID_KMS = 35.0
+
+ESTIMATOR_NAMES = (
+    "grid",
+    "parabolic_3pt",
+    "parabolic_ls",
+    "gauss_offset",
+    "smooth_peak",
+    "bi_gauss",
+    "auto",
+)
+
+LOWER_IS_BETTER_METRICS = frozenset(
+    {
+        "median_sigma_rv_kms",
+        "p90_sigma_rv_kms",
+        "median_chunk_scatter_kms",
+        "bias_curve_rms_kms",
+        "stellar_bias_cv_rmse_kms",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CcfRvResult:
+    rv_kms: float
+    rv_err_kms: float
+    estimator: str
+    peak_snr: float
+    v_grid_kms: float
+    gauss_popt: tuple[float, ...] | None
+    asymmetry: float
+    fit_ok: bool
+
+
+@dataclass
+class CcfFitSlice:
+    vel_shifts: np.ndarray
+    ccf: np.ndarray
+    peak_idx: int
+    peak_val: float
+    peak_snr: float
+    v_grid: float
+    v_lo: float
+    v_hi: float
+    x_m: np.ndarray
+    y_m: np.ndarray
+    scale_y: float
+
+
+@dataclass(frozen=True)
+class EstimatorConfig:
+    fit_width: int = 50
+    min_peak_snr: float = _DEFAULT_MIN_CCF_PEAK_SNR
+    max_gauss_offset_kms: float = _DEFAULT_MAX_GAUSS_OFFSET_FROM_GRID_KMS
+    ccf_neg_spike_sigma: float = 6.0
+    low_snr_parabolic_threshold: float = 4.5
+    high_asymmetry_bi_gauss_threshold: float = 0.22
+
+
+def prepare_ccf_fit_slice(
+    vel_shifts: np.ndarray,
+    ccf: np.ndarray,
+    *,
+    peak_idx: int,
+    peak_val: float,
+    peak_snr: float,
+    fit_width: int,
+    ccf_neg_spike_sigma: float,
+) -> CcfFitSlice | None:
+    """Window around grid argmax with CR spike masking for sub-pixel fits."""
+    vel_shifts = np.asarray(vel_shifts, float)
+    ccf = np.asarray(ccf, float)
+    v_grid = float(vel_shifts[peak_idx])
+    v_lo = float(np.min(vel_shifts))
+    v_hi = float(np.max(vel_shifts))
+
+    sl = slice(max(0, peak_idx - fit_width), min(len(ccf), peak_idx + fit_width + 1))
+    x_fit, y_fit = vel_shifts[sl], ccf[sl]
+    if len(x_fit) < 5:
+        return None
+
+    y = np.asarray(y_fit, float)
+    x_arr = np.asarray(x_fit, float)
+    med_y = float(np.median(y))
+    mad_y = float(np.median(np.abs(y - med_y))) + 1e-12
+    scale_y = 1.4826 * mad_y
+    neg_floor = med_y - float(ccf_neg_spike_sigma) * scale_y
+    use = y >= neg_floor
+    if int(np.sum(use)) < 5:
+        use = np.ones_like(y, dtype=bool)
+    x_m = x_arr[use]
+    y_m = y[use]
+    if len(x_m) < 5:
+        return None
+
+    span = float(max(np.ptp(y_m), 1e-9))
+    sig0 = float(max(2.0, min(80.0, 0.5 * (v_hi - v_lo) * fit_width / max(len(ccf), 1))))
+    rough = med_y + span * 0.5 * np.exp(-0.5 * ((x_arr - v_grid) / max(sig0, 2.0)) ** 2)
+    use = use & (y >= (rough - 4.0 * scale_y))
+    if int(np.sum(use)) < 5:
+        use = np.ones_like(y, dtype=bool)
+        x_m = x_arr[use]
+        y_m = y[use]
+    else:
+        x_m = x_arr[use]
+        y_m = y[use]
+
+    return CcfFitSlice(
+        vel_shifts=vel_shifts,
+        ccf=ccf,
+        peak_idx=peak_idx,
+        peak_val=peak_val,
+        peak_snr=peak_snr,
+        v_grid=v_grid,
+        v_lo=v_lo,
+        v_hi=v_hi,
+        x_m=np.asarray(x_m, float),
+        y_m=np.asarray(y_m, float),
+        scale_y=float(scale_y),
+    )
+
+
+def _ccf_asymmetry(slice_: CcfFitSlice) -> float:
+    _, asym = qc.ccf_shape_metrics(slice_.vel_shifts, slice_.ccf)
+    return float(asym) if np.isfinite(asym) else float("nan")
+
+
+def _estimate_grid(slice_: CcfFitSlice) -> CcfRvResult:
+    return CcfRvResult(
+        rv_kms=slice_.v_grid,
+        rv_err_kms=float("nan"),
+        estimator="grid",
+        peak_snr=slice_.peak_snr,
+        v_grid_kms=slice_.v_grid,
+        gauss_popt=None,
+        asymmetry=_ccf_asymmetry(slice_),
+        fit_ok=True,
+    )
+
+
+def _parabolic_vertex(_x: np.ndarray, a: float, b: float, _c: float) -> float:
+    if abs(a) < 1e-15:
+        return float("nan")
+    return float(-b / (2.0 * a))
+
+
+def _estimate_parabolic_3pt(slice_: CcfFitSlice) -> CcfRvResult:
+    i = slice_.peak_idx
+    ccf = slice_.ccf
+    vel = slice_.vel_shifts
+    if i <= 0 or i >= len(ccf) - 1:
+        return _estimate_grid(slice_)
+    x3 = vel[i - 1 : i + 2]
+    y3 = ccf[i - 1 : i + 2]
+    try:
+        coef = np.polyfit(x3, y3, 2)
+        mu = _parabolic_vertex(x3, *coef)
+    except Exception:
+        mu = float("nan")
+    if not np.isfinite(mu) or mu < slice_.v_lo or mu > slice_.v_hi:
+        return _estimate_grid(slice_)
+    return CcfRvResult(
+        rv_kms=mu,
+        rv_err_kms=float("nan"),
+        estimator="parabolic_3pt",
+        peak_snr=slice_.peak_snr,
+        v_grid_kms=slice_.v_grid,
+        gauss_popt=None,
+        asymmetry=_ccf_asymmetry(slice_),
+        fit_ok=True,
+    )
+
+
+def _estimate_parabolic_ls(slice_: CcfFitSlice) -> CcfRvResult:
+    x_m, y_m = slice_.x_m, slice_.y_m
+    if len(x_m) < 5:
+        return _estimate_grid(slice_)
+    try:
+        coef = np.polyfit(x_m, y_m, 2)
+        mu = _parabolic_vertex(x_m, *coef)
+    except Exception:
+        mu = float("nan")
+    if not np.isfinite(mu) or mu < slice_.v_lo or mu > slice_.v_hi:
+        return _estimate_grid(slice_)
+    return CcfRvResult(
+        rv_kms=mu,
+        rv_err_kms=float("nan"),
+        estimator="parabolic_ls",
+        peak_snr=slice_.peak_snr,
+        v_grid_kms=slice_.v_grid,
+        gauss_popt=None,
+        asymmetry=_ccf_asymmetry(slice_),
+        fit_ok=True,
+    )
+
+
+def _estimate_smooth_peak(slice_: CcfFitSlice, *, smooth_sigma_pts: float = 1.2) -> CcfRvResult:
+    y = gaussian_filter1d(slice_.ccf.astype(float), sigma=smooth_sigma_pts)
+    peak_i = int(np.argmax(y))
+    if peak_i <= 0 or peak_i >= len(y) - 1:
+        return _estimate_grid(slice_)
+    x3 = slice_.vel_shifts[peak_i - 1 : peak_i + 2]
+    y3 = y[peak_i - 1 : peak_i + 2]
+    try:
+        coef = np.polyfit(x3, y3, 2)
+        mu = _parabolic_vertex(x3, *coef)
+    except Exception:
+        mu = float("nan")
+    if not np.isfinite(mu) or mu < slice_.v_lo or mu > slice_.v_hi:
+        return _estimate_grid(slice_)
+    return CcfRvResult(
+        rv_kms=mu,
+        rv_err_kms=float("nan"),
+        estimator="smooth_peak",
+        peak_snr=slice_.peak_snr,
+        v_grid_kms=slice_.v_grid,
+        gauss_popt=None,
+        asymmetry=_ccf_asymmetry(slice_),
+        fit_ok=True,
+    )
+
+
+def _gauss_bounds_and_p0(slice_: CcfFitSlice) -> tuple[tuple, list]:
+    x_m, y_m = slice_.x_m, slice_.y_m
+    v_grid, v_lo, v_hi = slice_.v_grid, slice_.v_lo, slice_.v_hi
+    span = float(max(np.ptp(y_m), 1e-9))
+    c0_0 = float(np.median(y_m))
+    amp0 = float(max(float(np.max(y_m)) - c0_0, span * 0.02, 1e-9))
+    sig_est = float(max(2.0, min(80.0, 0.5 * (v_hi - v_lo) * len(x_m) / max(len(slice_.ccf), 1))))
+    c_lo = float(np.min(y_m) - 0.75 * span)
+    c_hi = float(np.max(y_m) + 0.25 * span)
+    span_v = float(v_hi - v_lo)
+    if span_v > 25.0:
+        wing_sep = max(28.0, min(0.11 * span_v, 140.0))
+        wing_mask = np.abs(slice_.vel_shifts - v_grid) >= wing_sep
+        n_wing = int(np.sum(wing_mask))
+        if n_wing >= 6:
+            y_w = np.asarray(slice_.ccf[wing_mask], float)
+            c0_wing = float(np.median(y_w))
+            mad_w = float(np.median(np.abs(y_w - c0_wing)) * 1.4826) + 1e-12
+            ptp_w = float(np.ptp(y_w))
+            band = max(10.0 * mad_w, 0.025 * abs(slice_.peak_val - c0_wing), 0.05 * max(ptp_w, mad_w))
+            band = max(band, 1e-9)
+            c_lo_n = max(c_lo, c0_wing - band)
+            c_hi_n = min(c_hi, c0_wing + band)
+            if c_lo_n < c_hi_n - 1e-6:
+                c_lo, c_hi = c_lo_n, c_hi_n
+                c0_0 = float(np.clip(c0_wing, c_lo + 1e-9, c_hi - 1e-9))
+                amp0 = float(max(float(np.max(y_m)) - c0_0, span * 0.02, 1e-9))
+    sig_max = min(400.0, max(10.0, v_hi - v_lo))
+    amp_hi = 10.0 * span + abs(c0_0)
+    bounds = (
+        [c_lo, 1e-12, v_lo, 0.5],
+        [c_hi, amp_hi, v_hi, sig_max],
+    )
+    p0 = [c0_0, amp0, v_grid, sig_est]
+    return bounds, p0
+
+
+def _fit_soft_l1_gauss(
+    x_m: np.ndarray,
+    y_m: np.ndarray,
+    bounds: tuple,
+    p0: list,
+    span: float,
+) -> tuple[float, float, float, float] | None:
+    lb = np.array(bounds[0], dtype=float)
+    ub = np.array(bounds[1], dtype=float)
+    p0a = np.clip(np.array(p0, dtype=float), lb + 1e-12, ub - 1e-12)
+    f_scale = max(span * 0.12, 1e-9)
+
+    def resid(p):
+        c0p, amp, mu, sig = p
+        return (c0p + amp * np.exp(-0.5 * ((x_m - mu) / sig) ** 2)) - y_m
+
+    try:
+        sol = least_squares(
+            resid,
+            p0a,
+            bounds=(lb, ub),
+            loss="soft_l1",
+            f_scale=f_scale,
+            max_nfev=8000,
+        )
+        if not np.all(np.isfinite(sol.x)):
+            return None
+        return tuple(float(v) for v in sol.x)
+    except Exception:
+        return None
+
+
+def _failed_gauss(slice_: CcfFitSlice) -> CcfRvResult:
+    return CcfRvResult(
+        rv_kms=slice_.v_grid,
+        rv_err_kms=float("nan"),
+        estimator="gauss_offset",
+        peak_snr=slice_.peak_snr,
+        v_grid_kms=slice_.v_grid,
+        gauss_popt=None,
+        asymmetry=_ccf_asymmetry(slice_),
+        fit_ok=False,
+    )
+
+
+def _estimate_gauss_offset(slice_: CcfFitSlice, cfg: EstimatorConfig) -> CcfRvResult:
+    x_m, y_m = slice_.x_m, slice_.y_m
+    v_grid, v_lo, v_hi = slice_.v_grid, slice_.v_lo, slice_.v_hi
+    span = float(max(np.ptp(y_m), 1e-9))
+
+    def ccf_offset_gauss(x, c0p, amp, mu, sig):
+        return c0p + amp * np.exp(-0.5 * ((x - mu) / sig) ** 2)
+
+    bounds, p0 = _gauss_bounds_and_p0(slice_)
+    gauss_popt = None
+    rv = v_grid
+    rv_err = float("nan")
+
+    try:
+        popt, pcov = curve_fit(ccf_offset_gauss, x_m, y_m, p0=p0, bounds=bounds, maxfev=8000)
+        c_fit, amp_fit, mu_fit, sig_fit = (float(v) for v in popt)
+        if amp_fit < 1e-11:
+            sl = _fit_soft_l1_gauss(x_m, y_m, bounds, p0, span)
+            if sl is None:
+                return _failed_gauss(slice_)
+            c_fit, amp_fit, mu_fit, sig_fit = sl
+            pcov = None
+        if amp_fit < 1e-11:
+            return _failed_gauss(slice_)
+        if abs(mu_fit - v_grid) > cfg.max_gauss_offset_kms:
+            return _failed_gauss(slice_)
+        if mu_fit < v_lo - 1e-3 or mu_fit > v_hi + 1e-3:
+            return _failed_gauss(slice_)
+        if float(sig_fit) < float(config.MASK_CCF_MIN_GAUSS_SIGMA_KMS):
+            return _failed_gauss(slice_)
+        rv = mu_fit
+        if pcov is not None:
+            perr = np.sqrt(np.diag(pcov))
+            rv_err = float(perr[2]) if np.isfinite(perr[2]) else float("nan")
+        gauss_popt = (c_fit, amp_fit, mu_fit, sig_fit)
+    except Exception:
+        sl = _fit_soft_l1_gauss(x_m, y_m, bounds, p0, span)
+        if sl is None:
+            return _failed_gauss(slice_)
+        c_fit, amp_fit, mu_fit, sig_fit = sl
+        if amp_fit < 1e-11 or abs(mu_fit - v_grid) > cfg.max_gauss_offset_kms:
+            return _failed_gauss(slice_)
+        if mu_fit < v_lo - 1e-3 or mu_fit > v_hi + 1e-3:
+            return _failed_gauss(slice_)
+        if float(sig_fit) < float(config.MASK_CCF_MIN_GAUSS_SIGMA_KMS):
+            return _failed_gauss(slice_)
+        rv = mu_fit
+        gauss_popt = (c_fit, amp_fit, mu_fit, sig_fit)
+
+    return CcfRvResult(
+        rv_kms=rv,
+        rv_err_kms=rv_err,
+        estimator="gauss_offset",
+        peak_snr=slice_.peak_snr,
+        v_grid_kms=slice_.v_grid,
+        gauss_popt=gauss_popt,
+        asymmetry=_ccf_asymmetry(slice_),
+        fit_ok=True,
+    )
+
+
+def _estimate_bi_gauss(slice_: CcfFitSlice, cfg: EstimatorConfig) -> CcfRvResult:
+    x_m, y_m = slice_.x_m, slice_.y_m
+    v_grid, v_lo, v_hi = slice_.v_grid, slice_.v_lo, slice_.v_hi
+    span = float(max(np.ptp(y_m), 1e-9))
+    c0_0 = float(np.median(y_m))
+    amp0 = float(max(float(np.max(y_m)) - c0_0, span * 0.02, 1e-9))
+    sig0 = float(max(2.0, min(40.0, 0.25 * (v_hi - v_lo))))
+
+    def bi_gauss(x, c0p, a1, mu1, s1, a2, mu2, s2):
+        g1 = a1 * np.exp(-0.5 * ((x - mu1) / s1) ** 2)
+        g2 = a2 * np.exp(-0.5 * ((x - mu2) / s2) ** 2)
+        return c0p + g1 + g2
+
+    c_lo = float(np.min(y_m) - span)
+    c_hi = float(np.max(y_m) + 0.5 * span)
+    sig_max = min(200.0, max(8.0, v_hi - v_lo))
+    amp_hi = 8.0 * span + abs(c0_0)
+    bounds = (
+        [c_lo, 1e-12, v_lo, 0.5, 1e-12, v_lo, 0.5],
+        [c_hi, amp_hi, v_hi, sig_max, amp_hi, v_hi, sig_max],
+    )
+    p0 = [c0_0, 0.65 * amp0, v_grid - 3.0, sig0, 0.35 * amp0, v_grid + 3.0, sig0 * 1.2]
+    try:
+        popt, pcov = curve_fit(bi_gauss, x_m, y_m, p0=p0, bounds=bounds, maxfev=12000)
+        c0p, a1, mu1, s1, a2, mu2, s2 = (float(v) for v in popt)
+        if a1 < 1e-11 and a2 < 1e-11:
+            return _estimate_gauss_offset(slice_, cfg)
+        if a1 >= a2:
+            mu_fit, sig_fit = mu1, s1
+            amp_fit = a1
+            idx = 2
+        else:
+            mu_fit, sig_fit = mu2, s2
+            amp_fit = a2
+            idx = 5
+        if abs(mu_fit - v_grid) > cfg.max_gauss_offset_kms * 1.5:
+            return _estimate_gauss_offset(slice_, cfg)
+        if float(sig_fit) < float(config.MASK_CCF_MIN_GAUSS_SIGMA_KMS):
+            return _estimate_gauss_offset(slice_, cfg)
+        rv_err = float("nan")
+        if pcov is not None:
+            perr = np.sqrt(np.diag(pcov))
+            if np.isfinite(perr[idx]):
+                rv_err = float(perr[idx])
+        gauss_popt = (c0p, amp_fit, mu_fit, sig_fit)
+        return CcfRvResult(
+            rv_kms=mu_fit,
+            rv_err_kms=rv_err,
+            estimator="bi_gauss",
+            peak_snr=slice_.peak_snr,
+            v_grid_kms=slice_.v_grid,
+            gauss_popt=gauss_popt,
+            asymmetry=_ccf_asymmetry(slice_),
+            fit_ok=True,
+        )
+    except Exception:
+        return _estimate_gauss_offset(slice_, cfg)
+
+
+_ESTIMATORS: dict[str, Callable[..., CcfRvResult]] = {
+    "grid": lambda s, c: _estimate_grid(s),
+    "parabolic_3pt": lambda s, c: _estimate_parabolic_3pt(s),
+    "parabolic_ls": lambda s, c: _estimate_parabolic_ls(s),
+    "gauss_offset": lambda s, c: _estimate_gauss_offset(s, c),
+    "smooth_peak": lambda s, c: _estimate_smooth_peak(s),
+    "bi_gauss": lambda s, c: _estimate_bi_gauss(s, c),
+}
+
+
+def select_ccf_estimator(
+    peak_snr: float,
+    asymmetry: float,
+    *,
+    cfg: EstimatorConfig | None = None,
+) -> str:
+    """Route to parabolic (low S/N), bi-Gaussian (high asymmetry), else Gaussian."""
+    cfg = cfg or EstimatorConfig()
+    if not np.isfinite(peak_snr) or peak_snr < cfg.low_snr_parabolic_threshold:
+        return "parabolic_3pt"
+    if np.isfinite(asymmetry) and asymmetry >= cfg.high_asymmetry_bi_gauss_threshold and peak_snr >= 6.0:
+        return "bi_gauss"
+    return "gauss_offset"
+
+
+def estimate_ccf_rv(
+    estimator: str,
+    slice_: CcfFitSlice,
+    *,
+    cfg: EstimatorConfig | None = None,
+) -> CcfRvResult:
+    cfg = cfg or EstimatorConfig()
+    name = estimator
+    if name == "auto":
+        asym = _ccf_asymmetry(slice_)
+        name = select_ccf_estimator(slice_.peak_snr, asym, cfg=cfg)
+    fn = _ESTIMATORS.get(name)
+    if fn is None:
+        raise ValueError(f"unknown estimator: {estimator}")
+    result = fn(slice_, cfg)
+    if estimator in _ESTIMATORS and estimator != result.estimator:
+        return CcfRvResult(
+            rv_kms=result.rv_kms,
+            rv_err_kms=result.rv_err_kms,
+            estimator=estimator,
+            peak_snr=result.peak_snr,
+            v_grid_kms=result.v_grid_kms,
+            gauss_popt=result.gauss_popt,
+            asymmetry=result.asymmetry,
+            fit_ok=result.fit_ok,
+        )
+    return result
+
+
+def estimate_all_ccf_rvs(
+    slice_: CcfFitSlice,
+    *,
+    cfg: EstimatorConfig | None = None,
+    estimators: tuple[str, ...] | None = None,
+) -> dict[str, CcfRvResult]:
+    cfg = cfg or EstimatorConfig()
+    names = estimators or tuple(n for n in ESTIMATOR_NAMES if n != "auto")
+    return {name: estimate_ccf_rv(name, slice_, cfg=cfg) for name in names}

--- a/darkhunter_rv/cone_utils.py
+++ b/darkhunter_rv/cone_utils.py
@@ -1,0 +1,40 @@
+"""Small-angle cone filtering for catalog cross-matches."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import numpy as np
+
+
+def angular_sep_deg(ra1: float, dec1: float, ra2: float, dec2: float) -> float:
+    """Small-angle separation in degrees."""
+    dra = float(ra1) - float(ra2)
+    ddec = float(dec1) - float(dec2)
+    cos_dec = np.cos(np.radians(float(dec1)))
+    return float(np.hypot(dra, ddec * cos_dec))
+
+
+def filter_rows_in_cone(
+    rows: Sequence[dict[str, Any]],
+    ra_deg: float,
+    dec_deg: float,
+    *,
+    ra_key: str = "target_ra",
+    dec_key: str = "target_dec",
+    radius_deg: float,
+) -> list[dict[str, Any]]:
+    kept: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            tra = float(row[ra_key])
+            tdec = float(row[dec_key])
+        except (KeyError, TypeError, ValueError):
+            continue
+        sep = angular_sep_deg(ra_deg, dec_deg, tra, tdec)
+        if sep <= radius_deg:
+            tagged = dict(row)
+            tagged["sep_deg"] = sep
+            kept.append(tagged)
+    kept.sort(key=lambda r: float(r.get("sep_deg", np.inf)))
+    return kept

--- a/darkhunter_rv/desi_rv_query.py
+++ b/darkhunter_rv/desi_rv_query.py
@@ -1,0 +1,290 @@
+"""Query DESI Milky Way Survey RVs from NOIRLab Astro Data Lab (TAP)."""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+from typing import Any, Sequence
+
+import numpy as np
+import requests
+
+from .cone_utils import angular_sep_deg, filter_rows_in_cone
+from .rv_frame import NativeFrame, finalize_external_rv_record
+from .vizier_tap import parse_gaia_source_id
+
+logger = logging.getLogger(__name__)
+
+DATALAB_TAP_SYNC = "https://datalab.noirlab.edu/tap/sync"
+DESI_RELEASE = "dr1"
+DESI_TABLE = f"desi_{DESI_RELEASE}.mws"
+ZPIX_TABLE = f"desi_{DESI_RELEASE}.zpix"
+DESI_TELESCOPE_PREFIX = "DESI_DR1"
+# Match DESI Data Lab Gaia crossmatch radius (1.5 arcsec).
+DESI_CONE_RADIUS_ARCSEC = 1.5
+DESI_CONE_RADIUS_DEG = DESI_CONE_RADIUS_ARCSEC / 3600.0
+
+_DESI_RV_SELECT = """
+SELECT m.source_id, m.targetid, m.survey, m.program,
+       m.rv_adop, m.rv_err, m.rvs_warn,
+       m.target_ra, m.target_dec,
+       z.min_mjd, z.max_mjd
+"""
+
+_DESI_RV_FROM = """
+FROM {mws} AS m
+LEFT JOIN {zpix} AS z
+  ON m.targetid = z.targetid AND m.survey = z.survey AND m.program = z.program
+"""
+
+_DESI_RV_WHERE_BASE = """
+WHERE m.rv_adop IS NOT NULL
+  AND m.success = 1
+"""
+
+_DESI_RV_SQL_BY_ID = (
+    _DESI_RV_SELECT
+    + _DESI_RV_FROM
+    + _DESI_RV_WHERE_BASE
+    + """
+  AND m.source_id IN ({ids})
+"""
+)
+
+_DESI_RV_SQL_BY_BOX = (
+    _DESI_RV_SELECT
+    + _DESI_RV_FROM
+    + _DESI_RV_WHERE_BASE
+    + """
+  AND m.target_ra BETWEEN ({ra}) - {radius_deg} AND ({ra}) + {radius_deg}
+  AND m.target_dec BETWEEN ({dec}) - {radius_deg} AND ({dec}) + {radius_deg}
+"""
+)
+
+
+def execute_datalab_adql(sql: str, *, timeout: float = 180.0) -> list[dict[str, Any]]:
+    """Run ADQL on Astro Data Lab TAP (sync, CSV)."""
+    resp = requests.get(
+        DATALAB_TAP_SYNC,
+        params={"REQUEST": "doQuery", "LANG": "ADQL", "FORMAT": "csv", "QUERY": sql},
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    text = resp.text.strip()
+    if text.startswith("<?xml") or text.startswith("<"):
+        raise RuntimeError(f"Data Lab TAP query failed: {text[:500]}")
+    if not text:
+        return []
+    reader = csv.DictReader(io.StringIO(text))
+    return [dict(row) for row in reader]
+
+
+def _row_dedupe_key(row: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(row.get("targetid", "")),
+        str(row.get("survey", "")),
+        str(row.get("program", "")),
+    )
+
+
+def _merge_desi_rows(*groups: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    merged: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for group in groups:
+        for row in group:
+            merged[_row_dedupe_key(row)] = row
+    return list(merged.values())
+
+
+def _mjd_from_row(row: dict[str, Any]) -> float:
+    try:
+        t0 = float(row.get("min_mjd", np.nan))
+        t1 = float(row.get("max_mjd", np.nan))
+    except (TypeError, ValueError):
+        return float("nan")
+    if np.isfinite(t0) and np.isfinite(t1):
+        return 0.5 * (t0 + t1)
+    if np.isfinite(t1):
+        return t1
+    if np.isfinite(t0):
+        return t0
+    return float("nan")
+
+
+def desi_rows_to_external_rvs(
+    rows: Sequence[dict[str, Any]],
+    *,
+    ra_deg: float | None = None,
+    dec_deg: float | None = None,
+) -> list[dict[str, Any]]:
+    """Convert Data Lab DESI MWS rows to summary [EXTERNAL RV DATA] records (barycentric)."""
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            rv = float(row["rv_adop"])
+            if not np.isfinite(rv):
+                continue
+            err_raw = row.get("rv_err")
+            rv_err = float(err_raw) if err_raw not in (None, "", "null") and np.isfinite(float(err_raw)) else 0.0
+            mjd = _mjd_from_row(row)
+            if not np.isfinite(mjd):
+                logger.debug("skip DESI row without MJD: targetid=%s", row.get("targetid"))
+                continue
+            survey = str(row.get("survey", "") or "")
+            program = str(row.get("program", "") or "")
+            targetid = str(row.get("targetid", "") or "")
+            warn = str(row.get("rvs_warn", "") or "")
+            flag = f"{survey}/{program}/{targetid}"
+            if warn not in ("", "0", "0.0"):
+                flag = f"{flag} warn={warn}"
+            cross_sid = parse_gaia_source_id(row.get("source_id"))
+            if cross_sid is not None:
+                flag = f"{flag} gaia={cross_sid}"
+            sep = row.get("sep_deg")
+            if sep not in (None, "", "null"):
+                try:
+                    sep_arcsec = float(sep) * 3600.0
+                    if np.isfinite(sep_arcsec):
+                        flag = f"{flag} sep={sep_arcsec:.2f}arcsec"
+                except (TypeError, ValueError):
+                    pass
+            rec = finalize_external_rv_record(
+                {
+                    "telescope": DESI_TELESCOPE_PREFIX,
+                    "mjd": float(mjd),
+                    "rv": rv,
+                    "rv_err": max(rv_err, 1e-4),
+                    "flag": flag,
+                },
+                ra_deg=ra_deg,
+                dec_deg=dec_deg,
+                native_frame=NativeFrame.HELIOCENTRIC,
+                site_key="DESI",
+            )
+            if rec is not None:
+                out.append(rec)
+        except (KeyError, TypeError, ValueError):
+            continue
+    out.sort(key=lambda r: (r["mjd"], r["flag"]))
+    return out
+
+
+def _query_desi_by_source_ids(
+    source_ids: Sequence[int],
+    *,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    id_list = ", ".join(str(int(i)) for i in source_ids)
+    sql = _DESI_RV_SQL_BY_ID.format(mws=DESI_TABLE, zpix=ZPIX_TABLE, ids=id_list)
+    return execute_datalab_adql(sql, timeout=timeout)
+
+
+def _query_desi_by_cone(
+    ra_deg: float,
+    dec_deg: float,
+    *,
+    radius_deg: float = DESI_CONE_RADIUS_DEG,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    # Use a simple RA/Dec box in SQL (Data Lab's parser chokes on sqrt/power/cos and
+    # on "dec - -45" which becomes an SQL comment). Refine to a true cone in Python.
+    sql = _DESI_RV_SQL_BY_BOX.format(
+        mws=DESI_TABLE,
+        zpix=ZPIX_TABLE,
+        ra=ra_deg,
+        dec=dec_deg,
+        radius_deg=radius_deg,
+    )
+    rows = execute_datalab_adql(sql, timeout=timeout)
+    return filter_rows_in_cone(rows, ra_deg, dec_deg, radius_deg=radius_deg)
+
+
+def query_desi_rvs_for_gaia_ids(
+    source_ids: Sequence[int],
+    *,
+    positions_by_id: dict[int, tuple[float, float]] | None = None,
+    cone_radius_deg: float = DESI_CONE_RADIUS_DEG,
+    chunk_size: int = 40,
+    timeout: float = 180.0,
+    progress: bool = False,
+) -> dict[int, list[dict[str, Any]]]:
+    """
+    Return DESI external-RV rows keyed by the requested Gaia DR3 source_id.
+
+    Lookup order per star:
+    1. ``desi_dr1.mws.source_id`` exact match (DESI's Gaia crossmatch id)
+    2. If no rows and RA/Dec are known: cone search on ``target_ra``/``target_dec``
+       within ``cone_radius_deg`` (default 1.5 arcsec, same as Data Lab xmatch)
+    """
+    ids = sorted({int(sid) for sid in source_ids if sid})
+    if not ids:
+        return {}
+
+    positions = positions_by_id or {}
+    rows_by_sid: dict[int, list[dict[str, Any]]] = {sid: [] for sid in ids}
+
+    n_chunks = (len(ids) + chunk_size - 1) // chunk_size
+    for chunk_i, start in enumerate(range(0, len(ids), chunk_size), start=1):
+        chunk = ids[start : start + chunk_size]
+        if progress:
+            print(
+                f"DESI source_id batch {chunk_i}/{n_chunks} ({len(chunk)} stars)...",
+                flush=True,
+            )
+        try:
+            id_rows = _query_desi_by_source_ids(chunk, timeout=timeout)
+        except Exception as exc:
+            logger.warning("DESI source_id query failed for %d Gaia ids: %s", len(chunk), exc)
+            id_rows = []
+
+        id_rows_by_sid: dict[int, list[dict[str, Any]]] = {sid: [] for sid in chunk}
+        for row in id_rows:
+            sid = parse_gaia_source_id(row.get("source_id"))
+            if sid is not None and sid in id_rows_by_sid:
+                id_rows_by_sid[sid].append(row)
+
+        cone_sids: list[int] = []
+        for sid in chunk:
+            merged = _merge_desi_rows(id_rows_by_sid.get(sid, []))
+            pos = positions.get(sid)
+            ra, dec = (pos[0], pos[1]) if pos else (None, None)
+            if merged:
+                rows_by_sid[sid] = desi_rows_to_external_rvs(merged, ra_deg=ra, dec_deg=dec)
+                continue
+            pos = positions.get(sid)
+            if pos is None:
+                continue
+            try:
+                ra, dec = float(pos[0]), float(pos[1])
+            except (TypeError, ValueError, IndexError):
+                continue
+            if np.isfinite(ra) and np.isfinite(dec):
+                cone_sids.append(sid)
+
+        for cone_i, sid in enumerate(cone_sids, start=1):
+            pos = positions[sid]
+            ra, dec = float(pos[0]), float(pos[1])
+            if progress:
+                print(
+                    f"DESI cone {cone_i}/{len(cone_sids)} Gaia_DR3_{sid} "
+                    f"(RA={ra:.4f} Dec={dec:.4f})...",
+                    flush=True,
+                )
+            try:
+                cone_rows = _query_desi_by_cone(ra, dec, radius_deg=cone_radius_deg, timeout=timeout)
+            except Exception as exc:
+                logger.warning("DESI cone query failed for Gaia %s: %s", sid, exc)
+                continue
+            if cone_rows:
+                logger.info(
+                    "DESI cone match for Gaia %s at RA=%.6f Dec=%.6f (%d row(s); no source_id match)",
+                    sid,
+                    ra,
+                    dec,
+                    len(cone_rows),
+                )
+                rows_by_sid[sid] = desi_rows_to_external_rvs(
+                    cone_rows, ra_deg=ra, dec_deg=dec
+                )
+
+    return {sid: rows for sid, rows in rows_by_sid.items() if rows}

--- a/darkhunter_rv/gaia_utils.py
+++ b/darkhunter_rv/gaia_utils.py
@@ -7,7 +7,28 @@ from pathlib import Path
 import numpy as np
 from astropy.time import Time
 from . import config
+from .apogee_rv_query import APOGEE_TELESCOPE_PREFIX, query_apogee_rvs_for_gaia_ids
+from .desi_rv_query import DESI_TELESCOPE_PREFIX, query_desi_rvs_for_gaia_ids
+from .galah_rv_query import GALAH_TELESCOPE_PREFIX, query_galah_rvs_for_gaia_ids
+from .ges_rv_query import GES_TELESCOPE_PREFIX, query_ges_rvs_for_gaia_ids
+from .rv_frame import (
+    EXTERNAL_RV_HEADER_COMMENT,
+    NativeFrame,
+    finalize_external_rv_record,
+    mjd_from_rave_obs_id,
+)
+from .rv_point_filters import mjd_is_valid
 from .thiele_innes_inclination import fill_inclination_in_metadata
+
+EXTERNAL_CATALOG_PREFIXES: tuple[str, ...] = (
+    "LAMOST_LRS",
+    "LAMOST_MRS",
+    "RAVE_DR6",
+    DESI_TELESCOPE_PREFIX,
+    GALAH_TELESCOPE_PREFIX,
+    APOGEE_TELESCOPE_PREFIX,
+    GES_TELESCOPE_PREFIX,
+)
 
 def _gaia_class():
     """Lazy import: avoids astroquery's noisy archive banner when only reading summaries from disk."""
@@ -91,7 +112,28 @@ def query_gaia_data(source_id):
     if not ext_rows:
         ext_rows = _query_external_rvs_sequential(prop_args)
 
-    return process_query_results(main_rows, ext_rows)
+    result = process_query_results(main_rows, ext_rows)
+    meta = result.get("metadata") or {}
+    ra = meta.get("RA")
+    dec = meta.get("Dec")
+    positions = None
+    try:
+        if ra is not None and dec is not None and np.isfinite(float(ra)) and np.isfinite(float(dec)):
+            positions = {int(source_id): (float(ra), float(dec))}
+    except (TypeError, ValueError):
+        positions = None
+    sid = int(source_id)
+    desi_rows = query_desi_rvs_for_gaia_ids([sid], positions_by_id=positions).get(sid, [])
+    galah_rows = query_galah_rvs_for_gaia_ids([sid], positions_by_id=positions).get(sid, [])
+    apogee_rows = query_apogee_rvs_for_gaia_ids([sid], positions_by_id=positions).get(sid, [])
+    result["external_rvs"] = merge_external_rv_lists(result.get("external_rvs", []), desi_rows)
+    result["external_rvs"] = merge_external_rv_lists(
+        result["external_rvs"], galah_rows, replace_prefixes=(GALAH_TELESCOPE_PREFIX,)
+    )
+    result["external_rvs"] = merge_external_rv_lists(
+        result["external_rvs"], apogee_rows, replace_prefixes=(APOGEE_TELESCOPE_PREFIX,)
+    )
+    return result
 
 
 def _query_external_rvs_combined(prop_args: str) -> list:
@@ -265,11 +307,20 @@ def process_query_results(main_rows, unified_external_rows):
 
     fill_inclination_in_metadata(metadata)
 
-    external_rvs = _external_rvs_from_unified_rows(unified_external_rows)
+    ra_meta = metadata.get("RA")
+    dec_meta = metadata.get("Dec")
+    external_rvs = _external_rvs_from_unified_rows(
+        unified_external_rows, ra_deg=ra_meta, dec_deg=dec_meta
+    )
     return {"metadata": metadata, "external_rvs": external_rvs}
 
 
-def _external_rvs_from_unified_rows(rows: list) -> list:
+def _external_rvs_from_unified_rows(
+    rows: list,
+    *,
+    ra_deg: float | None = None,
+    dec_deg: float | None = None,
+) -> list:
     external_rvs = []
     for r in rows:
         cat = str(r.get("ext_cat", "") or "")
@@ -292,9 +343,21 @@ def _external_rvs_from_unified_rows(rows: list) -> list:
                         t = Time(str(obs_str).strip(), format="isot", scale="utc").mjd
                     except Exception:
                         t = 0.0
-                external_rvs.append(
-                    {"telescope": "LAMOST_LRS", "mjd": t, "rv": rv, "rv_err": err, "flag": "z_meas"}
+                rec = finalize_external_rv_record(
+                    {
+                        "telescope": "LAMOST_LRS",
+                        "mjd": t,
+                        "rv": rv,
+                        "rv_err": err,
+                        "flag": "z_meas",
+                    },
+                    ra_deg=ra_deg,
+                    dec_deg=dec_deg,
+                    native_frame=NativeFrame.HELIOCENTRIC,
+                    site_key="LAMOST",
                 )
+                if rec is not None:
+                    external_rvs.append(rec)
         elif cat == "LAMOST_MRS":
             rv = float(z) if z is not None and np.isfinite(float(z)) else np.nan
             if np.isfinite(rv):
@@ -309,15 +372,21 @@ def _external_rvs_from_unified_rows(rows: list) -> list:
                     if z_err is not None and np.isfinite(float(z_err))
                     else 0.0
                 )
-                external_rvs.append(
+                rec = finalize_external_rv_record(
                     {
                         "telescope": "LAMOST_MRS",
                         "mjd": t,
                         "rv": rv,
                         "rv_err": err,
                         "flag": flag,
-                    }
+                    },
+                    ra_deg=ra_deg,
+                    dec_deg=dec_deg,
+                    native_frame=NativeFrame.BARYCENTRIC,
+                    site_key="LAMOST",
                 )
+                if rec is not None:
+                    external_rvs.append(rec)
         elif cat == "RAVE_DR6":
             rv = float(z) if z is not None and np.isfinite(float(z)) else np.nan
             if np.isfinite(rv):
@@ -326,15 +395,24 @@ def _external_rvs_from_unified_rows(rows: list) -> list:
                     if z_err is not None and np.isfinite(float(z_err))
                     else 0.0
                 )
-                external_rvs.append(
+                t = mjd_from_rave_obs_id(flag)
+                if not mjd_is_valid(t):
+                    continue
+                rec = finalize_external_rv_record(
                     {
                         "telescope": "RAVE_DR6",
-                        "mjd": 0.0,
+                        "mjd": t,
                         "rv": rv,
                         "rv_err": err,
                         "flag": flag,
-                    }
+                    },
+                    ra_deg=ra_deg,
+                    dec_deg=dec_deg,
+                    native_frame=NativeFrame.HELIOCENTRIC,
+                    site_key="RAVE",
                 )
+                if rec is not None:
+                    external_rvs.append(rec)
     return external_rvs
 
 
@@ -433,6 +511,60 @@ def parse_gaia_metadata_from_star_summary(path) -> dict | None:
             meta[k] = _parse_scalar(v)
         i += 1
     return meta if meta else None
+
+
+def is_desi_external_telescope(name: str) -> bool:
+    return str(name or "").startswith("DESI_")
+
+
+def format_external_rv_line(ext: dict) -> str:
+    flag = str(ext.get("flag", "") or "").strip()
+    base = (
+        f"{ext['telescope']} {float(ext['mjd']):.5f} "
+        f"{float(ext['rv']):.3f} {float(ext['rv_err']):.3f}"
+    )
+    return f"{base} {flag}".rstrip()
+
+
+def merge_external_rv_lists(
+    existing: list,
+    new_rows: list,
+    *,
+    replace_prefixes: tuple[str, ...] = (DESI_TELESCOPE_PREFIX,),
+) -> list:
+    """Drop rows whose telescope matches a replace prefix, then append new_rows."""
+    kept: list = []
+    for row in existing:
+        tele = str(row.get("telescope", "") or "")
+        if any(tele.startswith(p) for p in replace_prefixes):
+            continue
+        kept.append(row)
+    kept.extend(new_rows)
+    kept.sort(key=lambda r: (float(r.get("mjd", 0.0)), str(r.get("telescope", ""))))
+    return kept
+
+
+def replace_external_rv_section_in_summary(path: Path, external_rvs: list) -> None:
+    """Rewrite [EXTERNAL RV DATA] in a star summary, preserving other sections."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    marker = "[EXTERNAL RV DATA]"
+    if marker not in text:
+        raise ValueError(f"{path}: missing {marker}")
+    start = text.index(marker)
+    rest = text[start + len(marker) :]
+    end = len(text)
+    for off, ch in enumerate(rest):
+        if ch == "\n" and off + 1 < len(rest) and rest[off + 1] == "[":
+            end = start + len(marker) + off + 1
+            break
+    lines = [marker, EXTERNAL_RV_HEADER_COMMENT]
+    if external_rvs:
+        for ext in external_rvs:
+            lines.append(format_external_rv_line(ext))
+    else:
+        lines.append("# No external data found.")
+    new_block = "\n".join(lines) + "\n"
+    path.write_text(text[:start] + new_block + text[end:], encoding="utf-8")
 
 
 def parse_external_rvs_from_star_summary(path) -> list:
@@ -566,14 +698,111 @@ def _propagation_args_from_disk_metadata(meta: dict) -> str | None:
     return f"{ra}, {dec}, {plx}, {pmra}, {pmdec}, {rv}, 2016.0, 2000.0"
 
 
-def query_external_rvs_only_from_disk_metadata(metadata: dict) -> list:
+def _query_lamost_rave_from_metadata(metadata: dict) -> list:
     prop = _propagation_args_from_disk_metadata(metadata)
     if prop is None:
         return []
     rows = _query_external_rvs_combined(prop)
     if not rows:
         rows = _query_external_rvs_sequential(prop)
-    return _external_rvs_from_unified_rows(rows)
+    meta = normalize_parsed_star_metadata(metadata)
+    return _external_rvs_from_unified_rows(
+        rows, ra_deg=meta.get("RA"), dec_deg=meta.get("Dec")
+    )
+
+
+def query_external_rvs_only_from_disk_metadata(metadata: dict) -> list:
+    """LAMOST + RAVE via Gaia archive TAP (cone on propagated position)."""
+    return _query_lamost_rave_from_metadata(metadata)
+
+
+def _positions_from_metadata(metadata: dict | None, sid: int) -> dict[int, tuple[float, float]] | None:
+    if metadata is None:
+        return None
+    m = normalize_parsed_star_metadata(metadata)
+    try:
+        ra = float(m.get("RA"))
+        dec = float(m.get("Dec"))
+        if np.isfinite(ra) and np.isfinite(dec):
+            return {sid: (ra, dec)}
+    except (TypeError, ValueError):
+        pass
+    return None
+
+
+def query_external_rvs_for_source(
+    source_id: int | None,
+    metadata: dict | None,
+    *,
+    sources: tuple[str, ...] | None = None,
+) -> list:
+    """External RV rows for one Gaia source (LAMOST, RAVE, DESI, GALAH, APOGEE, GES)."""
+    enabled = set(sources) if sources else {
+        "lamost",
+        "rave",
+        "desi",
+        "galah",
+        "apogee",
+        "ges",
+    }
+    rows: list = []
+    if metadata and ("lamost" in enabled or "rave" in enabled):
+        rows.extend(_query_lamost_rave_from_metadata(metadata))
+    if source_id is not None:
+        try:
+            sid = int(source_id)
+        except (TypeError, ValueError):
+            sid = 0
+        if sid > 0:
+            positions = _positions_from_metadata(metadata, sid)
+            if "desi" in enabled:
+                desi_rows = query_desi_rvs_for_gaia_ids([sid], positions_by_id=positions).get(sid, [])
+                rows = merge_external_rv_lists(rows, desi_rows, replace_prefixes=(DESI_TELESCOPE_PREFIX,))
+            if "galah" in enabled:
+                galah_rows = query_galah_rvs_for_gaia_ids([sid], positions_by_id=positions).get(sid, [])
+                rows = merge_external_rv_lists(rows, galah_rows, replace_prefixes=(GALAH_TELESCOPE_PREFIX,))
+            if "apogee" in enabled:
+                apogee_rows = query_apogee_rvs_for_gaia_ids([sid], positions_by_id=positions).get(sid, [])
+                rows = merge_external_rv_lists(rows, apogee_rows, replace_prefixes=(APOGEE_TELESCOPE_PREFIX,))
+            if "ges" in enabled:
+                ges_rows = query_ges_rvs_for_gaia_ids([sid], positions_by_id=positions).get(sid, [])
+                rows = merge_external_rv_lists(rows, ges_rows, replace_prefixes=(GES_TELESCOPE_PREFIX,))
+    return rows
+
+
+def update_summary_desi_external_rvs(summary_path: Path, *, source_id: int | None = None) -> int:
+    """Query DESI and patch [EXTERNAL RV DATA] in one summary. Returns number of DESI rows written."""
+    summary_path = Path(summary_path)
+    meta = parse_gaia_metadata_from_star_summary(summary_path)
+    if meta is None:
+        return 0
+    meta = normalize_parsed_star_metadata(meta)
+    sid = source_id
+    if sid is None:
+        try:
+            sid = int(meta.get("Source_ID", 0))
+        except (TypeError, ValueError):
+            sid = 0
+    if not sid:
+        return 0
+    positions = None
+    try:
+        ra = float(meta.get("RA"))
+        dec = float(meta.get("Dec"))
+        if np.isfinite(ra) and np.isfinite(dec):
+            positions = {int(sid): (ra, dec)}
+    except (TypeError, ValueError):
+        positions = None
+    if positions is None:
+        logging.warning(
+            "Gaia_DR3_%s: no RA/Dec in summary; DESI lookup uses source_id only",
+            sid,
+        )
+    desi_rows = query_desi_rvs_for_gaia_ids([int(sid)], positions_by_id=positions).get(int(sid), [])
+    existing = parse_external_rvs_from_star_summary(summary_path)
+    merged = merge_external_rv_lists(existing, desi_rows)
+    replace_external_rv_section_in_summary(summary_path, merged)
+    return len(desi_rows)
 
 
 def load_gaia_data_from_star_summary(path, expected_source_id: int | None = None) -> dict | None:

--- a/darkhunter_rv/galah_rv_query.py
+++ b/darkhunter_rv/galah_rv_query.py
@@ -1,0 +1,137 @@
+"""Query GALAH DR3 VAC radial velocities from VizieR TAP."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Sequence
+
+import numpy as np
+
+from .rv_frame import NativeFrame, finalize_external_rv_record
+from .vizier_tap import execute_vizier_adql, parse_gaia_source_id, sql_in_ints, sql_max_err_clause
+
+logger = logging.getLogger(__name__)
+
+GALAH_TELESCOPE_PREFIX = "GALAH_DR3"
+GALAH_RV_TABLE = '"J/MNRAS/506/150/rv"'
+GALAH_STARS_TABLE = '"J/MNRAS/506/150/stars"'
+
+_GALAH_SQL_BY_GAIA = """
+SELECT s.GaiaEDR3 AS gaia_id, r.GALAH AS galah_id,
+       r.RVgalah AS rv, r.e_RVgalah AS rv_err, r.MJDlocal AS mjd, r.f_RVgalah AS rv_flag
+FROM {rv} AS r
+JOIN {stars} AS s ON r.GALAH = s.GALAH
+WHERE s.GaiaEDR3 IN ({ids})
+  AND r.RVgalah IS NOT NULL
+{err_clause}"""
+
+
+def _float_or_nan(val: Any) -> float:
+    try:
+        if val in (None, "", "null", "nan"):
+            return float("nan")
+        return float(val)
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def galah_rows_to_external_rvs(
+    rows: Sequence[dict[str, Any]],
+    *,
+    ra_deg: float | None,
+    dec_deg: float | None,
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        rv = _float_or_nan(row.get("rv"))
+        rv_err = _float_or_nan(row.get("rv_err"))
+        mjd = _float_or_nan(row.get("mjd"))
+        if not np.isfinite(rv) or not np.isfinite(mjd):
+            continue
+        galah_id = str(row.get("galah_id", "") or "")
+        rv_flag = str(row.get("rv_flag", "") or "")
+        flag = f"galah={galah_id}"
+        if rv_flag not in ("", "null"):
+            flag = f"{flag} use_rv_flag={rv_flag}"
+        rec = finalize_external_rv_record(
+            {
+                "telescope": GALAH_TELESCOPE_PREFIX,
+                "mjd": mjd,
+                "rv": rv,
+                "rv_err": rv_err if np.isfinite(rv_err) else 0.0,
+                "flag": flag,
+            },
+            ra_deg=ra_deg,
+            dec_deg=dec_deg,
+            native_frame=NativeFrame.HELIOCENTRIC,
+            site_key="GALAH_AAT",
+        )
+        if rec is not None:
+            out.append(rec)
+    out.sort(key=lambda r: (r["mjd"], r["flag"]))
+    return out
+
+
+def _query_galah_by_gaia_ids(
+    gaia_ids: Sequence[int],
+    *,
+    max_rv_err: float | None,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    id_list = sql_in_ints(list(gaia_ids))
+    sql = _GALAH_SQL_BY_GAIA.format(
+        rv=GALAH_RV_TABLE,
+        stars=GALAH_STARS_TABLE,
+        ids=id_list,
+        err_clause=sql_max_err_clause("r.e_RVgalah", max_rv_err),
+    )
+    return execute_vizier_adql(sql, timeout=timeout)
+
+
+def query_galah_rvs_for_gaia_ids(
+    source_ids: Sequence[int],
+    *,
+    positions_by_id: dict[int, tuple[float, float]] | None = None,
+    max_rv_err: float | None = None,
+    chunk_size: int = 200,
+    timeout: float = 180.0,
+    progress: bool = False,
+) -> dict[int, list[dict[str, Any]]]:
+    """
+    Return GALAH external-RV rows keyed by Gaia DR3 source_id (via GaiaEDR3 in stars table).
+    """
+    ids = sorted({int(sid) for sid in source_ids if sid})
+    if not ids:
+        return {}
+
+    positions = positions_by_id or {}
+    rows_by_sid: dict[int, list[dict[str, Any]]] = {}
+
+    n_chunks = (len(ids) + chunk_size - 1) // chunk_size
+    for chunk_i, start in enumerate(range(0, len(ids), chunk_size), start=1):
+        chunk = ids[start : start + chunk_size]
+        if progress:
+            print(
+                f"GALAH GaiaEDR3 batch {chunk_i}/{n_chunks} ({len(chunk)} stars)...",
+                flush=True,
+            )
+        try:
+            rows = _query_galah_by_gaia_ids(chunk, max_rv_err=max_rv_err, timeout=timeout)
+        except Exception as exc:
+            logger.warning("GALAH query failed for %d Gaia ids: %s", len(chunk), exc)
+            continue
+
+        by_gaia: dict[int, list[dict[str, Any]]] = {sid: [] for sid in chunk}
+        for row in rows:
+            sid = parse_gaia_source_id(row.get("gaia_id"))
+            if sid is not None and sid in by_gaia:
+                by_gaia[sid].append(row)
+
+        for sid in chunk:
+            pos = positions.get(sid)
+            ra, dec = (pos[0], pos[1]) if pos else (None, None)
+            ext = galah_rows_to_external_rvs(by_gaia.get(sid, []), ra_deg=ra, dec_deg=dec)
+            if ext:
+                rows_by_sid[sid] = ext
+
+    return rows_by_sid

--- a/darkhunter_rv/ges_rv_query.py
+++ b/darkhunter_rv/ges_rv_query.py
@@ -1,0 +1,167 @@
+"""Query Gaia-ESO DR5.1 radial velocities from VizieR TAP."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Sequence
+
+import numpy as np
+from astropy.time import Time
+
+from .cone_utils import filter_rows_in_cone
+from .rv_frame import NativeFrame, finalize_external_rv_record
+from .vizier_tap import execute_vizier_adql, sql_max_err_clause
+
+logger = logging.getLogger(__name__)
+
+GES_TELESCOPE_PREFIX = "GES_DR5"
+# Gaia-ESO DR5.1 is not published on VizieR TAP (table III/500/ges_dr5 returns 404).
+GES_VIZIER_AVAILABLE = False
+GES_TABLE = '"III/500/ges_dr5"'
+GES_CONE_RADIUS_ARCSEC = 2.0
+GES_CONE_RADIUS_DEG = GES_CONE_RADIUS_ARCSEC / 3600.0
+
+_GES_SQL_BY_BOX = """
+SELECT OBJECT AS ges_object, RA AS ra, DECLINATION AS dec,
+       VRAD AS rv, E_VRAD AS rv_err, VRAD_FLAG AS vrad_flag, DATE_OBS AS date_obs
+FROM {table}
+WHERE RA BETWEEN {ra} - {radius_deg} AND {ra} + {radius_deg}
+  AND DECLINATION BETWEEN {dec} - {radius_deg} AND {dec} + {radius_deg}
+  AND VRAD IS NOT NULL
+  AND (VRAD_FLAG IS NULL OR VRAD_FLAG = 0)
+{err_clause}"""
+
+
+def _float_or_nan(val: Any) -> float:
+    try:
+        if val in (None, "", "null", "nan"):
+            return float("nan")
+        return float(val)
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def _mjd_from_date_obs(date_obs: Any) -> float:
+    s = str(date_obs or "").strip()
+    if not s:
+        return float("nan")
+    try:
+        return float(Time(s, scale="utc").mjd)
+    except Exception:
+        return float("nan")
+
+
+def ges_rows_to_external_rvs(
+    rows: Sequence[dict[str, Any]],
+    *,
+    ra_deg: float | None,
+    dec_deg: float | None,
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        rv = _float_or_nan(row.get("rv"))
+        rv_err = _float_or_nan(row.get("rv_err"))
+        mjd = _mjd_from_date_obs(row.get("date_obs"))
+        if not np.isfinite(rv) or not np.isfinite(mjd):
+            continue
+        obj = str(row.get("ges_object", "") or "")
+        flag = f"ges={obj}"
+        sep = row.get("sep_deg")
+        if sep not in (None, "", "null"):
+            try:
+                sep_arcsec = float(sep) * 3600.0
+                if np.isfinite(sep_arcsec):
+                    flag = f"{flag} sep={sep_arcsec:.2f}arcsec"
+            except (TypeError, ValueError):
+                pass
+        rec = finalize_external_rv_record(
+            {
+                "telescope": GES_TELESCOPE_PREFIX,
+                "mjd": mjd,
+                "rv": rv,
+                "rv_err": rv_err if np.isfinite(rv_err) else 0.0,
+                "flag": flag,
+            },
+            ra_deg=ra_deg,
+            dec_deg=dec_deg,
+            native_frame=NativeFrame.BARYCENTRIC,
+            site_key="GES_VLT",
+        )
+        if rec is not None:
+            out.append(rec)
+    out.sort(key=lambda r: (r["mjd"], r["flag"]))
+    return out
+
+
+def _query_ges_by_cone(
+    ra_deg: float,
+    dec_deg: float,
+    *,
+    max_rv_err: float | None,
+    radius_deg: float = GES_CONE_RADIUS_DEG,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    sql = _GES_SQL_BY_BOX.format(
+        table=GES_TABLE,
+        ra=ra_deg,
+        dec=dec_deg,
+        radius_deg=radius_deg,
+        err_clause=sql_max_err_clause("E_VRAD", max_rv_err),
+    )
+    rows = execute_vizier_adql(sql, timeout=timeout)
+    return filter_rows_in_cone(
+        rows, ra_deg, dec_deg, ra_key="ra", dec_key="dec", radius_deg=radius_deg
+    )
+
+
+def query_ges_rvs_for_gaia_ids(
+    source_ids: Sequence[int],
+    *,
+    positions_by_id: dict[int, tuple[float, float]] | None = None,
+    max_rv_err: float | None = None,
+    cone_radius_deg: float = GES_CONE_RADIUS_DEG,
+    timeout: float = 180.0,
+    progress: bool = False,
+) -> dict[int, list[dict[str, Any]]]:
+    """Return GES DR5.1 RVs keyed by Gaia DR3 source_id (RA/Dec cone only)."""
+    ids = sorted({int(sid) for sid in source_ids if sid})
+    if not ids:
+        return {}
+    if not GES_VIZIER_AVAILABLE:
+        logger.warning(
+            "GES skipped: Gaia-ESO DR5 is not available on VizieR TAP "
+            "(use the ESO Gaia-ESO archive directly)."
+        )
+        return {}
+
+    positions = positions_by_id or {}
+    rows_by_sid: dict[int, list[dict[str, Any]]] = {}
+
+    for i, sid in enumerate(ids, start=1):
+        pos = positions.get(sid)
+        if pos is None:
+            continue
+        try:
+            ra, dec = float(pos[0]), float(pos[1])
+        except (TypeError, ValueError, IndexError):
+            continue
+        if not (np.isfinite(ra) and np.isfinite(dec)):
+            continue
+        if progress:
+            print(f"GES cone {i}/{len(ids)} Gaia_DR3_{sid}...", flush=True)
+        try:
+            raw = _query_ges_by_cone(
+                ra,
+                dec,
+                max_rv_err=max_rv_err,
+                radius_deg=cone_radius_deg,
+                timeout=timeout,
+            )
+        except Exception as exc:
+            logger.warning("GES cone query failed for Gaia %s: %s", sid, exc)
+            continue
+        ext = ges_rows_to_external_rvs(raw, ra_deg=ra, dec_deg=dec)
+        if ext:
+            rows_by_sid[sid] = ext
+
+    return rows_by_sid

--- a/darkhunter_rv/rv_frame.py
+++ b/darkhunter_rv/rv_frame.py
@@ -1,0 +1,239 @@
+"""Normalize external survey RVs to solar-system barycentric (km/s)."""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import Any
+
+import numpy as np
+from astropy import units as u
+from astropy.coordinates import EarthLocation
+from astropy.time import Time
+
+from .rv_point_filters import mjd_is_valid, rv_value_is_valid
+
+logger = logging.getLogger(__name__)
+
+EXTERNAL_RV_HEADER_COMMENT = (
+    "# Telescope | MJD | RV (km/s) | Err (km/s) | Flag/ID  "
+    "(RVs are solar-system barycentric)"
+)
+
+
+class NativeFrame(str, Enum):
+    HELIOCENTRIC = "heliocentric"
+    BARYCENTRIC = "barycentric"
+
+
+# Observatory geolocations (IAU EarthLocation conventions).
+OBSERVATORY_SITES: dict[str, EarthLocation] = {
+    "LICK": EarthLocation(lat=37.3413 * u.deg, lon=-121.6438 * u.deg, height=1280 * u.m),
+    "GALAH_AAT": EarthLocation(lat=-31.2733 * u.deg, lon=149.0642 * u.deg, height=1164 * u.m),
+    "APOGEE_APO": EarthLocation(lat=32.7801 * u.deg, lon=-105.8208 * u.deg, height=2798 * u.m),
+    "APOGEE_LCO": EarthLocation(lat=-29.0146 * u.deg, lon=-70.7380 * u.deg, height=2287 * u.m),
+    "LAMOST": EarthLocation(lat=40.3956 * u.deg, lon=117.5783 * u.deg, height=960 * u.m),
+    "RAVE": EarthLocation(lat=-31.2733 * u.deg, lon=149.0642 * u.deg, height=1164 * u.m),
+    "DESI": EarthLocation(lat=31.9634 * u.deg, lon=-111.5981 * u.deg, height=2120 * u.m),
+    "GES_VLT": EarthLocation(lat=-24.6275 * u.deg, lon=-70.4042 * u.deg, height=2635 * u.m),
+}
+
+NATIVE_FRAME_BY_PREFIX: dict[str, NativeFrame] = {
+    "LAMOST_LRS": NativeFrame.HELIOCENTRIC,
+    "LAMOST_MRS": NativeFrame.BARYCENTRIC,
+    "RAVE_DR6": NativeFrame.HELIOCENTRIC,
+    "DESI_DR1": NativeFrame.HELIOCENTRIC,
+    "GALAH_DR3": NativeFrame.HELIOCENTRIC,
+    "APOGEE_DR17": NativeFrame.BARYCENTRIC,
+    "GES_DR5": NativeFrame.BARYCENTRIC,
+}
+
+DEFAULT_SITE_BY_PREFIX: dict[str, str] = {
+    "LAMOST_LRS": "LAMOST",
+    "LAMOST_MRS": "LAMOST",
+    "RAVE_DR6": "RAVE",
+    "DESI_DR1": "DESI",
+    "GALAH_DR3": "GALAH_AAT",
+    "APOGEE_DR17": "APOGEE_APO",
+    "GES_DR5": "GES_VLT",
+}
+
+
+def site_key_for_apogee_telescope(telescope_tag: str | None) -> str:
+    """Map APOGEE ``TELESCOPE`` column to observatory site key."""
+    t = str(telescope_tag or "").strip().lower()
+    if "lco" in t:
+        return "APOGEE_LCO"
+    return "APOGEE_APO"
+
+
+def native_frame_for_telescope(telescope: str) -> NativeFrame:
+    tele = str(telescope or "").strip()
+    for prefix, frame in NATIVE_FRAME_BY_PREFIX.items():
+        if tele.startswith(prefix) or tele == prefix:
+            return frame
+    return NativeFrame.HELIOCENTRIC
+
+
+def default_site_key_for_telescope(telescope: str) -> str:
+    tele = str(telescope or "").strip()
+    for prefix, site in DEFAULT_SITE_BY_PREFIX.items():
+        if tele.startswith(prefix) or tele == prefix:
+            return site
+    return "LICK"
+
+
+# km/s per (AU/day): AU_km / seconds_per_day
+_AU_DAY_TO_KM_S = 149597870.7 / 86400.0
+
+
+def _los_unit_icrs(ra_deg: float, dec_deg: float) -> np.ndarray:
+    ra = np.radians(float(ra_deg))
+    dec = np.radians(float(dec_deg))
+    return np.array(
+        [np.cos(dec) * np.cos(ra), np.cos(dec) * np.sin(ra), np.sin(dec)],
+        dtype=float,
+    )
+
+
+def _helio_bary_orbit_delta_kms(ra_deg: float, dec_deg: float, mjd: float) -> float:
+    """
+    Orbit-only (barycentric − heliocentric) correction along the line of sight (km/s).
+
+    Diurnal terms largely cancel in this difference at a fixed site; sufficient for
+  external-RV cross-checks at ~10 km/s precision.
+    """
+    import erfa
+
+    t = Time(float(mjd), format="mjd", scale="utc")
+    d1, d2 = t.tdb.jd1, t.tdb.jd2
+    star = _los_unit_icrs(ra_deg, dec_deg)
+    pvh, pvb = erfa.epv00(d1, d2)
+    v_bary = -float(np.dot(np.asarray(pvb[1], dtype=float), star)) * _AU_DAY_TO_KM_S
+    v_helio = -float(np.dot(np.asarray(pvh[1], dtype=float), star)) * _AU_DAY_TO_KM_S
+    return v_bary - v_helio
+
+
+def helio_to_bary_kms(
+    rv_helio_kms: float,
+    *,
+    ra_deg: float,
+    dec_deg: float,
+    mjd: float,
+    site_key: str,
+) -> float:
+    """Convert heliocentric RV (km/s) at ``site_key`` to solar-system barycentric."""
+    del site_key  # orbit delta is site-independent at our precision
+    return float(rv_helio_kms) + _helio_bary_orbit_delta_kms(ra_deg, dec_deg, mjd)
+
+
+def _append_flag(flag: str, suffix: str) -> str:
+    s = str(flag or "").strip()
+    if not suffix:
+        return s
+    if suffix in s:
+        return s
+    return f"{s} {suffix}".strip() if s else suffix
+
+
+def normalize_external_rv_to_barycentric(
+    rv_kms: float,
+    *,
+    ra_deg: float | None,
+    dec_deg: float | None,
+    mjd: float,
+    telescope: str,
+    native_frame: NativeFrame | None = None,
+    site_key: str | None = None,
+    flag: str = "",
+) -> dict[str, Any] | None:
+    """
+    Return summary external-RV fields with RV in barycentric km/s, or None if unusable.
+
+    Skips rows without valid MJD, coordinates, or RV value.
+    """
+    if not mjd_is_valid(mjd):
+        return None
+    if not rv_value_is_valid(rv_kms):
+        return None
+    try:
+        ra = float(ra_deg)
+        dec = float(dec_deg)
+    except (TypeError, ValueError):
+        return None
+    if not (np.isfinite(ra) and np.isfinite(dec)):
+        return None
+
+    frame = native_frame or native_frame_for_telescope(telescope)
+    site = site_key or default_site_key_for_telescope(telescope)
+    rv_out = float(rv_kms)
+    flag_out = str(flag or "")
+
+    if frame == NativeFrame.HELIOCENTRIC:
+        try:
+            rv_out = helio_to_bary_kms(rv_out, ra_deg=ra, dec_deg=dec, mjd=float(mjd), site_key=site)
+        except Exception as exc:
+            logger.debug("helio→bary failed for %s MJD=%s: %s", telescope, mjd, exc)
+            return None
+        flag_out = _append_flag(flag_out, "conv=helio→bary")
+    else:
+        flag_out = _append_flag(flag_out, "frame=bary-native")
+
+    if not rv_value_is_valid(rv_out):
+        return None
+    return {"rv": rv_out, "flag": flag_out}
+
+
+def finalize_external_rv_record(
+    record: dict[str, Any],
+    *,
+    ra_deg: float | None,
+    dec_deg: float | None,
+    native_frame: NativeFrame | None = None,
+    site_key: str | None = None,
+) -> dict[str, Any] | None:
+    """Apply barycentric normalization to a partial external-RV dict (telescope/mjd/rv/rv_err/flag)."""
+    tele = str(record.get("telescope", "") or "")
+    try:
+        mjd = float(record["mjd"])
+        rv = float(record["rv"])
+        rv_err = float(record.get("rv_err", 0.0) or 0.0)
+    except (KeyError, TypeError, ValueError):
+        return None
+    norm = normalize_external_rv_to_barycentric(
+        rv,
+        ra_deg=ra_deg,
+        dec_deg=dec_deg,
+        mjd=mjd,
+        telescope=tele,
+        native_frame=native_frame,
+        site_key=site_key,
+        flag=str(record.get("flag", "") or ""),
+    )
+    if norm is None:
+        return None
+    return {
+        "telescope": tele,
+        "mjd": mjd,
+        "rv": norm["rv"],
+        "rv_err": max(rv_err, 1e-4) if np.isfinite(rv_err) and rv_err > 0 else 1e-4,
+        "flag": norm["flag"],
+    }
+
+
+def mjd_from_rave_obs_id(obs_id: str) -> float:
+    """
+    Parse observation date from RAVE ``rave_obs_id`` (leading YYMMDD before first '_').
+    """
+    s = str(obs_id or "").strip()
+    if not s:
+        return float("nan")
+    head = s.split("_", 1)[0]
+    if len(head) != 6 or not head.isdigit():
+        return float("nan")
+    yy, mm, dd = int(head[:2]), int(head[2:4]), int(head[4:6])
+    year = 2000 + yy if yy < 80 else 1900 + yy
+    try:
+        return float(Time(f"{year:04d}-{mm:02d}-{dd:02d}", format="iso", scale="utc").mjd)
+    except Exception:
+        return float("nan")

--- a/darkhunter_rv/vizier_tap.py
+++ b/darkhunter_rv/vizier_tap.py
@@ -1,0 +1,60 @@
+"""VizieR TAP sync queries (ADQL → CSV)."""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+VIZIER_TAP_SYNC = "https://tapvizier.cds.unistra.fr/TAPVizieR/tap/sync"
+
+
+def execute_vizier_adql(query: str, *, timeout: float = 180.0) -> list[dict[str, str]]:
+    """Run ADQL on VizieR TAP (sync, CSV)."""
+    resp = requests.post(
+        VIZIER_TAP_SYNC,
+        data={
+            "REQUEST": "doQuery",
+            "LANG": "ADQL",
+            "FORMAT": "csv",
+            "QUERY": query,
+        },
+        timeout=timeout,
+    )
+    if not resp.ok:
+        detail = resp.text.strip()
+        if detail.startswith("<"):
+            detail = detail[:800]
+        raise RuntimeError(f"VizieR TAP HTTP {resp.status_code}: {detail[:500]}")
+    text = resp.text.strip()
+    if text.startswith("<?xml") or text.startswith("<"):
+        raise RuntimeError(f"VizieR TAP query failed: {text[:500]}")
+    if not text:
+        return []
+    reader = csv.DictReader(io.StringIO(text))
+    return [dict(row) for row in reader]
+
+
+def sql_in_ints(values: list[int]) -> str:
+    return ", ".join(str(int(v)) for v in values)
+
+
+def parse_gaia_source_id(val: object) -> int | None:
+    """Parse Gaia source_id from TAP CSV (string int; avoid float round-off)."""
+    if val in (None, "", "null", "nan"):
+        return None
+    try:
+        return int(str(val).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def sql_max_err_clause(column: str, max_rv_err: float | None) -> str:
+    """Optional ADQL ``AND column <= max`` fragment; empty when ``max_rv_err`` is None."""
+    if max_rv_err is None:
+        return ""
+    return f"  AND {column} <= {float(max_rv_err)}\n"

--- a/docs/external_rv_sources.md
+++ b/docs/external_rv_sources.md
@@ -1,0 +1,43 @@
+# External RV catalog sources
+
+Star summaries store third-party spectroscopic RVs in `[EXTERNAL RV DATA]`. **All values are solar-system barycentric (km/s)** after ingest, using each survey's observation MJD, observatory site, and the target RA/Dec from `[GAIA METADATA]`.
+
+Heliocentric catalog values are converted with `astropy.coordinates.SkyCoord.radial_velocity_correction` (see [`darkhunter_rv/rv_frame.py`](../darkhunter_rv/rv_frame.py)).
+
+## Batch update
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+python3 scripts/update_summary_external_rvs.py --sources galah,apogee,desi
+python3 scripts/update_summary_external_rvs.py --star-id 1551542027851147904 --sources galah,apogee,ges
+```
+
+DESI-only (legacy script):
+
+```bash
+python3 scripts/update_summary_desi_rvs.py --star-id 1551542027851147904
+```
+
+## Catalog reference
+
+| Source | Access | Native frame | Site key | Epoch column | Typical σ |
+|--------|--------|--------------|----------|--------------|-----------|
+| GALAH DR3 | VizieR `J/MNRAS/506/150/rv` + `stars` (`GaiaEDR3`) | Heliocentric | `GALAH_AAT` | `MJDlocal` | ~0.1 km/s |
+| APOGEE DR17 | VizieR `III/286/catalog` + `allvis` (`VHelio`, `Tel`) | Barycentric | `APOGEE_APO` / `APOGEE_LCO` | `MJD` | ~0.1 km/s |
+| Gaia-ESO DR5.1 | ESO archive only (not on VizieR TAP) | Barycentric | `GES_VLT` | `DATE_OBS` | 0.2–0.4 km/s |
+| DESI MWS DR1 | NOIRLab Data Lab `desi_dr1.mws` | Heliocentric | `DESI` | `min_mjd`/`max_mjd` | ~1 km/s |
+| LAMOST LRS DR9 | Gaia `external.lamost_dr9_lrs` | Heliocentric (`z`) | `LAMOST` | `obsdate` | variable |
+| LAMOST MRS DR9 | Gaia `external.lamost_dr9_mrs` | Barycentric (`rv_br1`) | `LAMOST` | `obsdate` | ~1 km/s |
+| RAVE DR6 | Gaia `external.ravedr6` | Heliocentric | `RAVE` | `rave_obs_id` date | ~1 km/s |
+
+**Not used:** Gaia DR3 mission-mean `radial_velocity` (no per-epoch MJD; may blend epochs).
+
+## Flag column
+
+Provenance is recorded in the `Flag/ID` field, e.g. `conv=helio→bary`, `frame=bary-native`, survey ids, cone separation.
+
+## Quality cuts at ingest
+
+All catalog rows with a finite RV and valid MJD are written to the summary (including large `rv_err`). Optional `--max-rv-err KM_S` on the batch script filters at download time; omit it to keep everything.
+
+Rows without valid MJD (≥ 40000) or coordinates are still skipped (needed for barycentric conversion and orbit fits).

--- a/docs/plans/steps/09-ccf-rv-estimator.md
+++ b/docs/plans/steps/09-ccf-rv-estimator.md
@@ -1,0 +1,111 @@
+---
+step_id: 09-ccf-rv-estimator
+phase: D
+status: complete_gauss_offset_adopted
+depends_on: [01-benchmark-cool-precision]
+blocks: []
+---
+
+# Step 09: CCF RV estimator study
+
+## Goal
+
+Compare mask-CCF RV estimators (Gaussian, parabolic, smoothed peak, bi-Gaussian), deploy an S/N-adaptive router, and rebuild bias with stellar-parameter trend correction. Phase gates ensure precision does not regress.
+
+## Decision (2026-06-09)
+
+**Production estimator: `gauss_offset` (symmetric offset + Gaussian).** Keep `MASK_CCF_ESTIMATOR = "gauss_offset"` in `darkhunter_rv/config.py`. Do not deploy `auto` or `smooth_peak` despite marginal post-debias σ_RV differences — Gaussian is simpler, essentially tied on the primary metric, and was the pre-debias composite winner.
+
+Stellar-regression debias for `gauss_offset` uses a **curve** model (`validation_output/ccf_estimator_study/bias_gauss_offset/`). Rebuild production `bias_statistics.txt` from a full mask-only pipeline on `calibration/bias_train.txt` before catalog refit (campaign regression used raw lag-frame RVs).
+
+## Key modules
+
+- `darkhunter_rv/ccf_rv_estimators.py` — estimator library + `select_ccf_estimator`
+- `darkhunter_rv/config.py` — `MASK_CCF_ESTIMATOR = "gauss_offset"`
+- `validation/ccf_rv_estimator_benchmark.py` — multi-estimator campaign
+- `validation/ccf_rv_post_debias.py` — post-debias σ_RV ranking
+- `validation/ccf_rv_precision_gates.py` — phase gate checks
+- `validation/ccf_estimator_bias.py` — Teff/logg/[M/H] bias regression
+- `calibration/ccf_estimator_baseline/` — frozen reference metrics
+
+## Phase C campaign (114 spectra, 19 029 chunks)
+
+Raw pre-debias metrics (not used for final decision — see post-debias below):
+
+| Estimator | median σ_RV (formal, pre-debias) | median chunk scatter (pre-debias) | composite |
+|-----------|-----------------------------------|-----------------------------------|-----------|
+| gauss_offset | 0.0087 km/s | 18.9 km/s | **9.73** |
+| auto | 0.0079 | 23.4 | 10.76 |
+| smooth_peak | 0.0077 | 22.0 | 10.12 |
+| bi_gauss | 0.0106 | 21.3 | 10.93 |
+
+Pre-debias σ_RV ≈ 0.008 km/s is an artifact of the 0.1 km/s per-chunk error floor, not science precision. Pre-debias scatter (~19 km/s) is order-to-order structure before debias.
+
+Artifacts: `validation_output/ccf_estimator_study/per_chunk_rv.csv`, `estimator_comparison.csv`, `phase_C_metrics.json`.
+
+## Phase C post-debias results (primary metric)
+
+Method: per estimator, fit nested bias regression (chunk curve + Teff/logg/[M/H] + per-object offset), subtract `adjusted_bias_kms`, IVW stack per exposure (`stack_calibrated_exposure`). All chunks with finite RV in the campaign; no extra high-S/N cut.
+
+| Estimator | median σ_RV (debiased) | p90 σ_RV | debiased chunk scatter | chosen bias model |
+|-----------|------------------------|----------|------------------------|-------------------|
+| auto | **0.0444 km/s** | 0.055 | 23.2 km/s | intercept |
+| **gauss_offset** | **0.0458** | 0.057 | 23.1 | curve |
+| parabolic_ls | 0.0469 | 0.058 | 22.7 | intercept |
+| smooth_peak | 0.0469 | 0.058 | **22.0** | intercept |
+| grid | 0.0484 | 0.060 | 23.3 | intercept |
+| bi_gauss | 0.0697 | 0.118 | 24.5 | curve |
+
+`auto` is marginally best on median σ_RV (~0.001 km/s over Gaussian). `smooth_peak` has lowest debiased chunk scatter but worse σ_RV. **Adopted: gauss_offset.**
+
+Artifacts: `validation_output/ccf_estimator_study/estimator_comparison_post_debias.csv`, `phase_C_post_debias_winner.json`, `epochs_post_debias__*.csv`.
+
+```bash
+PYTHONPATH=. python -m validation.ccf_rv_post_debias \
+  --wide-diagnostics validation_output/ccf_estimator_study/per_chunk_rv.csv \
+  --summary-dir output \
+  --out-dir validation_output/ccf_estimator_study
+```
+
+### Caveats
+
+- Debiased chunk scatter remains ~22 km/s because the benchmark used raw lag-frame mask CCF RVs, not full pipeline debias with per-order `bias_statistics.txt`.
+- Follow-up: mask-only pipeline on `calibration/bias_train.txt` with `gauss_offset`, then rebuild `bias_statistics.txt` for catalog refit.
+
+## Commands
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+PYTHONPATH=. pytest tests/test_ccf_rv_estimators.py \
+  tests/validation/test_ccf_rv_precision_gates.py \
+  tests/validation/test_ccf_estimator_bias.py \
+  tests/validation/test_ccf_rv_post_debias.py -q
+
+PYTHONPATH=. python -m validation.ccf_rv_estimator_benchmark \
+  --spectrum-list validation_output/chunk_campaign/spectrum_list.txt \
+  --chunk-layout calibration/chunk_layouts/subchunks_4.yaml \
+  --phase C --check-gate \
+  --baseline calibration/ccf_estimator_baseline/phase_c_reference.json \
+  --out-dir validation_output/ccf_estimator_study
+
+PYTHONPATH=. python -m validation.ccf_estimator_bias \
+  --wide-diagnostics validation_output/ccf_estimator_study/per_chunk_rv.csv \
+  --summary-dir output \
+  --estimator gauss_offset \
+  --out-dir validation_output/ccf_estimator_study/bias_gauss_offset
+```
+
+## Phase gates
+
+| Phase | Gate | Outcome |
+|-------|------|---------|
+| A | Synthetic estimator tests pass; `gauss_offset` backward compatible | Pass |
+| B | Best param sweep ≤ Phase A `median_sigma_rv_kms` | Not run on full bias_train |
+| C | Post-debias σ_RV comparison on chunk-campaign list | Done — see table above |
+| D | Stellar regression debias + `bias_statistics.txt` for gauss_offset | Campaign export done; pipeline rebuild pending |
+
+## Remaining
+
+- [ ] Mask-only pipeline on `calibration/bias_train.txt` with `gauss_offset` + `subchunks_4`
+- [ ] Replace `bias_statistics.txt` from pipeline orders (not campaign lag-frame regression)
+- [ ] Optional: re-run post-debias on pipeline diagnostics to confirm σ_RV after proper debias

--- a/scripts/update_summary_desi_rvs.py
+++ b/scripts/update_summary_desi_rvs.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Query DESI MWS RVs — thin wrapper around update_summary_external_rvs.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    if str(_REPO) not in sys.path:
+        sys.path.insert(0, str(_REPO))
+    prior = list(sys.argv)
+    try:
+        sys.argv = ["update_summary_external_rvs.py", "--sources", "desi", *prior[1:]]
+        ext_path = _REPO / "scripts" / "update_summary_external_rvs.py"
+        spec = importlib.util.spec_from_file_location("update_summary_external_rvs", ext_path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"cannot load {ext_path}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return int(mod.main())
+    finally:
+        sys.argv = prior
+
+
+if __name__ == "__main__":
+    print("update_summary_desi_rvs", flush=True)
+    raise SystemExit(main())

--- a/scripts/update_summary_external_rvs.py
+++ b/scripts/update_summary_external_rvs.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Query external spectroscopic RV catalogs and patch star summary [EXTERNAL RV DATA]."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from darkhunter_rv.apogee_rv_query import APOGEE_TELESCOPE_PREFIX, query_apogee_rvs_for_gaia_ids
+from darkhunter_rv.desi_rv_query import DESI_TELESCOPE_PREFIX, query_desi_rvs_for_gaia_ids
+from darkhunter_rv.galah_rv_query import GALAH_TELESCOPE_PREFIX, query_galah_rvs_for_gaia_ids
+from darkhunter_rv.ges_rv_query import GES_TELESCOPE_PREFIX, query_ges_rvs_for_gaia_ids
+from darkhunter_rv.gaia_utils import (
+    merge_external_rv_lists,
+    normalize_parsed_star_metadata,
+    parse_external_rvs_from_star_summary,
+    parse_gaia_metadata_from_star_summary,
+    query_external_rvs_for_source,
+    replace_external_rv_section_in_summary,
+)
+from darkhunter_rv.summary_paths import discover_summary_files, parse_object_id_from_summary
+
+ALL_SOURCES = ("lamost", "rave", "desi", "galah", "apogee", "ges")
+# VizieR batch + DESI; LAMOST/RAVE hit Gaia TAP per star (often 500s during DR4 prep).
+DEFAULT_SOURCES = ("desi", "galah", "apogee")
+SOURCE_PREFIXES: dict[str, tuple[str, ...]] = {
+    "lamost": ("LAMOST_LRS", "LAMOST_MRS"),
+    "rave": ("RAVE_DR6",),
+    "desi": (DESI_TELESCOPE_PREFIX,),
+    "galah": (GALAH_TELESCOPE_PREFIX,),
+    "apogee": (APOGEE_TELESCOPE_PREFIX,),
+    "ges": (GES_TELESCOPE_PREFIX,),
+}
+
+
+def _log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def _discover_summaries(out_dir: Path) -> list[Path]:
+    flat = sorted(out_dir.glob("Gaia_DR3_*_summary.txt"))
+    if flat:
+        return flat
+    return discover_summary_files(out_dir)
+
+
+def _parse_sources(raw: str) -> tuple[str, ...]:
+    parts = [p.strip().lower() for p in raw.split(",") if p.strip()]
+    unknown = [p for p in parts if p not in ALL_SOURCES]
+    if unknown:
+        raise SystemExit(f"Unknown --sources entries: {unknown} (choose from {ALL_SOURCES})")
+    return tuple(parts or DEFAULT_SOURCES)
+
+
+def _batch_query(
+    source: str,
+    all_ids: list[int],
+    positions_by_id: dict[int, tuple[float, float]],
+    *,
+    max_rv_err: float | None,
+    progress: bool,
+) -> dict[int, list[dict]]:
+    if source == "desi":
+        return query_desi_rvs_for_gaia_ids(
+            all_ids, positions_by_id=positions_by_id, progress=progress
+        )
+    if source == "galah":
+        return query_galah_rvs_for_gaia_ids(
+            all_ids,
+            positions_by_id=positions_by_id,
+            max_rv_err=max_rv_err,
+            progress=progress,
+        )
+    if source == "apogee":
+        return query_apogee_rvs_for_gaia_ids(
+            all_ids,
+            positions_by_id=positions_by_id,
+            max_rv_err=max_rv_err,
+            progress=progress,
+        )
+    if source == "ges":
+        return query_ges_rvs_for_gaia_ids(
+            all_ids,
+            positions_by_id=positions_by_id,
+            max_rv_err=max_rv_err,
+            progress=progress,
+        )
+    return {}
+
+
+def _merge_source_rows(
+    existing: list,
+    new_rows: list,
+    source: str,
+) -> list:
+    prefixes = SOURCE_PREFIXES.get(source, ())
+    if not prefixes:
+        return existing + new_rows
+    return merge_external_rv_lists(existing, new_rows, replace_prefixes=prefixes)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Fetch external survey RVs and update summary [EXTERNAL RV DATA] blocks."
+    )
+    ap.add_argument(
+        "--output-dir",
+        default=None,
+        help="Pipeline output root (default: repo output/ or DARKHUNTER_OUTPUT_DIR)",
+    )
+    ap.add_argument("--star-id", default=None, help="Optional single Gaia DR3 source id")
+    ap.add_argument(
+        "--sources",
+        default=",".join(DEFAULT_SOURCES),
+        help=(
+            f"Comma-separated catalogs (default: {','.join(DEFAULT_SOURCES)}). "
+            f"All choices: {','.join(ALL_SOURCES)}. "
+            "Add lamost,rave for Gaia-archive cross-match (slow; archive may 500)."
+        ),
+    )
+    ap.add_argument(
+        "--max-rv-err",
+        type=float,
+        default=None,
+        metavar="KM_S",
+        help="Optional: drop VizieR rows with rv_err above this (km/s). Default: keep all.",
+    )
+    ap.add_argument("--dry-run", action="store_true", help="List summaries only; do not query or write")
+    args = ap.parse_args()
+
+    sources = _parse_sources(args.sources)
+    _log(f"update_summary_external_rvs: sources={sources}")
+
+    repo = Path(__file__).resolve().parents[1]
+    out_dir = Path(args.output_dir) if args.output_dir else Path(
+        os.environ.get("DARKHUNTER_OUTPUT_DIR", repo / "output")
+    )
+    _log(f"Output dir: {out_dir}")
+
+    files = _discover_summaries(out_dir)
+    if args.star_id:
+        files = [p for p in files if parse_object_id_from_summary(p) == str(args.star_id)]
+    if not files:
+        _log("No summary files found.")
+        return 2
+
+    targets: list[tuple[Path, int, dict]] = []
+    positions_by_id: dict[int, tuple[float, float]] = {}
+
+    for summ in files:
+        sid_s = parse_object_id_from_summary(summ)
+        if not sid_s:
+            continue
+        sid = int(sid_s)
+        meta = parse_gaia_metadata_from_star_summary(summ)
+        if meta is None:
+            continue
+        meta = normalize_parsed_star_metadata(meta)
+        try:
+            ra = float(meta.get("RA"))
+            dec = float(meta.get("Dec"))
+            if np.isfinite(ra) and np.isfinite(dec):
+                positions_by_id[sid] = (ra, dec)
+        except (TypeError, ValueError):
+            pass
+        targets.append((summ, sid, meta))
+
+    _log(f"Found {len(targets)} star(s) with metadata.")
+
+    if args.dry_run:
+        for summ, sid, _ in targets:
+            _log(f"would_update Gaia_DR3_{sid} {summ}")
+        return 0
+
+    if not targets:
+        return 2
+
+    batch_sources = [s for s in sources if s in ("desi", "galah", "apogee", "ges")]
+    per_source: dict[str, dict[int, list[dict]]] = {}
+    all_ids = [sid for _, sid, _ in targets]
+
+    for src in batch_sources:
+        _log(f"Batch query: {src}...")
+        per_source[src] = _batch_query(
+            src,
+            all_ids,
+            positions_by_id,
+            max_rv_err=args.max_rv_err,
+            progress=True,
+        )
+
+    per_star_sources = [s for s in sources if s in ("lamost", "rave")]
+
+    updated = 0
+    total_rows = 0
+    for i, (summ, sid, meta) in enumerate(targets, start=1):
+        existing = parse_external_rvs_from_star_summary(summ)
+        merged = list(existing)
+
+        for src in batch_sources:
+            rows = per_source.get(src, {}).get(sid, [])
+            merged = _merge_source_rows(merged, rows, src)
+
+        if per_star_sources:
+            tap_rows = query_external_rvs_for_source(
+                sid,
+                meta,
+                sources=tuple(per_star_sources),
+            )
+            for src in per_star_sources:
+                prefixes = SOURCE_PREFIXES[src]
+                src_rows = [
+                    r
+                    for r in tap_rows
+                    if any(str(r.get("telescope", "")).startswith(p) for p in prefixes)
+                ]
+                merged = _merge_source_rows(merged, src_rows, src)
+
+        replace_external_rv_section_in_summary(summ, merged)
+        n_new = sum(
+            len(per_source.get(src, {}).get(sid, []))
+            for src in batch_sources
+        )
+        if n_new:
+            updated += 1
+            total_rows += n_new
+            _log(f"[{i}/{len(targets)}] Gaia_DR3_{sid}: wrote external RVs ({len(merged)} total rows)")
+        else:
+            _log(f"[{i}/{len(targets)}] Gaia_DR3_{sid}: no new batch rows ({len(merged)} total)")
+
+    _log(f"Done: {updated} summaries updated ({total_rows} new batch rows).")
+    return 0
+
+
+if __name__ == "__main__":
+    print("update_summary_external_rvs", flush=True)
+    raise SystemExit(main())

--- a/tests/test_apogee_rv_query.py
+++ b/tests/test_apogee_rv_query.py
@@ -1,0 +1,32 @@
+"""Tests for APOGEE external RV query helpers (no network)."""
+
+from darkhunter_rv.apogee_rv_query import apogee_rows_to_external_rvs, query_apogee_rvs_for_gaia_ids
+
+
+def test_apogee_rows_to_external_rvs() -> None:
+    rows = apogee_rows_to_external_rvs(
+        [
+            {
+                "gaia_id": "123",
+                "apogee_id": "2M0000+0000",
+                "apo_telescope": "apo25m",
+                "rv": "10.0",
+                "rv_err": "0.05",
+                "mjd": "58402.0",
+            }
+        ],
+        ra_deg=180.0,
+        dec_deg=-30.0,
+    )
+    assert len(rows) == 1
+    assert rows[0]["telescope"] == "APOGEE_DR17"
+    assert "frame=bary-native" in rows[0]["flag"]
+    assert "tel=apo25m" in rows[0]["flag"]
+
+
+def test_query_apogee_batch_empty(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "darkhunter_rv.apogee_rv_query.execute_vizier_adql",
+        lambda *_a, **_k: [],
+    )
+    assert query_apogee_rvs_for_gaia_ids([123], positions_by_id={123: (180.0, -30.0)}) == {}

--- a/tests/test_ccf_rv_estimators.py
+++ b/tests/test_ccf_rv_estimators.py
@@ -1,0 +1,94 @@
+"""Tests for mask-CCF RV estimators and S/N router."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from darkhunter_rv import config
+from darkhunter_rv.ccf_rv_estimators import (
+    EstimatorConfig,
+    estimate_ccf_rv,
+    prepare_ccf_fit_slice,
+    select_ccf_estimator,
+)
+from darkhunter_rv.rv_core import cross_correlate_stellar_mask
+
+
+def _synthetic_ccf_slice(
+    true_mu: float = 12.0,
+    *,
+    skew_kms: float = 0.0,
+    noise: float = 0.0,
+) -> tuple:
+    vel = np.linspace(-80.0, 80.0, 321)
+    y = 2.0 + 100.0 * np.exp(-0.5 * ((vel - true_mu) / 5.5) ** 2)
+    if abs(skew_kms) > 0:
+        # Red wing shoulder pulls symmetric Gaussian centroid away from true_mu.
+        y += 0.55 * 100.0 * np.exp(-0.5 * ((vel - true_mu - skew_kms) / 3.0) ** 2)
+    if noise > 0:
+        rng = np.random.default_rng(0)
+        y += rng.normal(0, noise, size=len(y))
+    peak_idx = int(np.argmax(y))
+    peak_val = float(y[peak_idx])
+    c_med = float(np.median(y))
+    c_mad = float(np.median(np.abs(y - c_med))) + 1e-12
+    peak_snr = float((peak_val - c_med) / (1.4826 * c_mad))
+    sl = prepare_ccf_fit_slice(
+        vel,
+        y,
+        peak_idx=peak_idx,
+        peak_val=peak_val,
+        peak_snr=peak_snr,
+        fit_width=50,
+        ccf_neg_spike_sigma=6.0,
+    )
+    assert sl is not None
+    return sl, true_mu
+
+
+def test_symmetric_estimators_near_true_shift():
+    sl, true_mu = _synthetic_ccf_slice(true_mu=-18.5, skew_kms=0.0)
+    cfg = EstimatorConfig()
+    for est in ("gauss_offset", "parabolic_ls", "smooth_peak", "grid"):
+        res = estimate_ccf_rv(est, sl, cfg=cfg)
+        assert np.isfinite(res.rv_kms)
+        assert abs(res.rv_kms - true_mu) < 0.5
+
+
+def test_skewed_ccf_bi_gauss_beats_gaussian():
+    sl, true_mu = _synthetic_ccf_slice(true_mu=10.0, skew_kms=14.0)
+    cfg = EstimatorConfig(high_asymmetry_bi_gauss_threshold=0.1)
+    gauss = estimate_ccf_rv("gauss_offset", sl, cfg=cfg)
+    bi = estimate_ccf_rv("bi_gauss", sl, cfg=cfg)
+    gauss_err = abs(gauss.rv_kms - true_mu)
+    bi_err = abs(bi.rv_kms - true_mu)
+    assert bi_err < gauss_err - 0.3
+
+
+def test_select_ccf_estimator_low_snr():
+    assert select_ccf_estimator(3.0, 0.1) == "parabolic_3pt"
+
+
+def test_select_ccf_estimator_high_asymmetry():
+    assert select_ccf_estimator(8.0, 0.35) == "bi_gauss"
+
+
+def test_select_ccf_estimator_default_gaussian():
+    assert select_ccf_estimator(7.0, 0.05) == "gauss_offset"
+
+
+def test_rv_core_backward_compat_symmetric_line():
+    wave = np.linspace(5000, 5100, 2048)
+    rest = 5050.0
+    true_rv = 12.3
+    shifted = rest * (1 + true_rv / config.C_KMS)
+    flux = 1.0 - 0.5 * np.exp(-0.5 * ((wave - shifted) / 0.3) ** 2)
+    obs = 1.0 - flux
+    mask_wave = np.linspace(5020.0, 5080.0, 40)
+    mask_strength = np.ones_like(mask_wave)
+
+    rv_gauss, _, _, _, _, _, _ = cross_correlate_stellar_mask(
+        wave, obs, mask_wave, mask_strength, max_lag=200, min_peak_snr=1.5
+    )
+    assert np.isfinite(rv_gauss)
+    assert abs(rv_gauss - true_rv) < 50

--- a/tests/test_desi_rv_query.py
+++ b/tests/test_desi_rv_query.py
@@ -1,0 +1,132 @@
+"""Tests for DESI external RV query helpers (no network)."""
+
+from darkhunter_rv import gaia_utils
+from darkhunter_rv.cone_utils import filter_rows_in_cone
+from darkhunter_rv.desi_rv_query import (
+    desi_rows_to_external_rvs,
+    query_desi_rvs_for_gaia_ids,
+)
+
+
+def test_desi_rows_to_external_rvs() -> None:
+    rows = desi_rows_to_external_rvs(
+        [
+            {
+                "source_id": "381210920555640576",
+                "targetid": "28684312379395",
+                "survey": "sv1",
+                "program": "other",
+                "rv_adop": "-153.35",
+                "rv_err": "1.12",
+                "rvs_warn": "0",
+                "min_mjd": "59230.16",
+                "max_mjd": "59230.19",
+            }
+        ],
+        ra_deg=180.0,
+        dec_deg=45.0,
+    )
+    assert len(rows) == 1
+    assert rows[0]["telescope"] == "DESI_DR1"
+    assert rows[0]["rv"] != -153.35
+    assert "conv=helio→bary" in rows[0]["flag"]
+    assert rows[0]["mjd"] == 0.5 * (59230.16 + 59230.19)
+    assert "sv1/other" in rows[0]["flag"]
+
+
+def test_desi_rows_skip_missing_mjd() -> None:
+    assert desi_rows_to_external_rvs([{"rv_adop": "1.0", "rv_err": "0.1"}]) == []
+
+
+def test_merge_external_rv_lists_replaces_desi() -> None:
+    existing = [
+        {"telescope": "LAMOST_LRS", "mjd": 59000.0, "rv": -10.0, "rv_err": 1.0, "flag": "z"},
+        {"telescope": "DESI_DR1", "mjd": 59200.0, "rv": -20.0, "rv_err": 2.0, "flag": "old"},
+    ]
+    new_desi = [{"telescope": "DESI_DR1", "mjd": 59230.0, "rv": -15.0, "rv_err": 1.5, "flag": "new"}]
+    merged = gaia_utils.merge_external_rv_lists(existing, new_desi)
+    assert len(merged) == 2
+    assert merged[0]["telescope"] == "LAMOST_LRS"
+    assert merged[1]["rv"] == -15.0
+
+
+def test_replace_external_rv_section(tmp_path) -> None:
+    summ = tmp_path / "Gaia_DR3_111_summary.txt"
+    summ.write_text(
+        "[GAIA METADATA]\nSource_ID: 111\nRA: 1.0\nDec: 2.0\n"
+        "\n[EXTERNAL RV DATA]\n# No external data found.\n"
+        "\n[PIPELINE RESULTS]\n# hdr\n"
+    )
+    gaia_utils.replace_external_rv_section_in_summary(
+        summ,
+        [{"telescope": "DESI_DR1", "mjd": 59230.0, "rv": -12.0, "rv_err": 1.0, "flag": "main/bright/1"}],
+    )
+    ext = gaia_utils.parse_external_rvs_from_star_summary(summ)
+    assert len(ext) == 1
+    assert ext[0]["telescope"] == "DESI_DR1"
+    text = summ.read_text()
+    assert "[PIPELINE RESULTS]" in text
+    assert "[GAIA METADATA]" in text
+
+
+def test_query_desi_batch_empty(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "darkhunter_rv.desi_rv_query.execute_datalab_adql",
+        lambda *_a, **_k: [],
+    )
+    assert query_desi_rvs_for_gaia_ids([123]) == {}
+
+
+def test_filter_rows_in_cone_negative_dec() -> None:
+    rows = [
+        {
+            "target_ra": "180.5",
+            "target_dec": "-45.25",
+            "rv_adop": "1.0",
+            "targetid": "1",
+            "survey": "main",
+            "program": "bright",
+            "rv_err": "0.1",
+            "rvs_warn": "0",
+            "min_mjd": "60000",
+            "max_mjd": "60001",
+        }
+    ]
+    kept = filter_rows_in_cone(rows, 180.5, -45.25, radius_deg=0.01)
+    assert len(kept) == 1
+    assert kept[0]["sep_deg"] == 0.0
+
+
+def test_query_desi_cone_fallback_when_source_id_misses(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def _fake_adql(sql: str, *, timeout: float = 180.0):
+        calls.append(sql)
+        if "m.source_id IN" in sql:
+            return []
+        if "BETWEEN" in sql:
+            assert "(-45.25)" in sql or "(-45.25) -" in sql
+            return [
+                {
+                    "source_id": "999888777",
+                    "targetid": "1",
+                    "survey": "main",
+                    "program": "bright",
+                    "rv_adop": "10.5",
+                    "rv_err": "0.8",
+                    "rvs_warn": "0",
+                    "target_ra": "180.5",
+                    "target_dec": "-45.25",
+                    "min_mjd": "60000.0",
+                    "max_mjd": "60001.0",
+                }
+            ]
+        return []
+
+    monkeypatch.setattr("darkhunter_rv.desi_rv_query.execute_datalab_adql", _fake_adql)
+    out = query_desi_rvs_for_gaia_ids([123], positions_by_id={123: (180.5, -45.25)})
+    assert 123 in out
+    assert out[123][0]["rv"] != 10.5
+    assert "conv=helio→bary" in out[123][0]["flag"]
+    assert "sep=" in out[123][0]["flag"]
+    assert len(calls) == 2

--- a/tests/test_external_rv_unified_rows.py
+++ b/tests/test_external_rv_unified_rows.py
@@ -1,0 +1,23 @@
+"""Tests for LAMOST/RAVE external RV normalization in gaia_utils."""
+
+from darkhunter_rv.gaia_utils import _external_rvs_from_unified_rows
+
+
+def test_rave_row_gets_mjd_from_obs_id() -> None:
+    rows = _external_rvs_from_unified_rows(
+        [
+            {
+                "ext_cat": "RAVE_DR6",
+                "obs_str": "",
+                "rv_z": 12.5,
+                "err_z": 1.0,
+                "flag_raw": "101021_0941_2",
+            }
+        ],
+        ra_deg=180.0,
+        dec_deg=-30.0,
+    )
+    assert len(rows) == 1
+    assert rows[0]["telescope"] == "RAVE_DR6"
+    assert rows[0]["mjd"] > 40000
+    assert "conv=helio→bary" in rows[0]["flag"]

--- a/tests/test_galah_rv_query.py
+++ b/tests/test_galah_rv_query.py
@@ -1,0 +1,31 @@
+"""Tests for GALAH external RV query helpers (no network)."""
+
+from darkhunter_rv.galah_rv_query import galah_rows_to_external_rvs, query_galah_rvs_for_gaia_ids
+
+
+def test_galah_rows_to_external_rvs() -> None:
+    rows = galah_rows_to_external_rvs(
+        [
+            {
+                "gaia_id": "123",
+                "galah_id": "999",
+                "rv": "-10.5",
+                "rv_err": "0.2",
+                "mjd": "59000.0",
+                "rv_flag": "0",
+            }
+        ],
+        ra_deg=180.0,
+        dec_deg=-30.0,
+    )
+    assert len(rows) == 1
+    assert rows[0]["telescope"] == "GALAH_DR3"
+    assert "conv=helio→bary" in rows[0]["flag"]
+
+
+def test_query_galah_batch_empty(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "darkhunter_rv.galah_rv_query.execute_vizier_adql",
+        lambda *_a, **_k: [],
+    )
+    assert query_galah_rvs_for_gaia_ids([123], positions_by_id={123: (180.0, -30.0)}) == {}

--- a/tests/test_rv_frame.py
+++ b/tests/test_rv_frame.py
@@ -1,0 +1,73 @@
+"""Tests for external RV frame normalization."""
+
+import numpy as np
+
+from darkhunter_rv.rv_frame import (
+    NativeFrame,
+    finalize_external_rv_record,
+    helio_to_bary_kms,
+    mjd_from_rave_obs_id,
+    normalize_external_rv_to_barycentric,
+)
+
+
+def test_mjd_from_rave_obs_id() -> None:
+    mjd = mjd_from_rave_obs_id("101021_0941_2")
+    assert np.isfinite(mjd)
+    assert 55000 < mjd < 56000
+
+
+def test_helio_to_bary_shift_is_finite() -> None:
+    rv_bary = helio_to_bary_kms(
+        10.0,
+        ra_deg=180.0,
+        dec_deg=45.0,
+        mjd=59000.0,
+        site_key="DESI",
+    )
+    assert np.isfinite(rv_bary)
+    assert abs(rv_bary - 10.0) < 40.0
+
+
+def test_bary_native_pass_through() -> None:
+    out = normalize_external_rv_to_barycentric(
+        -20.5,
+        ra_deg=10.0,
+        dec_deg=20.0,
+        mjd=59000.0,
+        telescope="APOGEE_DR17",
+        native_frame=NativeFrame.BARYCENTRIC,
+    )
+    assert out is not None
+    assert out["rv"] == -20.5
+    assert "frame=bary-native" in out["flag"]
+
+
+def test_helio_conversion_flag() -> None:
+    rec = finalize_external_rv_record(
+        {
+            "telescope": "DESI_DR1",
+            "mjd": 59000.0,
+            "rv": 5.0,
+            "rv_err": 1.0,
+            "flag": "main/bright/1",
+        },
+        ra_deg=180.0,
+        dec_deg=30.0,
+        native_frame=NativeFrame.HELIOCENTRIC,
+        site_key="DESI",
+    )
+    assert rec is not None
+    assert "conv=helio→bary" in rec["flag"]
+    assert rec["rv"] != 5.0
+
+
+def test_skip_invalid_mjd() -> None:
+    assert (
+        finalize_external_rv_record(
+            {"telescope": "RAVE_DR6", "mjd": 0.0, "rv": 1.0, "rv_err": 0.5, "flag": "x"},
+            ra_deg=1.0,
+            dec_deg=2.0,
+        )
+        is None
+    )

--- a/tests/test_vizier_tap.py
+++ b/tests/test_vizier_tap.py
@@ -1,0 +1,17 @@
+"""Tests for VizieR TAP helpers."""
+
+from darkhunter_rv.vizier_tap import parse_gaia_source_id, sql_max_err_clause
+
+
+def test_sql_max_err_clause_empty_when_unset() -> None:
+    assert sql_max_err_clause("VERR", None) == ""
+
+
+def test_sql_max_err_clause_when_set() -> None:
+    assert "VERR <= 10" in sql_max_err_clause("VERR", 10.0)
+
+
+def test_parse_gaia_source_id_avoids_float_roundoff() -> None:
+    sid = 4667368899326729856
+    assert parse_gaia_source_id(str(sid)) == sid
+    assert parse_gaia_source_id(sid) == sid

--- a/tests/validation/test_ccf_estimator_bias.py
+++ b/tests/validation/test_ccf_estimator_bias.py
@@ -1,0 +1,52 @@
+"""Tests for stellar-parameter bias regression per estimator."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from validation.ccf_estimator_bias import _wide_to_bias_csv
+from validation.chunk_bias_regression import choose_best_model, compare_models
+
+
+def test_compare_models_prefers_stellar_when_teff_trend_present():
+    rng = np.random.default_rng(1)
+    n = 100
+    teff = np.repeat([4200, 4800, 5400, 6000], n // 4)
+    order = np.tile(np.arange(10, 20), n // 10)
+    bias = 0.001 * (teff - 5000) + 0.05 * (order - order.mean()) / order.std() + rng.normal(0, 0.02, n)
+    df = pd.DataFrame(
+        {
+            "gaia_dr3_id": np.repeat(np.arange(n // 10), 10).astype(str),
+            "chunk_key": order.astype(str),
+            "chunk_order": order,
+            "chunk_order_norm": (order - order.min()) / (order.max() - order.min()),
+            "weighted_mean_residual_kms": bias,
+            "statistical_err_kms": np.full(n, 0.08),
+            "intrinsic_scatter_kms": np.full(n, 0.03),
+            "teff": teff,
+            "logg": 4.5 + rng.normal(0, 0.1, n),
+            "mh": rng.normal(0, 0.1, n),
+            "log10_median_mask_ccf_peak_snr": np.full(n, 1.0),
+        }
+    )
+    cmp = compare_models(df)
+    chosen = choose_best_model(cmp)
+    assert chosen in ("stellar", "curve_stellar", "curve_stellar_interaction")
+
+
+def test_wide_to_bias_csv_builds_object_table():
+    wide = pd.DataFrame(
+        [
+            {"file": "a.txt", "gaia_dr3_id": "1", "chunk_key": "10_0", "chunk_order": 10,
+             "rv_kms__gauss_offset": 10.0, "rv_err_kms__gauss_offset": 0.1, "peak_snr": 12.0},
+            {"file": "a.txt", "gaia_dr3_id": "1", "chunk_key": "10_1", "chunk_order": 10,
+             "rv_kms__gauss_offset": 12.0, "rv_err_kms__gauss_offset": 0.1, "peak_snr": 11.0},
+            {"file": "b.txt", "gaia_dr3_id": "1", "chunk_key": "10_0", "chunk_order": 10,
+             "rv_kms__gauss_offset": 10.5, "rv_err_kms__gauss_offset": 0.1, "peak_snr": 10.0},
+            {"file": "b.txt", "gaia_dr3_id": "1", "chunk_key": "10_1", "chunk_order": 10,
+             "rv_kms__gauss_offset": 12.5, "rv_err_kms__gauss_offset": 0.1, "peak_snr": 9.0},
+        ]
+    )
+    bias = _wide_to_bias_csv(wide, "gauss_offset")
+    assert len(bias) >= 1
+    assert "weighted_mean_residual_kms" in bias.columns

--- a/tests/validation/test_ccf_rv_post_debias.py
+++ b/tests/validation/test_ccf_rv_post_debias.py
@@ -1,0 +1,52 @@
+"""Post-debias σ_RV stack tests."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from validation.ccf_rv_post_debias import stack_post_debias_exposures
+
+
+def test_post_debias_sigma_smaller_than_raw_scatter(tmp_path) -> None:
+    """After debias, exposure σ_RV should be modest when chunk biases are structured."""
+    rng = np.random.default_rng(2)
+    rows = []
+    for star_i in range(5):
+        gid = str(100 + star_i)
+        for epoch_i, fid in enumerate([f"a{star_i}.txt", f"b{star_i}.txt", f"c{star_i}.txt"]):
+            for ck, bias in [("10_0", 50.0), ("10_1", 52.0), ("11_0", 48.0), ("11_1", 51.0)]:
+                rv = bias + rng.normal(0, 0.05)
+                rows.append(
+                    {
+                        "file": fid,
+                        "gaia_dr3_id": gid,
+                        "chunk_key": ck,
+                        "chunk_order": int(ck.split("_")[0]) * 100 + int(ck.split("_")[1]),
+                        "teff": 5000.0 + star_i * 150.0,
+                        "logg": 4.5,
+                        "mh": 0.0,
+                        "log10_peak_snr": 1.0,
+                        "rv_kms__gauss_offset": rv,
+                        "rv_err_kms__gauss_offset": 0.08,
+                        "peak_snr": 10.0,
+                    }
+                )
+    wide = pd.DataFrame(rows)
+    summary_dir = tmp_path / "output"
+    summary_dir.mkdir()
+    for star_i in range(5):
+        gid = str(100 + star_i)
+        (summary_dir / f"Gaia_DR3_{gid}_summary.txt").write_text(
+            f"Teff: {5000 + star_i * 150}\nlogg: 4.5\n[M/H]: 0.0\n",
+            encoding="utf-8",
+        )
+
+    epochs, summary = stack_post_debias_exposures(
+        wide,
+        "gauss_offset",
+        summary_dir,
+        min_chunks=3,
+    )
+    assert len(epochs) >= 2
+    assert summary["median_sigma_rv_kms"] < 0.5
+    assert summary["median_chunk_scatter_debiased_kms"] < 5.0

--- a/tests/validation/test_ccf_rv_precision_gates.py
+++ b/tests/validation/test_ccf_rv_precision_gates.py
@@ -1,0 +1,63 @@
+"""Tests for CCF RV precision phase gates."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from validation.ccf_rv_precision_gates import check_phase_gate, load_baseline, save_baseline
+
+
+def test_gate_passes_when_metrics_improve(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "ref.json"
+    save_baseline(
+        baseline_path,
+        phase="A",
+        metrics={
+            "median_sigma_rv_kms": 0.35,
+            "p90_sigma_rv_kms": 0.55,
+            "median_chunk_scatter_kms": 0.28,
+            "bias_curve_rms_kms": 0.12,
+            "stellar_bias_cv_rmse_kms": 0.15,
+            "low_snr_finite_rate": 0.75,
+        },
+    )
+    prior = load_baseline(baseline_path)
+    new_metrics = {
+        "median_sigma_rv_kms": 0.33,
+        "p90_sigma_rv_kms": 0.52,
+        "median_chunk_scatter_kms": 0.26,
+        "bias_curve_rms_kms": 0.11,
+        "stellar_bias_cv_rmse_kms": 0.14,
+        "low_snr_finite_rate": 0.78,
+    }
+    result = check_phase_gate("C", new_metrics, prior, strict=True)
+    assert result["passed"] is True
+    assert not result["failures"]
+
+
+def test_gate_fails_on_sigma_regression(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "ref.json"
+    save_baseline(
+        baseline_path,
+        phase="A",
+        metrics={"median_sigma_rv_kms": 0.30, "low_snr_finite_rate": 0.80},
+    )
+    prior = load_baseline(baseline_path)
+    result = check_phase_gate(
+        "C",
+        {"median_sigma_rv_kms": 0.32, "low_snr_finite_rate": 0.80},
+        prior,
+        strict=True,
+    )
+    assert result["passed"] is False
+    assert any("median_sigma_rv_kms" in f for f in result["failures"])
+
+
+def test_gate_fails_on_coverage_drop(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "ref.json"
+    save_baseline(baseline_path, phase="A", metrics={"low_snr_finite_rate": 0.80})
+    prior = load_baseline(baseline_path)
+    result = check_phase_gate("C", {"low_snr_finite_rate": 0.70}, prior, strict=True)
+    assert result["passed"] is False

--- a/tests/validation/test_chunk_grid_search.py
+++ b/tests/validation/test_chunk_grid_search.py
@@ -8,7 +8,15 @@ from validation.chunk_layout import (
     build_equal_subchunk_layout,
     build_merge_orders_layout,
     default_parametric_grid,
+    load_campaign_layout_by_name,
 )
+
+
+def test_load_campaign_layout_subchunks_8(tmp_path) -> None:
+    lay = load_campaign_layout_by_name("subchunks_8", tmp_path)
+    assert lay is not None
+    assert lay.name == "subchunks_8"
+    assert lay.subchunks == 8
 
 
 def test_build_merge_orders_layout_width_2() -> None:

--- a/tests/validation/test_chunk_weight_lookup.py
+++ b/tests/validation/test_chunk_weight_lookup.py
@@ -1,0 +1,46 @@
+"""Tests for chunk weight lookup merge semantics."""
+from __future__ import annotations
+
+import pandas as pd
+
+from validation.chunk_weight_lookup import (
+    LOOKUP_COLUMNS,
+    build_lookup_from_fallback,
+    merge_lookup,
+)
+
+
+def _fallback(layout: str, ck: str, bias: float = 0.1, stat: float = 0.2) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "layout_name": layout,
+                "chunk_key": ck,
+                "bias_kms": bias,
+                "statistical_err_kms": stat,
+                "intrinsic_scatter_kms": 0.05,
+            }
+        ]
+    )
+
+
+def test_merge_preserves_other_layouts() -> None:
+    a = build_lookup_from_fallback(_fallback("subchunks_4", "15_0"), layout_name="subchunks_4")
+    b = build_lookup_from_fallback(_fallback("merge_w4", "merge_0"), layout_name="merge_w4")
+    merged = merge_lookup(a, b)
+    assert len(merged) == 2
+    assert set(merged["layout_name"]) == {"subchunks_4", "merge_w4"}
+
+
+def test_re_run_updates_only_touched_layout() -> None:
+    v1 = build_lookup_from_fallback(_fallback("subchunks_4", "15_0", bias=0.1), layout_name="subchunks_4")
+    v1 = merge_lookup(
+        v1,
+        build_lookup_from_fallback(_fallback("merge_w4", "merge_0"), layout_name="merge_w4"),
+    )
+    v2_piece = build_lookup_from_fallback(_fallback("subchunks_4", "15_0", bias=0.2), layout_name="subchunks_4")
+    v2 = merge_lookup(v1, v2_piece)
+    sub = v2[v2["layout_name"] == "subchunks_4"]
+    merge = v2[v2["layout_name"] == "merge_w4"]
+    assert float(sub.iloc[0]["bias_kms"]) == 0.2
+    assert len(merge) == 1

--- a/tests/validation/test_per_order_chunk_baseline.py
+++ b/tests/validation/test_per_order_chunk_baseline.py
@@ -1,0 +1,134 @@
+"""Tests for per-order chunk baseline."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from validation.chunk_adaptive_stack import ChunkMeas
+from validation.chunk_layout import build_equal_subchunk_layout, build_merge_orders_layout
+from validation.per_order_chunk_baseline import (
+    greedy_assign_file,
+    enumerate_order_candidates,
+    needs_subchunks_8_from_map,
+    stack_norm_factor,
+    sigma_rv_normalized_kms,
+)
+
+
+def _meas(
+    layout: str,
+    ck: str,
+    rv: float,
+    err: float,
+    orders: frozenset[int],
+    *,
+    file: str = "f1",
+    gid: str = "1",
+) -> ChunkMeas:
+    return ChunkMeas(
+        layout_name=layout,
+        chunk_key=ck,
+        rv_kms=rv,
+        rv_err_kms=err,
+        orders=orders,
+        qc_pass=True,
+        file=file,
+        gaia_dr3_id=gid,
+        mjd=60000.0,
+        teff=5500.0,
+    )
+
+
+def _fallback_for(rows: list[ChunkMeas]) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "layout_name": r.layout_name,
+                "chunk_key": r.chunk_key,
+                "bias_kms": 0.0,
+                "statistical_err_kms": r.rv_err_kms,
+                "intrinsic_scatter_kms": 0.0,
+            }
+            for r in rows
+        ]
+    )
+
+
+def test_merge_norm_multiplies_by_sqrt_n() -> None:
+    m = _meas("merge_w2", "merge_0", 10.0, 0.02, frozenset({10, 11}))
+    assert stack_norm_factor([m]) == np.sqrt(2)
+    assert sigma_rv_normalized_kms(0.02, [m]) == 0.02 * np.sqrt(2)
+
+
+def test_subchunks_norm_divides_by_sqrt_n() -> None:
+    chunks = [
+        _meas("subchunks_4", "10_0", 10.0, 0.1, frozenset({10})),
+        _meas("subchunks_4", "10_1", 10.0, 0.1, frozenset({10})),
+        _meas("subchunks_4", "10_2", 10.0, 0.1, frozenset({10})),
+        _meas("subchunks_4", "10_3", 10.0, 0.1, frozenset({10})),
+    ]
+    assert stack_norm_factor(chunks) == 0.5
+    sig_stack = 0.05
+    assert sigma_rv_normalized_kms(sig_stack, chunks) == 0.025
+
+
+def test_merge_covers_second_order() -> None:
+    orders = list(range(10, 18))
+    merge = build_merge_orders_layout(merge_width=2, valid_orders=orders)
+    s4 = build_equal_subchunk_layout(4)
+    layouts = {"merge_w2": merge, "subchunks_4": s4}
+    file = "f1"
+    rows: list[ChunkMeas] = []
+    for o in orders:
+        for si in range(4):
+            rows.append(_meas("subchunks_4", f"{o}_{si}", 10.0, 0.05, frozenset({o})))
+    for gi, (lo, hi) in enumerate(merge.merge_orders or []):
+        rows.append(_meas("merge_w2", f"merge_{gi}", 10.0, 0.02, frozenset(range(lo, hi + 1))))
+    idx = {(r.file, r.layout_name, r.chunk_key): r for r in rows}
+    empty_bias = pd.DataFrame(columns=["gaia_dr3_id", "layout_name", "chunk_key", "weighted_mean_residual_kms"])
+    intrinsic = __import__(
+        "validation.chunk_calibration", fromlist=["build_intrinsic_scatter_model"]
+    ).build_intrinsic_scatter_model(empty_bias)
+    fallback = _fallback_for(rows)
+    steps, stack = greedy_assign_file(
+        file,
+        idx,
+        layouts,
+        per_object=empty_bias,
+        fallback=fallback,
+        intrinsic_model=intrinsic,
+        star_meta={},
+        split_ns=(1, 2, 4),
+    )
+    assert steps
+    assert np.isfinite(stack["rv_err_calibrated_kms"])
+
+
+def test_split_candidates_include_merge_and_subchunks() -> None:
+    orders = [10, 11]
+    merge = build_merge_orders_layout(merge_width=2, valid_orders=orders)
+    s2 = build_equal_subchunk_layout(2)
+    layouts = {"merge_w2": merge, "subchunks_2": s2, "subchunks_4": build_equal_subchunk_layout(4)}
+    rows = [
+        _meas("subchunks_4", "10_0", 1.0, 0.1, frozenset({10})),
+        _meas("subchunks_4", "10_1", 1.0, 0.1, frozenset({10})),
+        _meas("subchunks_4", "10_2", 1.0, 0.1, frozenset({10})),
+        _meas("subchunks_4", "10_3", 1.0, 0.1, frozenset({10})),
+        _meas("subchunks_2", "10_0", 1.0, 0.1, frozenset({10})),
+        _meas("subchunks_2", "10_1", 1.0, 0.1, frozenset({10})),
+        _meas("merge_w2", "merge_0", 1.0, 0.05, frozenset({10, 11})),
+    ]
+    idx = {(r.file, r.layout_name, r.chunk_key): r for r in rows}
+    cands = enumerate_order_candidates("f1", 10, idx, layouts, split_ns=(1, 2))
+    names = {c.name for c in cands}
+    assert "subchunks_1" in names
+    assert "subchunks_2" in names
+    assert "merge_w2" in names
+
+
+def test_needs_subchunks_8_flag() -> None:
+    chunk_map = pd.DataFrame([{"order": 15, "choice": "subchunks_4"}, {"order": 16, "choice": "subchunks_2"}])
+    assert needs_subchunks_8_from_map(chunk_map, has_subchunks_8=False) is True
+    assert needs_subchunks_8_from_map(chunk_map, has_subchunks_8=True) is False
+    chunk_map2 = pd.DataFrame([{"order": 15, "choice": "subchunks_2"}])
+    assert needs_subchunks_8_from_map(chunk_map2, has_subchunks_8=False) is False

--- a/tests/validation/test_spectrum_tiling_search.py
+++ b/tests/validation/test_spectrum_tiling_search.py
@@ -1,0 +1,270 @@
+"""Tests for exhaustive spectrum tiling search."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from validation.chunk_adaptive_stack import ChunkMeas
+from validation.chunk_calibration import lookup_chunk_bias, stack_calibrated_exposure
+from validation.chunk_layout import build_equal_subchunk_layout, build_merge_orders_layout
+from validation.spectrum_tiling import (
+    TileRegistry,
+    count_complete_tilings,
+    file_meas_index,
+    find_best_tiling_for_file,
+    full_order_region,
+    register_custom_tile_layout,
+    stack_tiling_pipeline,
+    TileCandidate,
+)
+
+
+def _meas(
+    layout: str,
+    ck: str,
+    rv: float,
+    err: float,
+    orders: frozenset[int],
+    *,
+    file: str = "f1",
+    gid: str = "1",
+) -> ChunkMeas:
+    return ChunkMeas(
+        layout_name=layout,
+        chunk_key=ck,
+        rv_kms=rv,
+        rv_err_kms=err,
+        orders=orders,
+        qc_pass=True,
+        file=file,
+        gaia_dr3_id=gid,
+        mjd=60000.0,
+        teff=5500.0,
+    )
+
+
+def _registry(
+    rows: list[ChunkMeas],
+    layouts: dict,
+    *,
+    file: str = "f1",
+    mix_layout_names: list[str] | None = None,
+) -> TileRegistry:
+    global_idx = {(r.file, r.layout_name, r.chunk_key): r for r in rows}
+    fidx = file_meas_index(global_idx, file)
+    return TileRegistry.for_file(
+        file,
+        layouts,
+        fidx,
+        mix_layout_names=mix_layout_names,
+    )
+
+
+def _bias_tables(rows: list[ChunkMeas]) -> tuple[pd.DataFrame, pd.DataFrame]:
+    per_object = pd.DataFrame(
+        [
+            {
+                "gaia_dr3_id": r.gaia_dr3_id,
+                "layout_name": r.layout_name,
+                "chunk_key": r.chunk_key,
+                "weighted_mean_residual_kms": 0.0,
+                "statistical_err_kms": r.rv_err_kms,
+                "intrinsic_scatter_kms": 0.0,
+                "teff": r.teff,
+            }
+            for r in rows
+        ]
+    )
+    fallback = pd.DataFrame(
+        [
+            {
+                "layout_name": r.layout_name,
+                "chunk_key": r.chunk_key,
+                "bias_kms": 0.0,
+                "statistical_err_kms": r.rv_err_kms,
+                "intrinsic_scatter_kms": 0.0,
+            }
+            for r in rows
+        ]
+    )
+    intrinsic = __import__(
+        "validation.chunk_calibration", fromlist=["build_intrinsic_scatter_model"]
+    ).build_intrinsic_scatter_model(per_object)
+    return per_object, fallback, intrinsic
+
+
+def test_layout_aware_bias_lookup() -> None:
+    per_object = pd.DataFrame(
+        [
+            {
+                "gaia_dr3_id": "1",
+                "layout_name": "subchunks_4",
+                "chunk_key": "10_0",
+                "weighted_mean_residual_kms": 1.0,
+            },
+            {
+                "gaia_dr3_id": "1",
+                "layout_name": "subchunks_2",
+                "chunk_key": "10_0",
+                "weighted_mean_residual_kms": 2.0,
+            },
+        ]
+    )
+    fallback = pd.DataFrame(columns=["layout_name", "chunk_key", "bias_kms"])
+    b4, _ = lookup_chunk_bias("1", "10_0", per_object, fallback, layout_name="subchunks_4")
+    b2, _ = lookup_chunk_bias("1", "10_0", per_object, fallback, layout_name="subchunks_2")
+    assert b4 == 1.0
+    assert b2 == 2.0
+
+
+def test_count_tilings_two_orders() -> None:
+    orders = [10, 11]
+    merge = build_merge_orders_layout(merge_width=2, valid_orders=orders)
+    s2 = build_equal_subchunk_layout(2)
+    s4 = build_equal_subchunk_layout(4)
+    layouts = {"merge_w2": merge, "subchunks_2": s2, "subchunks_4": s4}
+    rows: list[ChunkMeas] = []
+    for o in orders:
+        for si in range(4):
+            rows.append(_meas("subchunks_4", f"{o}_{si}", 10.0, 0.04, frozenset({o})))
+        for si in range(2):
+            rows.append(_meas("subchunks_2", f"{o}_{si}", 10.0, 0.06, frozenset({o})))
+    rows.append(_meas("merge_w2", "merge_0", 10.0, 0.02, frozenset({10, 11})))
+    registry = _registry(rows, layouts)
+    assert count_complete_tilings(registry) == 5
+
+
+def test_find_best_prefers_merge_when_tighter() -> None:
+    orders = list(range(10, 16))
+    merge = build_merge_orders_layout(merge_width=2, valid_orders=orders)
+    s4 = build_equal_subchunk_layout(4)
+    layouts = {"merge_w2": merge, "subchunks_4": s4}
+    rows: list[ChunkMeas] = []
+    for o in orders:
+        for si in range(4):
+            rows.append(_meas("subchunks_4", f"{o}_{si}", 10.0, 0.08, frozenset({o})))
+    for gi, grp in enumerate(merge.merge_orders or []):
+        lo, hi = int(grp[0]), int(grp[1])
+        covered = frozenset(o for o in range(lo, hi + 1) if o in orders)
+        if covered:
+            rows.append(_meas("merge_w2", f"merge_{gi}", 10.0, 0.02, covered))
+    registry = _registry(rows, layouts)
+    per_object, fallback, intrinsic = _bias_tables(rows)
+    result = find_best_tiling_for_file(
+        registry,
+        per_object=per_object,
+        fallback=fallback,
+        intrinsic_model=intrinsic,
+        star_meta={},
+        include_whole_layouts=False,
+    )
+    assert result is not None
+    assert result.tiling_name.startswith("mix:") and "merge_w2" in result.tiling_name
+    assert result.stack["rv_err_calibrated_kms"] < 0.04
+    assert int(result.stack["n_chunks_used"]) >= 3
+
+
+def test_custom_tile_provider_registers_partial_order_tiles() -> None:
+    from validation.spectrum_tiling import SpectrumRegion
+
+    class _HybridProvider:
+        def __init__(self, _layout: object, ctx: dict) -> None:
+            self.file_idx = ctx["file_idx"]
+
+        def tiles_for_anchor(
+            self,
+            anchor,
+            *,
+            uncovered: tuple,
+        ) -> list[TileCandidate]:
+            out: list[TileCandidate] = []
+            if anchor.order == 10:
+                m = self.file_idx.get(("hybrid", "10+11a"))
+                if m is not None:
+                    out.append(
+                        TileCandidate(
+                            name="hybrid:10+11a",
+                            layout_name="hybrid",
+                            measurements=(m,),
+                            regions=frozenset(
+                                {full_order_region(10), SpectrumRegion(11, 0.0, 0.5)}
+                            ),
+                        )
+                    )
+            if anchor.order == 11 and anchor.pixel_lo >= 0.5:
+                parts = [
+                    self.file_idx.get(("hybrid", "11b_0")),
+                    self.file_idx.get(("hybrid", "11b_1")),
+                ]
+                if all(p is not None for p in parts):
+                    out.append(
+                        TileCandidate(
+                            name="hybrid:11b_split",
+                            layout_name="hybrid",
+                            measurements=tuple(parts),  # type: ignore[arg-type]
+                            regions=frozenset({SpectrumRegion(11, 0.5, 1.0)}),
+                        )
+                    )
+            return out
+
+    register_custom_tile_layout("hybrid", lambda lay, ctx: _HybridProvider(lay, ctx))
+
+    class ChunkLayoutStub:
+        name = "hybrid"
+        merge_orders = None
+
+        def n_chunks_per_order(self) -> int:
+            return 1
+
+    rows = [
+        _meas("hybrid", "10+11a", 10.0, 0.02, frozenset({10, 11})),
+        _meas("hybrid", "11b_0", 10.0, 0.04, frozenset({11})),
+        _meas("hybrid", "11b_1", 10.0, 0.04, frozenset({11})),
+    ]
+    registry = _registry(rows, {"hybrid": ChunkLayoutStub()}, mix_layout_names=["hybrid"])
+    assert count_complete_tilings(registry) == 1
+    tiles = registry._tiles_for_anchor_uncovered(
+        full_order_region(10),
+        [full_order_region(10), SpectrumRegion(11, 0.0, 1.0)],
+    )
+    assert any(t.name == "hybrid:10+11a" for t in tiles)
+
+
+def test_stack_tiling_pipeline_matches_stack_calibrated_exposure() -> None:
+    rows = [
+        _meas("subchunks_4", "10_0", 10.0, 0.1, frozenset({10})),
+        _meas("subchunks_4", "10_1", 10.1, 0.1, frozenset({10})),
+        _meas("subchunks_4", "11_0", 10.0, 0.1, frozenset({11})),
+    ]
+    per_object, fallback, intrinsic = _bias_tables(rows)
+    out = stack_tiling_pipeline(
+        rows,
+        per_object=per_object,
+        fallback=fallback,
+        intrinsic_model=intrinsic,
+        star_meta={},
+        min_chunks=3,
+    )
+    chunk_df = pd.DataFrame(
+        [
+            {
+                "gaia_dr3_id": "1",
+                "layout_name": r.layout_name,
+                "chunk_key": r.chunk_key,
+                "rv_kms": r.rv_kms,
+                "rv_err_kms": r.rv_err_kms,
+                "chunk_kept": True,
+                "teff": 5500.0,
+            }
+            for r in rows
+        ]
+    )
+    direct = stack_calibrated_exposure(
+        chunk_df,
+        per_object=per_object,
+        fallback=fallback,
+        intrinsic_model=intrinsic,
+        min_chunks=3,
+    )
+    assert out["rv_err_calibrated_kms"] == direct["rv_err_calibrated_kms"]
+    assert out["sigma_rv_core90_kms"] == direct["sigma_rv_core90_kms"]

--- a/validation/ccf_estimator_bias.py
+++ b/validation/ccf_estimator_bias.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Build stellar-parameter-corrected bias tables per CCF estimator.
+
+Joins per-object chunk residuals with Teff/logg/[M/H], fits nested regression models,
+and exports bias_statistics.txt on regression-adjusted residuals.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  PYTHONPATH=. python -m validation.ccf_estimator_bias \\
+    --wide-diagnostics validation_output/ccf_estimator_study/per_chunk_rv.csv \\
+    --summary-dir output \\
+    --estimator auto \\
+    --out-dir validation_output/ccf_estimator_study/bias_auto
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from validation.ccf_rv_precision_metrics import build_per_object_bias_table  # noqa: E402
+from validation.chunk_bias_lib import load_stellar_metadata  # noqa: E402
+from validation.chunk_bias_regression import (  # noqa: E402
+    _fit_model,
+    choose_best_model,
+    compare_models,
+    export_regression_bias_table,
+    per_chunk_stellar_slopes,
+)
+logger = logging.getLogger(__name__)
+
+
+def _wide_to_bias_csv(wide: pd.DataFrame, estimator: str) -> pd.DataFrame:
+    rv_col = f"rv_kms__{estimator}"
+    err_col = f"rv_err_kms__{estimator}"
+    if rv_col not in wide.columns:
+        raise ValueError(f"estimator column missing: {rv_col}")
+    return build_per_object_bias_table(wide, rv_col=rv_col, err_col=err_col)
+
+
+def prepare_bias_regression_table(
+    wide: pd.DataFrame,
+    estimator: str,
+    summary_dir: Path,
+) -> pd.DataFrame:
+    """Per-object chunk residuals joined with stellar metadata for regression."""
+    bias_raw = _wide_to_bias_csv(wide, estimator)
+    if bias_raw.empty:
+        raise RuntimeError(f"No bias rows for estimator={estimator}")
+    meta = load_stellar_metadata(summary_dir)
+    bias_raw["gaia_dr3_id"] = bias_raw["gaia_dr3_id"].astype(str)
+    if not meta.empty:
+        meta["gaia_dr3_id"] = meta["gaia_dr3_id"].astype(str)
+        bias_raw = bias_raw.merge(meta, on="gaia_dr3_id", how="left")
+    if "teff" not in bias_raw.columns or bias_raw["teff"].isna().all():
+        bias_raw["teff"] = (
+            bias_raw["teff_gaia"].astype(float) if "teff_gaia" in bias_raw.columns else float("nan")
+        )
+    if "logg" not in bias_raw.columns:
+        bias_raw["logg"] = float("nan")
+    if "mh" not in bias_raw.columns:
+        bias_raw["mh"] = float("nan")
+    if "log10_median_mask_ccf_peak_snr" not in bias_raw.columns:
+        if "log10_peak_snr" in wide.columns:
+            snr = (
+                wide.groupby("gaia_dr3_id")["log10_peak_snr"]
+                .median()
+                .rename("log10_median_mask_ccf_peak_snr")
+            )
+            bias_raw = bias_raw.merge(snr, on="gaia_dr3_id", how="left")
+        else:
+            bias_raw["log10_median_mask_ccf_peak_snr"] = float("nan")
+    orders = bias_raw["chunk_order"].astype(float)
+    o_min, o_max = float(np.nanmin(orders)), float(np.nanmax(orders))
+    bias_raw["chunk_order_norm"] = (orders - o_min) / max(o_max - o_min, 1.0)
+    return bias_raw
+
+
+def fit_regression_bias(
+    wide: pd.DataFrame,
+    estimator: str,
+    summary_dir: Path,
+) -> tuple[pd.DataFrame, pd.DataFrame, str, pd.DataFrame]:
+    """
+    Nested chunk/stellar bias regression.
+
+    Returns (adjusted, per_object_stack, chosen_model, model_cmp).
+    ``per_object_stack.weighted_mean_residual_kms`` holds ``adjusted_bias_kms`` for IVW stack.
+    """
+    bias_raw = prepare_bias_regression_table(wide, estimator, summary_dir)
+    model_cmp = compare_models(bias_raw)
+    chosen = choose_best_model(model_cmp)
+    fit = _fit_model(bias_raw, chosen)
+    adjusted = export_regression_bias_table(bias_raw, fit)
+
+    per_object_stack = adjusted.copy()
+    debias = per_object_stack["adjusted_bias_kms"].astype(float)
+    raw_bias = bias_raw["weighted_mean_residual_kms"].astype(float).values
+    per_object_stack["weighted_mean_residual_kms"] = np.where(np.isfinite(debias), debias, raw_bias)
+    if "sample_kept" not in per_object_stack.columns:
+        per_object_stack["sample_kept"] = True
+    return adjusted, per_object_stack, chosen, model_cmp
+
+
+def _export_bias_statistics(adjusted: pd.DataFrame, out_path: Path) -> None:
+    """Per-order b0 from sample mean of adjusted bias (stellar+curve corrected)."""
+    if adjusted.empty or "adjusted_bias_kms" not in adjusted.columns:
+        out_path.write_text("# order bias_dv bias_err_stat bias_rms_stat\n", encoding="utf-8")
+        return
+    tmp = adjusted.copy()
+    tmp["order"] = tmp["chunk_key"].astype(str).str.split("_").str[0].astype(int)
+    order_rows = []
+    for order, g in tmp.groupby("order"):
+        vals = g["adjusted_bias_kms"].astype(float).values
+        vals = vals[np.isfinite(vals)]
+        if len(vals) == 0:
+            continue
+        order_rows.append(
+            (int(order), float(np.mean(vals)), float(np.std(vals)), float(np.std(vals)))
+        )
+    with open(out_path, "w", encoding="utf-8") as fh:
+        fh.write("# order bias_dv bias_err_stat bias_rms_stat\n")
+        for o, b, e, r in sorted(order_rows):
+            fh.write(f"{o} {b:.8f} {e:.8f} {r:.8f}\n")
+
+
+def build_estimator_bias(
+    wide_path: Path,
+    *,
+    summary_dir: Path,
+    estimator: str,
+    out_dir: Path,
+) -> dict:
+    wide = pd.read_csv(wide_path)
+    bias_raw = prepare_bias_regression_table(wide, estimator, summary_dir)
+    adjusted, _, chosen, model_cmp = fit_regression_bias(wide, estimator, summary_dir)
+    slopes = per_chunk_stellar_slopes(bias_raw)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    bias_raw.to_csv(out_dir / "per_object_chunk_bias_raw.csv", index=False)
+    adjusted.to_csv(out_dir / "bias_by_chunk_corrected.csv", index=False)
+    model_cmp.to_csv(out_dir / "model_comparison.csv", index=False)
+    slopes.to_csv(out_dir / "stellar_slope_report.csv", index=False)
+    _export_bias_statistics(adjusted, out_dir / "bias_statistics.txt")
+
+    summary = {
+        "estimator": estimator,
+        "chosen_bias_model": chosen,
+        "n_objects": int(bias_raw["gaia_dr3_id"].nunique()),
+        "n_rows": int(len(bias_raw)),
+        "n_significant_teff_slopes": int(slopes["significant"].sum()) if not slopes.empty else 0,
+        "cv_rmse_kms": float(model_cmp.loc[model_cmp["model"] == chosen, "cv_rmse_kms"].iloc[0]),
+    }
+    (out_dir / "chosen_bias_model.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    return summary
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--wide-diagnostics", type=Path, required=True)
+    ap.add_argument("--summary-dir", type=Path, default=REPO_ROOT / "output")
+    ap.add_argument("--estimator", default="auto")
+    ap.add_argument("--out-dir", type=Path, required=True)
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO), format="%(levelname)s %(message)s")
+    summary = build_estimator_bias(
+        args.wide_diagnostics,
+        summary_dir=args.summary_dir,
+        estimator=args.estimator,
+        out_dir=args.out_dir,
+    )
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/ccf_param_sweep.py
+++ b/validation/ccf_param_sweep.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Phase B: sweep mask-CCF fit parameters on a bias-train subset.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  PYTHONPATH=. python -m validation.ccf_param_sweep \\
+    --bias-train calibration/bias_train.txt \\
+    --chunk-layout calibration/chunk_layouts/subchunks_4.yaml \\
+    --out-dir validation_output/ccf_estimator_study/param_sweep
+"""
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from darkhunter_rv import config  # noqa: E402
+from validation.ccf_rv_precision_gates import check_phase_gate, load_baseline  # noqa: E402
+from validation.ccf_rv_precision_metrics import build_per_object_bias_table, summarize_estimator_metrics  # noqa: E402
+from validation.chunk_layout import load_chunk_layout  # noqa: E402
+from darkhunter_rv import instruments  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+def _read_paths_list(path: Path, max_n: int | None) -> list[Path]:
+    lines = [
+        ln.strip()
+        for ln in path.read_text(encoding="utf-8", errors="replace").splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+    paths = [Path(ln) if Path(ln).is_absolute() else REPO_ROOT / ln for ln in lines]
+    if max_n is not None:
+        paths = paths[: int(max_n)]
+    return paths
+
+
+def run_sweep(args: argparse.Namespace) -> pd.DataFrame:
+    layout = load_chunk_layout(args.chunk_layout)
+    instrument = instruments.get_instrument_profile(args.instrument)
+    spec_paths = _read_paths_list(args.bias_train, max_n=args.max_spectra)
+
+    fit_widths = [int(x) for x in args.fit_widths.split(",")]
+    min_snrs = [float(x) for x in args.min_peak_snr.split(",")]
+    min_sigmas = [float(x) for x in args.min_gauss_sigma_kms.split(",")]
+
+    rows: list[dict] = []
+    orig_sigma = float(config.MASK_CCF_MIN_GAUSS_SIGMA_KMS)
+
+    from darkhunter_rv import continuum, io_utils, rv_core  # noqa: E402
+
+    for fw, msnr, msig in itertools.product(fit_widths, min_snrs, min_sigmas):
+        config.MASK_CCF_MIN_GAUSS_SIGMA_KMS = msig
+        from darkhunter_rv.pipeline import _mask_tournament  # noqa: E402
+        from validation.chunk_layout import iter_order_chunks_from_layout  # noqa: E402
+
+        chunk_rows = []
+        for sp in spec_paths:
+            if not sp.is_file():
+                continue
+            _, spec_data = io_utils.read_spectrum(str(sp))
+            valid_orders = sorted(o for o in spec_data if o not in instrument.bad_orders)
+            mid = len(valid_orders) // 2
+            test_orders = valid_orders[max(0, mid - 2) : min(len(valid_orders), mid + 2)]
+            mask_pack, _, _ = _mask_tournament(
+                spec_data, instrument, test_orders, Path(instrument.mask_directory), args.continuum_mode
+            )
+            if mask_pack is None:
+                continue
+            mw, ms = mask_pack["w"], mask_pack["s"]
+            for chunk_key, w, f, e in iter_order_chunks_from_layout(spec_data, instrument.bad_orders, layout):
+                if len(w) < 10:
+                    continue
+                try:
+                    nw, nf, ne = continuum.fit_continuum(w, f, e, continuum_mode=args.continuum_mode)
+                    nw, nf, ne = continuum.despike_normalized_pre_ccf(nw, nf, ne)
+                except Exception:
+                    continue
+                if nw[-1] < mw[0] or nw[0] > mw[-1]:
+                    continue
+                line_obs = rv_core.mask_line_flux_in_excluded_wavelengths(nw, 1.0 - nf)
+                rv, err, _, _, peak, _, snr = rv_core.cross_correlate_stellar_mask(
+                    nw,
+                    line_obs,
+                    mw,
+                    ms,
+                    fit_width=int(fw),
+                    min_peak_snr=float(msnr),
+                    estimator="gauss_offset",
+                )
+                chunk_rows.append(
+                    {
+                        "file": sp.name,
+                        "gaia_dr3_id": sp.stem.replace("Gaia_DR3_", "").split("_")[0],
+                        "chunk_key": str(chunk_key),
+                        "rv_kms__gauss_offset": float(rv),
+                        "rv_err_kms__gauss_offset": float(err),
+                        "peak_snr": float(snr),
+                    }
+                )
+        chunk_df = pd.DataFrame(chunk_rows)
+        bias_df = build_per_object_bias_table(chunk_df, rv_col="rv_kms__gauss_offset", err_col="rv_err_kms__gauss_offset")
+        m = summarize_estimator_metrics(chunk_df, estimator="gauss_offset", bias_df=bias_df)
+        m.update(
+            {
+                "fit_width": fw,
+                "min_peak_snr": msnr,
+                "min_gauss_sigma_kms": msig,
+            }
+        )
+        rows.append(m)
+        logger.info(
+            "fit_width=%s min_snr=%s min_sigma=%s -> median_sigma=%.4f",
+            fw,
+            msnr,
+            msig,
+            m.get("median_sigma_rv_kms", float("nan")),
+        )
+
+    config.MASK_CCF_MIN_GAUSS_SIGMA_KMS = orig_sigma
+    return pd.DataFrame(rows)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--bias-train", type=Path, default=REPO_ROOT / "calibration/bias_train.txt")
+    ap.add_argument("--chunk-layout", type=Path, required=True)
+    ap.add_argument("--instrument", default="APF")
+    ap.add_argument("--out-dir", type=Path, default=Path("validation_output/ccf_estimator_study/param_sweep"))
+    ap.add_argument("--fit-widths", default="25,50,75")
+    ap.add_argument("--min-peak-snr", default="2.5,3.5,5")
+    ap.add_argument("--min-gauss-sigma-kms", default="2,2.5,3")
+    ap.add_argument("--max-spectra", type=int, default=30)
+    ap.add_argument("--default-teff", type=float, default=4500.0)
+    ap.add_argument("--continuum-mode", default="chebyshev")
+    ap.add_argument("--baseline", type=Path, default=REPO_ROOT / "calibration/ccf_estimator_baseline/phase_a_reference.json")
+    ap.add_argument("--check-gate", action="store_true")
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO), format="%(levelname)s %(message)s")
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    sweep_df = run_sweep(args)
+    sweep_df.to_csv(args.out_dir / "param_sweep.csv", index=False)
+
+    if sweep_df.empty:
+        print(json.dumps({"error": "no results"}))
+        return 1
+
+    best = sweep_df.sort_values("median_sigma_rv_kms").iloc[0]
+    best_metrics = {k: float(best[k]) for k in sweep_df.columns if k in (
+        "median_sigma_rv_kms", "p90_sigma_rv_kms", "median_chunk_scatter_kms",
+        "bias_curve_rms_kms", "stellar_bias_cv_rmse_kms", "low_snr_finite_rate",
+    )}
+    (args.out_dir / "phase_B_best.json").write_text(json.dumps(dict(best), indent=2, default=str) + "\n")
+
+    if args.check_gate and args.baseline.is_file():
+        prior = load_baseline(args.baseline)
+        gate = check_phase_gate("B", best_metrics, prior, strict=True)
+        (args.out_dir / "phase_B_gate.json").write_text(json.dumps(gate, indent=2) + "\n")
+        if not gate["passed"]:
+            return 1
+    print(json.dumps({"best": dict(best), "n_configs": len(sweep_df)}, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/ccf_rv_estimator_benchmark.py
+++ b/validation/ccf_rv_estimator_benchmark.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""
+Multi-estimator mask-CCF benchmark with phase precision gates.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  PYTHONPATH=. python -m validation.ccf_rv_estimator_benchmark \\
+    --spectrum-list validation_output/chunk_campaign/spectrum_list.txt \\
+    --chunk-layout calibration/chunk_layouts/subchunks_4.yaml \\
+    --estimators gauss_offset,parabolic_ls,smooth_peak,bi_gauss,grid,auto \\
+    --phase C --check-gate \\
+    --baseline calibration/ccf_estimator_baseline/phase_c_reference.json \\
+    --out-dir validation_output/ccf_estimator_study
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from darkhunter_rv import continuum, instruments, io_utils, rv_core  # noqa: E402
+from darkhunter_rv.pipeline import _mask_tournament  # noqa: E402
+from validation.ccf_rv_precision_gates import (  # noqa: E402
+    check_phase_gate,
+    load_baseline,
+    save_baseline,
+    update_baseline_if_passed,
+)
+from validation.ccf_rv_post_debias import compare_estimators_post_debias  # noqa: E402
+from validation.ccf_rv_precision_metrics import (  # noqa: E402
+    build_per_object_bias_table,
+    composite_score,
+    summarize_estimator_metrics,
+)
+from validation.chunk_bias_lib import load_stellar_metadata  # noqa: E402
+from validation.chunk_layout import iter_order_chunks_from_layout, load_chunk_layout  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+def _attach_stellar_metadata(chunk_df: pd.DataFrame, summary_dir: Path) -> pd.DataFrame:
+    if chunk_df.empty:
+        return chunk_df
+    meta = load_stellar_metadata(summary_dir)
+    if meta.empty:
+        return chunk_df
+    out = chunk_df.copy()
+    out["gaia_dr3_id"] = out["gaia_dr3_id"].astype(str)
+    meta["gaia_dr3_id"] = meta["gaia_dr3_id"].astype(str)
+    out = out.merge(meta, on="gaia_dr3_id", how="left", suffixes=("", "_meta"))
+    if "teff_gaia" in out.columns:
+        out["teff"] = out["teff_gaia"].astype(float)
+    if "logg" in out.columns:
+        out["logg"] = out["logg"].astype(float)
+    if "mh" in out.columns:
+        out["mh"] = out["mh"].astype(float)
+    return out
+
+
+def _teff_for_star(gid: str, meta: pd.DataFrame, default_teff: float) -> float:
+    if meta.empty:
+        return default_teff
+    row = meta.loc[meta["gaia_dr3_id"].astype(str) == str(gid)]
+    if row.empty:
+        return default_teff
+    t = float(row["teff_gaia"].iloc[0])
+    return t if np.isfinite(t) else default_teff
+
+
+def summarize_chunk_table(
+    chunk_df: pd.DataFrame,
+    estimators: tuple[str, ...],
+    out_dir: Path,
+    *,
+    summary_dir: Path,
+    phase: str,
+    baseline: Path | None,
+    check_gate: bool,
+    update_baseline: bool,
+    post_debias: bool = False,
+) -> dict:
+    """Write comparison CSV + phase metrics from an existing per-chunk table."""
+    comparison_rows = []
+    metrics_by_est: dict[str, dict] = {}
+    for est in estimators:
+        bias_df = build_per_object_bias_table(
+            chunk_df,
+            rv_col=f"rv_kms__{est}",
+            err_col=f"rv_err_kms__{est}",
+        )
+        if not bias_df.empty:
+            bias_df = _attach_stellar_metadata(bias_df, summary_dir)
+            if "teff_gaia" in bias_df.columns:
+                miss = ~np.isfinite(bias_df["teff"].astype(float)) if "teff" in bias_df.columns else np.ones(len(bias_df), bool)
+                if "teff" not in bias_df.columns:
+                    bias_df["teff"] = bias_df["teff_gaia"].astype(float)
+                else:
+                    bias_df.loc[miss, "teff"] = bias_df.loc[miss, "teff_gaia"].astype(float)
+            bias_df.to_csv(out_dir / f"per_object_bias__{est}.csv", index=False)
+        m = summarize_estimator_metrics(chunk_df, estimator=est, bias_df=bias_df)
+        m["composite_score"] = composite_score(m)
+        metrics_by_est[est] = m
+        comparison_rows.append(m)
+
+    cmp_df = pd.DataFrame(comparison_rows).sort_values("composite_score")
+    cmp_df.to_csv(out_dir / "estimator_comparison.csv", index=False)
+
+    winner = str(cmp_df.iloc[0]["estimator_name"]) if not cmp_df.empty else estimators[0]
+    phase_metrics = dict(metrics_by_est.get(winner, {}))
+    phase_metrics["winner_estimator"] = winner
+
+    phase_path = out_dir / f"phase_{phase}_metrics.json"
+    phase_path.write_text(json.dumps(phase_metrics, indent=2) + "\n", encoding="utf-8")
+
+    gate_result = None
+    if baseline is not None and baseline.is_file():
+        prior = load_baseline(baseline)
+        gate_result = check_phase_gate(str(phase), phase_metrics, prior, strict=check_gate)
+        gate_path = out_dir / f"phase_{phase}_gate.json"
+        gate_path.write_text(json.dumps(gate_result, indent=2) + "\n", encoding="utf-8")
+        if check_gate and not gate_result["passed"]:
+            logger.error("Phase %s gate FAILED: %s", phase, gate_result["failures"])
+        elif gate_result["passed"]:
+            logger.info("Phase %s gate PASSED", phase)
+        if update_baseline and gate_result.get("passed"):
+            update_baseline_if_passed(
+                baseline,
+                phase=str(phase),
+                metrics=phase_metrics,
+                gate_result=gate_result,
+                estimator=winner,
+            )
+
+    post_debias_result = None
+    if post_debias:
+        post_cmp = compare_estimators_post_debias(
+            chunk_df,
+            estimators,
+            summary_dir,
+            out_dir=out_dir,
+        )
+        post_cmp.to_csv(out_dir / "estimator_comparison_post_debias.csv", index=False)
+        post_winner = str(post_cmp.iloc[0]["estimator_name"]) if not post_cmp.empty else winner
+        post_debias_result = {
+            "winner": post_winner,
+            "comparison_path": str(out_dir / "estimator_comparison_post_debias.csv"),
+        }
+        (out_dir / "phase_C_post_debias_winner.json").write_text(
+            json.dumps(post_debias_result, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        logger.info("Post-debias winner: %s (median σ_RV=%.4f km/s)", post_winner, post_cmp.iloc[0]["median_sigma_rv_kms"])
+
+    return {
+        "n_chunks": len(chunk_df),
+        "n_spectra": chunk_df["file"].nunique() if not chunk_df.empty else 0,
+        "winner": winner,
+        "phase_metrics": phase_metrics,
+        "gate": gate_result,
+        "post_debias": post_debias_result,
+    }
+
+
+def _read_spectrum_list(path: Path, *, max_n: int | None) -> list[Path]:
+    lines = [
+        ln.strip()
+        for ln in path.read_text(encoding="utf-8", errors="replace").splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+    paths = [Path(ln) if Path(ln).is_absolute() else REPO_ROOT / ln for ln in lines]
+    if max_n is not None:
+        paths = paths[: int(max_n)]
+    return paths
+
+
+def _gaia_id_from_path(path: Path) -> str:
+    stem = path.stem
+    if stem.startswith("Gaia_DR3_"):
+        return stem.replace("Gaia_DR3_", "").split("_")[0]
+    return stem
+
+
+def measure_spectrum_chunks(
+    spectrum_path: Path,
+    *,
+    instrument,
+    layout,
+    estimators: tuple[str, ...],
+    teff: float,
+    continuum_mode: str,
+) -> list[dict]:
+    if instrument.name == "GHOST":
+        _, spec_data = io_utils.read_spectrum_ghost(str(spectrum_path))
+    elif instrument.name == "MAROON-X":
+        _, spec_data = io_utils.read_spectrum_maroonx(str(spectrum_path))
+    else:
+        _, spec_data = io_utils.read_spectrum(str(spectrum_path))
+
+    valid_orders = sorted(o for o in spec_data if o not in instrument.bad_orders)
+    if not valid_orders:
+        return []
+    mid = len(valid_orders) // 2
+    test_orders = valid_orders[max(0, mid - 2) : min(len(valid_orders), mid + 2)]
+    mask_dir = Path(instrument.mask_directory)
+    mask_pack, _, _ = _mask_tournament(spec_data, instrument, test_orders, mask_dir, continuum_mode)
+    if mask_pack is None:
+        logger.warning("No mask for %s", spectrum_path)
+        return []
+
+    mw, ms = mask_pack["w"], mask_pack["s"]
+    gid = _gaia_id_from_path(spectrum_path)
+    rows: list[dict] = []
+
+    for chunk_key, w, f, e in iter_order_chunks_from_layout(spec_data, instrument.bad_orders, layout):
+        if len(w) < 10:
+            continue
+        try:
+            nw, nf, _ = continuum.fit_continuum(w, f, e, continuum_mode=continuum_mode)
+            nw, nf, _ = continuum.despike_normalized_pre_ccf(nw, nf, _)
+        except Exception as ex:
+            logger.debug("continuum fail %s %s: %s", spectrum_path.name, chunk_key, ex)
+            continue
+        if nw[-1] < mw[0] or nw[0] > mw[-1]:
+            continue
+        line_obs = rv_core.mask_line_flux_in_excluded_wavelengths(nw, 1.0 - nf)
+        results, _, _, peak_snr = rv_core.cross_correlate_stellar_mask_all(
+            nw, line_obs, mw, ms, estimators=estimators
+        )
+        if not results:
+            continue
+        base = {
+            "file": spectrum_path.name,
+            "spectrum_path": str(spectrum_path),
+            "gaia_dr3_id": gid,
+            "chunk_key": str(chunk_key),
+            "teff": float(teff),
+            "peak_snr": float(peak_snr),
+            "log10_peak_snr": float(np.log10(peak_snr)) if np.isfinite(peak_snr) and peak_snr > 0 else float("nan"),
+        }
+        from darkhunter_rv import chunking
+
+        _, ord_num, _ = chunking.parse_chunk_key(str(chunk_key))
+        base["chunk_order"] = int(ord_num)
+        for est_name, res in results.items():
+            base[f"rv_kms__{est_name}"] = float(res.rv_kms)
+            base[f"rv_err_kms__{est_name}"] = float(res.rv_err_kms)
+            base[f"asymmetry__{est_name}"] = float(res.asymmetry)
+            base[f"fit_ok__{est_name}"] = bool(res.fit_ok)
+        rows.append(base)
+    return rows
+
+
+def run_benchmark(args: argparse.Namespace) -> dict:
+    layout = load_chunk_layout(args.chunk_layout)
+    instrument = instruments.get_instrument_profile(args.instrument)
+    estimators = tuple(e.strip() for e in args.estimators.split(",") if e.strip())
+
+    spec_paths = _read_spectrum_list(args.spectrum_list, max_n=args.max_spectra)
+    stellar_meta = load_stellar_metadata(args.summary_dir)
+    all_rows: list[dict] = []
+    for i, sp in enumerate(spec_paths):
+        if not sp.is_file():
+            logger.warning("Missing spectrum: %s", sp)
+            continue
+        gid = _gaia_id_from_path(sp)
+        teff = _teff_for_star(gid, stellar_meta, float(args.default_teff))
+        rows = measure_spectrum_chunks(
+            sp,
+            instrument=instrument,
+            layout=layout,
+            estimators=estimators,
+            teff=teff,
+            continuum_mode=args.continuum_mode,
+        )
+        all_rows.extend(rows)
+        if (i + 1) % 10 == 0:
+            logger.info("Processed %d / %d spectra (%d chunks)", i + 1, len(spec_paths), len(all_rows))
+
+    out_dir = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    chunk_df = pd.DataFrame(all_rows)
+    chunk_df = _attach_stellar_metadata(chunk_df, args.summary_dir)
+    chunk_df.to_csv(out_dir / "per_chunk_rv.csv", index=False)
+
+    return summarize_chunk_table(
+        chunk_df,
+        estimators,
+        out_dir,
+        summary_dir=args.summary_dir,
+        phase=str(args.phase),
+        baseline=args.baseline,
+        check_gate=bool(args.check_gate),
+        update_baseline=bool(args.update_baseline),
+        post_debias=bool(args.post_debias),
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--spectrum-list", type=Path, default=None)
+    ap.add_argument("--chunk-layout", type=Path, default=None)
+    ap.add_argument("--resummarize-only", action="store_true", help="Recompute metrics from out-dir/per_chunk_rv.csv")
+    ap.add_argument("--summary-dir", type=Path, default=REPO_ROOT / "output")
+    ap.add_argument("--instrument", default="APF")
+    ap.add_argument("--estimators", default="gauss_offset,parabolic_ls,smooth_peak,bi_gauss,grid,auto")
+    ap.add_argument("--out-dir", type=Path, default=Path("validation_output/ccf_estimator_study"))
+    ap.add_argument("--phase", default="C")
+    ap.add_argument("--baseline", type=Path, default=None)
+    ap.add_argument("--check-gate", action="store_true")
+    ap.add_argument("--update-baseline", action="store_true")
+    ap.add_argument("--max-spectra", type=int, default=None)
+    ap.add_argument("--default-teff", type=float, default=4500.0)
+    ap.add_argument("--continuum-mode", default="chebyshev")
+    ap.add_argument("--post-debias", action="store_true", help="Rank estimators by σ_RV after regression debias")
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO), format="%(levelname)s %(message)s")
+    if args.baseline is None and args.check_gate:
+        args.baseline = REPO_ROOT / "calibration/ccf_estimator_baseline" / f"phase_{args.phase.lower()}_reference.json"
+
+    if args.resummarize_only:
+        chunk_path = args.out_dir / "per_chunk_rv.csv"
+        if not chunk_path.is_file():
+            logger.error("Missing %s", chunk_path)
+            return 1
+        chunk_df = pd.read_csv(chunk_path)
+        chunk_df = _attach_stellar_metadata(chunk_df, args.summary_dir)
+        estimators = tuple(e.strip() for e in args.estimators.split(",") if e.strip())
+        summary = summarize_chunk_table(
+            chunk_df,
+            estimators,
+            args.out_dir,
+            summary_dir=args.summary_dir,
+            phase=str(args.phase),
+            baseline=args.baseline,
+            check_gate=bool(args.check_gate),
+            update_baseline=bool(args.update_baseline),
+            post_debias=bool(args.post_debias),
+        )
+    else:
+        if args.spectrum_list is None or args.chunk_layout is None:
+            ap.error("--spectrum-list and --chunk-layout required unless --resummarize-only")
+        summary = run_benchmark(args)
+    print(json.dumps(summary, indent=2, default=str))
+    if args.check_gate and summary.get("gate") and not summary["gate"].get("passed"):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/ccf_rv_post_debias.py
+++ b/validation/ccf_rv_post_debias.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+Post-debias σ_RV: apply chunk + stellar regression bias, then IVW stack per exposure.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  PYTHONPATH=. python -m validation.ccf_rv_post_debias \\
+    --wide-diagnostics validation_output/ccf_estimator_study/per_chunk_rv.csv \\
+    --summary-dir output \\
+    --estimators gauss_offset,parabolic_ls,smooth_peak,bi_gauss,grid,auto \\
+    --out-dir validation_output/ccf_estimator_study
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from validation.ccf_estimator_bias import fit_regression_bias  # noqa: E402
+from validation.ccf_rv_precision_metrics import _finite_err_kms  # noqa: E402
+from validation.chunk_calibration import (  # noqa: E402
+    build_intrinsic_scatter_model,
+    build_layout_fallback_tables,
+    stack_calibrated_exposure,
+    summarize_sigma_rv_metrics,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _wide_to_stack_chunks(wide: pd.DataFrame, estimator: str) -> pd.DataFrame:
+    rv_col = f"rv_kms__{estimator}"
+    err_col = f"rv_err_kms__{estimator}"
+    if rv_col not in wide.columns:
+        raise ValueError(f"missing column {rv_col}")
+    out = wide.copy()
+    out["rv_kms"] = out[rv_col].astype(float)
+    raw_err = out[err_col].astype(float).values if err_col in out.columns else np.full(len(out), np.nan)
+    out["rv_err_kms"] = _finite_err_kms(raw_err)
+    out["gaia_dr3_id"] = out["gaia_dr3_id"].astype(str)
+    out["chunk_key"] = out["chunk_key"].astype(str)
+    if "teff_gaia" in out.columns:
+        if "teff" not in out.columns:
+            out["teff"] = out["teff_gaia"].astype(float)
+        else:
+            miss = ~np.isfinite(out["teff"].astype(float))
+            out.loc[miss, "teff"] = out.loc[miss, "teff_gaia"].astype(float)
+    return out
+
+
+def stack_post_debias_exposures(
+    wide: pd.DataFrame,
+    estimator: str,
+    summary_dir: Path,
+    *,
+    min_chunks: int = 3,
+    cdf_weight_fraction: float = 0.9,
+) -> tuple[pd.DataFrame, dict]:
+    """
+    Per-exposure calibrated RV after regression debias (chunk curve + stellar terms).
+
+    σ_RV = formal IVW stack error on debiased chunks (``rv_err_calibrated_kms``).
+    """
+    _, per_object_stack, chosen_model, model_cmp = fit_regression_bias(wide, estimator, summary_dir)
+    sample = per_object_stack[per_object_stack.get("sample_kept", True).astype(bool)]
+    _, fallback = build_layout_fallback_tables(sample)
+    intrinsic_model = build_intrinsic_scatter_model(per_object_stack)
+    chunks = _wide_to_stack_chunks(wide, estimator)
+
+    epoch_rows: list[dict] = []
+    for file, g in chunks.groupby("file"):
+        g = g[np.isfinite(g["rv_kms"].astype(float))].copy()
+        if len(g) < min_chunks:
+            continue
+        stack = stack_calibrated_exposure(
+            g,
+            per_object=per_object_stack,
+            fallback=fallback,
+            intrinsic_model=intrinsic_model,
+            min_chunks=min_chunks,
+            cdf_weight_fraction=cdf_weight_fraction,
+        )
+        sig = float(stack.get("rv_err_calibrated_kms", np.nan))
+        if not np.isfinite(sig) or sig <= 0:
+            continue
+        epoch_rows.append(
+            {
+                "file": str(file),
+                "gaia_dr3_id": str(g["gaia_dr3_id"].iloc[0]),
+                "estimator": estimator,
+                "chosen_bias_model": chosen_model,
+                "rv_calibrated_kms": stack["rv_calibrated_kms"],
+                "rv_err_calibrated_kms": sig,
+                "sigma_rv_core90_kms": stack["sigma_rv_core90_kms"],
+                "chunk_scatter_calibrated_kms": stack["chunk_scatter_calibrated_kms"],
+                "n_chunks_used": stack["n_chunks_used"],
+                "n_chunks_core90": stack["n_chunks_core90"],
+                "bias_source_mix": stack["bias_source_mix"],
+            }
+        )
+
+    epochs = pd.DataFrame(epoch_rows)
+    sigma = summarize_sigma_rv_metrics(epochs) if not epochs.empty else {}
+    sc = epochs["chunk_scatter_calibrated_kms"].astype(float) if not epochs.empty else pd.Series(dtype=float)
+    sc_ok = sc[np.isfinite(sc)]
+
+    summary = {
+        "estimator_name": estimator,
+        "chosen_bias_model": chosen_model,
+        "bias_cv_rmse_kms": float(
+            model_cmp.loc[model_cmp["model"] == chosen_model, "cv_rmse_kms"].iloc[0]
+        ),
+        "n_exposures_stacked": int(len(epochs)),
+        "median_sigma_rv_kms": float(sigma.get("median_sigma_rv_kms", np.nan)),
+        "p90_sigma_rv_kms": float(sigma.get("p90_sigma_rv_kms", np.nan)),
+        "min_sigma_rv_kms": float(sigma.get("min_sigma_rv_kms", np.nan)),
+        "median_chunk_scatter_debiased_kms": float(np.median(sc_ok)) if len(sc_ok) else float("nan"),
+        "p90_chunk_scatter_debiased_kms": float(np.percentile(sc_ok, 90)) if len(sc_ok) else float("nan"),
+    }
+    summary["post_debias_composite_score"] = post_debias_composite_score(summary)
+    return epochs, summary
+
+
+def post_debias_composite_score(summary: dict) -> float:
+    """Lower is better; debiased σ_RV is primary."""
+    sig = float(summary.get("median_sigma_rv_kms", np.nan))
+    scatter = float(summary.get("median_chunk_scatter_debiased_kms", np.nan))
+    parts, weights = [], []
+    if np.isfinite(sig):
+        parts.append(sig)
+        weights.append(0.7)
+    if np.isfinite(scatter):
+        parts.append(scatter)
+        weights.append(0.3)
+    if not parts:
+        return float("inf")
+    w = np.asarray(weights, float) / np.sum(weights)
+    return float(np.dot(w, parts))
+
+
+def compare_estimators_post_debias(
+    wide: pd.DataFrame,
+    estimators: tuple[str, ...],
+    summary_dir: Path,
+    *,
+    min_chunks: int = 3,
+    out_dir: Path | None = None,
+) -> pd.DataFrame:
+    """Rank estimators by post-debias median σ_RV (lower is better)."""
+    rows: list[dict] = []
+    for est in estimators:
+        epochs, summary = stack_post_debias_exposures(
+            wide,
+            est,
+            summary_dir,
+            min_chunks=min_chunks,
+        )
+        if out_dir is not None:
+            epochs.to_csv(out_dir / f"epochs_post_debias__{est}.csv", index=False)
+        rows.append(summary)
+    out = pd.DataFrame(rows)
+    if out.empty:
+        return out
+    return out.sort_values(
+        ["median_sigma_rv_kms", "p90_sigma_rv_kms", "median_chunk_scatter_debiased_kms"],
+        ascending=[True, True, True],
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--wide-diagnostics", type=Path, required=True)
+    ap.add_argument("--summary-dir", type=Path, default=REPO_ROOT / "output")
+    ap.add_argument(
+        "--estimators",
+        default="gauss_offset,parabolic_ls,smooth_peak,bi_gauss,grid,auto",
+    )
+    ap.add_argument("--out-dir", type=Path, default=Path("validation_output/ccf_estimator_study"))
+    ap.add_argument("--min-chunks", type=int, default=3)
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO), format="%(levelname)s %(message)s")
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    wide = pd.read_csv(args.wide_diagnostics)
+    estimators = tuple(e.strip() for e in args.estimators.split(",") if e.strip())
+    cmp_df = compare_estimators_post_debias(
+        wide,
+        estimators,
+        args.summary_dir,
+        min_chunks=args.min_chunks,
+        out_dir=args.out_dir,
+    )
+    cmp_df.to_csv(args.out_dir / "estimator_comparison_post_debias.csv", index=False)
+
+    winner = str(cmp_df.iloc[0]["estimator_name"]) if not cmp_df.empty else ""
+    result = {
+        "winner": winner,
+        "comparison": cmp_df.to_dict(orient="records"),
+    }
+    (args.out_dir / "phase_C_post_debias_winner.json").write_text(
+        json.dumps(result, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/ccf_rv_precision_gates.py
+++ b/validation/ccf_rv_precision_gates.py
@@ -1,0 +1,142 @@
+"""Phase gates: precision metrics must not regress between CCF estimator study phases."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+METRIC_LOWER_IS_BETTER = frozenset(
+    {
+        "median_sigma_rv_kms",
+        "p90_sigma_rv_kms",
+        "median_chunk_scatter_kms",
+        "bias_curve_rms_kms",
+        "stellar_bias_cv_rmse_kms",
+    }
+)
+
+METRIC_HIGHER_IS_BETTER = frozenset({"low_snr_finite_rate"})
+
+DEFAULT_TOLERANCE = {
+    "median_sigma_rv_kms": 0.005,
+    "p90_sigma_rv_kms": 0.008,
+    "median_chunk_scatter_kms": 0.005,
+    "bias_curve_rms_kms": 0.003,
+    "stellar_bias_cv_rmse_kms": 0.003,
+    "low_snr_finite_rate": 0.02,
+}
+
+
+def load_baseline(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if "metrics" not in data:
+        raise ValueError(f"baseline missing metrics: {path}")
+    return data
+
+
+def save_baseline(
+    path: Path,
+    *,
+    phase: str,
+    metrics: dict[str, float],
+    estimator: str = "gauss_offset",
+    tolerance: dict[str, float] | None = None,
+    notes: str = "",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "phase": phase,
+        "estimator": estimator,
+        "created_utc": datetime.now(timezone.utc).isoformat(),
+        "metrics": {k: float(v) for k, v in metrics.items() if np.isfinite(float(v))},
+        "tolerance": dict(tolerance or DEFAULT_TOLERANCE),
+        "notes": notes,
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _metric_ok(
+    key: str,
+    new_val: float,
+    prior_val: float,
+    tol: float,
+) -> tuple[bool, str]:
+    if not np.isfinite(new_val) or not np.isfinite(prior_val):
+        return True, f"{key}: skip (non-finite)"
+    if key in METRIC_LOWER_IS_BETTER:
+        ok = new_val <= prior_val + tol
+        return ok, f"{key}: {new_val:.4f} vs prior {prior_val:.4f} (tol +{tol})"
+    if key in METRIC_HIGHER_IS_BETTER:
+        ok = new_val >= prior_val - tol
+        return ok, f"{key}: {new_val:.4f} vs prior {prior_val:.4f} (tol -{tol})"
+    return True, f"{key}: ungated"
+
+
+def check_phase_gate(
+    phase: str,
+    metrics: dict[str, float],
+    prior: dict[str, Any],
+    *,
+    strict: bool = True,
+) -> dict[str, Any]:
+    """
+    Compare ``metrics`` against ``prior`` baseline.
+
+    Returns dict with ``passed``, ``failures``, ``checks``.
+    """
+    prior_metrics = prior.get("metrics", prior)
+    tolerance = prior.get("tolerance", DEFAULT_TOLERANCE)
+    checks: list[str] = []
+    failures: list[str] = []
+
+    keys = set(prior_metrics.keys()) | set(metrics.keys())
+    gate_keys = METRIC_LOWER_IS_BETTER | METRIC_HIGHER_IS_BETTER
+
+    for key in sorted(keys):
+        if key not in gate_keys:
+            continue
+        new_val = float(metrics.get(key, np.nan))
+        prior_val = float(prior_metrics.get(key, np.nan))
+        tol = float(tolerance.get(key, DEFAULT_TOLERANCE.get(key, 0.0)))
+        ok, msg = _metric_ok(key, new_val, prior_val, tol)
+        checks.append(msg)
+        if not ok:
+            failures.append(msg)
+
+    passed = len(failures) == 0
+    if strict and not passed:
+        return {
+            "phase": phase,
+            "passed": False,
+            "failures": failures,
+            "checks": checks,
+        }
+    return {
+        "phase": phase,
+        "passed": passed,
+        "failures": failures,
+        "checks": checks,
+    }
+
+
+def update_baseline_if_passed(
+    baseline_path: Path,
+    *,
+    phase: str,
+    metrics: dict[str, float],
+    gate_result: dict[str, Any],
+    estimator: str,
+) -> bool:
+    if not gate_result.get("passed"):
+        return False
+    save_baseline(
+        baseline_path,
+        phase=phase,
+        metrics=metrics,
+        estimator=estimator,
+        notes=f"Updated after phase {phase} gate pass",
+    )
+    return True

--- a/validation/ccf_rv_precision_metrics.py
+++ b/validation/ccf_rv_precision_metrics.py
@@ -1,0 +1,259 @@
+"""Aggregate precision metrics for CCF RV estimator benchmark and phase gates."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from validation.chunk_bias_lib import sample_mean_bias_curve
+from validation.chunk_bias_regression import choose_best_model, compare_models
+from validation.chunk_calibration import summarize_sigma_rv_metrics
+
+LOW_SNR_LOG10_CUT = 0.5
+_DEFAULT_CHUNK_ERR_KMS = 0.1
+
+
+def _finite_err_kms(err: np.ndarray, *, floor_kms: float = _DEFAULT_CHUNK_ERR_KMS) -> np.ndarray:
+    er = np.asarray(err, float)
+    out = np.where(np.isfinite(er) & (er > 0), er, floor_kms)
+    return out
+
+
+def _exposure_chunk_scatter(df: pd.DataFrame, rv_col: str, err_col: str) -> pd.Series:
+    """Per-exposure weighted RMS of chunk RVs about exposure mean."""
+    rows: list[float] = []
+    keys: list[str] = []
+    for file, g in df.groupby("file"):
+        rv = g[rv_col].astype(float).values
+        er = g.get(err_col, pd.Series(np.full(len(g), 0.1))).astype(float).values
+        ok = np.isfinite(rv)
+        if ok.sum() < 2:
+            continue
+        rv_ok = rv[ok]
+        er_ok = _finite_err_kms(er[ok])
+        w = 1.0 / er_ok**2
+        center = float(np.average(rv_ok, weights=w))
+        resid = rv_ok - center
+        sw = w / w.sum()
+        scatter = float(np.sqrt(np.sum(sw * resid**2)))
+        rows.append(scatter)
+        keys.append(str(file))
+    return pd.Series(rows, index=keys, dtype=float)
+
+
+def _exposure_sigma_rv(df: pd.DataFrame, rv_col: str, err_col: str) -> pd.DataFrame:
+    """Build per-exposure table with rv_err_calibrated_kms for summarize_sigma_rv_metrics."""
+    epochs: list[dict] = []
+    for file, g in df.groupby("file"):
+        rv = g[rv_col].astype(float).values
+        er = g.get(err_col, pd.Series(np.full(len(g), 0.1))).astype(float).values
+        ok = np.isfinite(rv)
+        if ok.sum() < 2:
+            continue
+        rv_ok = rv[ok]
+        er_ok = _finite_err_kms(er[ok])
+        w = 1.0 / er_ok**2
+        sig = float(1.0 / np.sqrt(np.sum(w)))
+        center = float(np.average(rv_ok, weights=w))
+        scatter = float(np.std(rv_ok - center, ddof=1)) if len(rv_ok) >= 2 else float("nan")
+        epochs.append(
+            {
+                "file": str(file),
+                "rv_err_calibrated_kms": sig,
+                "sigma_rv_core90_kms": sig,
+                "chunk_scatter_calibrated_kms": scatter,
+            }
+        )
+    return pd.DataFrame(epochs)
+
+
+def _bias_metrics_from_object_table(bias_df: pd.DataFrame) -> dict[str, float]:
+    if bias_df.empty or "weighted_mean_residual_kms" not in bias_df.columns:
+        return {
+            "bias_curve_rms_kms": float("nan"),
+            "stellar_bias_cv_rmse_kms": float("nan"),
+            "chosen_bias_model": "none",
+        }
+    work_bias = bias_df[np.isfinite(bias_df["weighted_mean_residual_kms"].astype(float))].copy()
+    if work_bias.empty:
+        return {
+            "bias_curve_rms_kms": float("nan"),
+            "stellar_bias_cv_rmse_kms": float("nan"),
+            "chosen_bias_model": "none",
+        }
+    curve = sample_mean_bias_curve(work_bias)
+    bias_curve_rms = float("nan")
+    if not curve.empty:
+        vals = curve["sample_mean_bias_kms"].astype(float).values
+        vals = vals[np.isfinite(vals)]
+        if len(vals):
+            bias_curve_rms = float(np.sqrt(np.mean(vals**2)))
+
+    work = work_bias.copy()
+    if "teff" not in work.columns and "teff_gaia" in work.columns:
+        work["teff"] = work["teff_gaia"]
+    for col, default in [("logg", np.nan), ("mh", np.nan), ("log10_median_mask_ccf_peak_snr", 1.0)]:
+        if col not in work.columns:
+            work[col] = default
+    orders = work["chunk_order"].astype(float)
+    o_min, o_max = float(np.nanmin(orders)), float(np.nanmax(orders))
+    work["chunk_order_norm"] = (orders - o_min) / max(o_max - o_min, 1.0)
+
+    model_cmp = compare_models(work)
+    chosen = choose_best_model(model_cmp)
+    cv_rmse = float(model_cmp.loc[model_cmp["model"] == chosen, "cv_rmse_kms"].iloc[0])
+    return {
+        "bias_curve_rms_kms": bias_curve_rms,
+        "stellar_bias_cv_rmse_kms": cv_rmse,
+        "chosen_bias_model": str(chosen),
+    }
+
+
+def build_per_object_bias_table(
+    chunk_df: pd.DataFrame,
+    *,
+    rv_col: str,
+    err_col: str,
+    min_measurements: int = 2,
+) -> pd.DataFrame:
+    """Per-object weighted mean chunk residual vs exposure-centered RV."""
+    rows: list[dict] = []
+    for (gid, ck), g in chunk_df.groupby(["gaia_dr3_id", "chunk_key"]):
+        if len(g) < min_measurements:
+            continue
+        resid_vals: list[float] = []
+        err_vals: list[float] = []
+        for _, row in g.iterrows():
+            file_rows = chunk_df[chunk_df["file"] == row["file"]]
+            rv = file_rows[rv_col].astype(float).values
+            er = file_rows.get(err_col, pd.Series(np.full(len(file_rows), 0.1))).astype(float).values
+            ok = np.isfinite(rv)
+            if ok.sum() < 2:
+                continue
+            rv_ok = rv[ok]
+            er_ok = _finite_err_kms(er[ok])
+            w = 1.0 / er_ok**2
+            center = float(np.average(rv_ok, weights=w))
+            rv_i = float(row[rv_col])
+            if not np.isfinite(rv_i):
+                continue
+            resid_vals.append(rv_i - center)
+            err_i = float(row.get(err_col, 0.1))
+            err_vals.append(err_i if np.isfinite(err_i) and err_i > 0 else 0.1)
+        if len(resid_vals) < min_measurements:
+            continue
+        rv_a = np.asarray(resid_vals, float)
+        er_a = np.asarray(err_vals, float)
+        w = 1.0 / er_a**2
+        mu = float(np.average(rv_a, weights=w))
+        stat = float(1.0 / np.sqrt(np.sum(w)))
+        intrinsic = float(np.std(rv_a - mu, ddof=1)) if len(rv_a) >= 3 else 0.05
+        rows.append(
+            {
+                "gaia_dr3_id": str(gid),
+                "chunk_key": str(ck),
+                "chunk_order": int(g["chunk_order"].iloc[0]) if "chunk_order" in g.columns else 0,
+                "n_measurements": len(resid_vals),
+                "weighted_mean_residual_kms": mu,
+                "statistical_err_kms": stat,
+                "intrinsic_scatter_kms": intrinsic,
+                "teff": float(g["teff"].iloc[0]) if "teff" in g.columns else float("nan"),
+                "logg": float(g["logg"].iloc[0]) if "logg" in g.columns else float("nan"),
+                "mh": float(g["mh"].iloc[0]) if "mh" in g.columns else float("nan"),
+                "log10_median_mask_ccf_peak_snr": float(
+                    g["log10_peak_snr"].iloc[0] if "log10_peak_snr" in g.columns else np.nan
+                ),
+                "sample_kept": True,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def summarize_estimator_metrics(
+    chunk_df: pd.DataFrame,
+    *,
+    estimator: str,
+    bias_df: pd.DataFrame | None = None,
+) -> dict[str, float]:
+    """Precision metrics for one estimator column set in wide chunk table."""
+    rv_col = f"rv_kms__{estimator}"
+    err_col = f"rv_err_kms__{estimator}"
+    if rv_col not in chunk_df.columns:
+        rv_col = "rv_kms"
+        err_col = "rv_err_kms"
+
+    sub = chunk_df[np.isfinite(chunk_df[rv_col].astype(float))].copy()
+
+    out: dict[str, float] = {
+        "estimator_name": estimator,
+        "n_chunks": float(len(sub)),
+        "n_exposures": float(sub["file"].nunique()) if "file" in sub.columns and len(sub) else 0.0,
+    }
+
+    if sub.empty:
+        out.update(
+            {
+                "median_sigma_rv_kms": float("nan"),
+                "p90_sigma_rv_kms": float("nan"),
+                "median_chunk_scatter_kms": float("nan"),
+                "low_snr_finite_rate": 0.0,
+                "bias_curve_rms_kms": float("nan"),
+                "stellar_bias_cv_rmse_kms": float("nan"),
+            }
+        )
+        return out
+
+    epochs = _exposure_sigma_rv(sub, rv_col, err_col)
+    sigma = summarize_sigma_rv_metrics(epochs) if not epochs.empty else {}
+    out["median_sigma_rv_kms"] = float(sigma.get("median_sigma_rv_kms", np.nan))
+    out["p90_sigma_rv_kms"] = float(sigma.get("p90_sigma_rv_kms", np.nan))
+
+    scatters = _exposure_chunk_scatter(sub, rv_col, err_col)
+    sc_ok = scatters[np.isfinite(scatters)]
+    out["median_chunk_scatter_kms"] = float(np.median(sc_ok)) if len(sc_ok) else float("nan")
+
+    if "peak_snr" in sub.columns:
+        snr = sub["peak_snr"].astype(float)
+        log_snr = np.log10(np.clip(snr, 1e-9, None))
+        low = log_snr < LOW_SNR_LOG10_CUT
+        if low.sum() > 0:
+            finite_low = np.isfinite(sub.loc[low, rv_col].astype(float))
+            out["low_snr_finite_rate"] = float(finite_low.mean())
+        else:
+            out["low_snr_finite_rate"] = 1.0
+    else:
+        out["low_snr_finite_rate"] = float("nan")
+
+    if bias_df is None:
+        bias_df = build_per_object_bias_table(sub, rv_col=rv_col, err_col=err_col)
+    bias_m = _bias_metrics_from_object_table(bias_df)
+    out["bias_curve_rms_kms"] = bias_m["bias_curve_rms_kms"]
+    out["stellar_bias_cv_rmse_kms"] = bias_m["stellar_bias_cv_rmse_kms"]
+    out["chosen_bias_model"] = bias_m["chosen_bias_model"]
+    return out
+
+
+def composite_score(metrics: dict[str, float]) -> float:
+    """Lower is better. Weight precision + bias + coverage penalty."""
+    sig = float(metrics.get("median_sigma_rv_kms", np.nan))
+    scatter = float(metrics.get("median_chunk_scatter_kms", np.nan))
+    bias = float(metrics.get("bias_curve_rms_kms", np.nan))
+    finite = float(metrics.get("low_snr_finite_rate", np.nan))
+    parts = []
+    weights = []
+    if np.isfinite(sig):
+        parts.append(sig)
+        weights.append(0.4)
+    if np.isfinite(scatter):
+        parts.append(scatter)
+        weights.append(0.3)
+    if np.isfinite(bias):
+        parts.append(bias)
+        weights.append(0.2)
+    if np.isfinite(finite):
+        parts.append(1.0 - finite)
+        weights.append(0.1)
+    if not parts:
+        return float("inf")
+    w = np.asarray(weights, float)
+    w = w / w.sum()
+    return float(np.dot(w, parts))

--- a/validation/chunk_adaptive_stack.py
+++ b/validation/chunk_adaptive_stack.py
@@ -68,6 +68,7 @@ PER_ORDER_LAYOUTS = (
     "subchunks_2",
     "subchunks_3",
     "subchunks_4",
+    "subchunks_8",
     "n3_red_heavy",
     "n3_blue_heavy",
 )

--- a/validation/chunk_calibration.py
+++ b/validation/chunk_calibration.py
@@ -168,15 +168,37 @@ def lookup_chunk_bias(
     chunk_key: str,
     per_object: pd.DataFrame,
     fallback: pd.DataFrame,
+    *,
+    layout_name: str | None = None,
 ) -> tuple[float, str]:
-    """Return debias correction (km/s) and source label."""
+    """Return debias correction (km/s) and source label.
+
+    When ``layout_name`` is set and bias tables include a ``layout_name`` column,
+    lookup uses ``(layout_name, chunk_key)`` first (required for mixed-layout stacks).
+    Falls back to ``chunk_key``-only rows for single-layout pipeline tables.
+    """
+    if layout_name and len(per_object) and "layout_name" in per_object.columns:
+        po = per_object[
+            (per_object["gaia_dr3_id"] == str(gaia_id))
+            & (per_object["layout_name"].astype(str) == str(layout_name))
+            & (per_object["chunk_key"].astype(str) == str(chunk_key))
+        ]
+        if len(po):
+            return float(po.iloc[0]["weighted_mean_residual_kms"]), "object"
+    if layout_name and len(fallback) and "layout_name" in fallback.columns:
+        fb = fallback[
+            (fallback["layout_name"].astype(str) == str(layout_name))
+            & (fallback["chunk_key"].astype(str) == str(chunk_key))
+        ]
+        if len(fb) and np.isfinite(fb.iloc[0]["bias_kms"]):
+            return float(fb.iloc[0]["bias_kms"]), "sample_fallback"
     po = per_object[
         (per_object["gaia_dr3_id"] == str(gaia_id))
-        & (per_object["chunk_key"] == str(chunk_key))
+        & (per_object["chunk_key"].astype(str) == str(chunk_key))
     ]
     if len(po):
         return float(po.iloc[0]["weighted_mean_residual_kms"]), "object"
-    fb = fallback[fallback["chunk_key"] == str(chunk_key)]
+    fb = fallback[fallback["chunk_key"].astype(str) == str(chunk_key)]
     if len(fb) and np.isfinite(fb.iloc[0]["bias_kms"]):
         return float(fb.iloc[0]["bias_kms"]), "sample_fallback"
     return float("nan"), "missing"
@@ -210,11 +232,17 @@ def _chunk_weight(
     fallback: pd.DataFrame,
 ) -> tuple[float, float, float, str] | None:
     """Per-chunk debiased RV and IVW weight using this spectrum's stat error."""
+    layout_name = (
+        str(row["layout_name"])
+        if "layout_name" in row.index and pd.notna(row.get("layout_name"))
+        else None
+    )
     bias, src = lookup_chunk_bias(
         str(row["gaia_dr3_id"]),
         str(row["chunk_key"]),
         per_object,
         fallback,
+        layout_name=layout_name,
     )
     if not np.isfinite(bias):
         return None

--- a/validation/chunk_campaign.py
+++ b/validation/chunk_campaign.py
@@ -37,6 +37,7 @@ from validation.chunk_layout import (  # noqa: E402
     build_campaign_broad_grid,
     build_campaign_edge_grid,
     build_custom_edge_layout,
+    load_campaign_layout_by_name,
     save_chunk_layout,
 )
 from validation.chunk_measurement_cache import (  # noqa: E402
@@ -254,7 +255,16 @@ def run_campaign(
 
     if only_layouts:
         want = set(only_layouts)
-        unique_layouts = [lay for lay in unique_layouts if lay.name in want]
+        from_grid = [lay for lay in unique_layouts if lay.name in want]
+        found = {lay.name for lay in from_grid}
+        extras: list[ChunkLayout] = []
+        for name in sorted(want - found):
+            lay = load_campaign_layout_by_name(name, campaign_dir)
+            if lay is not None:
+                extras.append(lay)
+            else:
+                logger.warning("Unknown layout %r (not in grid and no YAML found)", name)
+        unique_layouts = from_grid + extras
         if not unique_layouts:
             logger.error("No layouts matched --only-layouts %s", sorted(want))
             return pd.DataFrame()

--- a/validation/chunk_layout.py
+++ b/validation/chunk_layout.py
@@ -147,6 +147,28 @@ def build_equal_subchunk_layout(n: int) -> ChunkLayout:
     )
 
 
+def load_campaign_layout_by_name(name: str, campaign_dir: Path | str) -> ChunkLayout | None:
+    """
+    Resolve a layout by name from campaign layouts/, calibration/chunk_layouts/, or subchunks_N.
+    """
+    campaign_dir = Path(campaign_dir)
+    repo_root = Path(__file__).resolve().parents[1]
+    for base in (
+        campaign_dir / "layouts",
+        repo_root / "calibration" / "chunk_layouts",
+    ):
+        path = base / f"{name}.yaml"
+        if path.is_file():
+            return load_chunk_layout(path)
+    if str(name).startswith("subchunks_"):
+        try:
+            n_sub = int(str(name).split("_", 1)[1])
+            return build_equal_subchunk_layout(n_sub)
+        except (ValueError, IndexError):
+            pass
+    return None
+
+
 def build_custom_edge_layout(name: str, pixel_edges: list[float]) -> ChunkLayout:
     """N chunks from explicit N+1 fractional pixel edges."""
     edges = [float(x) for x in pixel_edges]

--- a/validation/chunk_optimization_advice.md
+++ b/validation/chunk_optimization_advice.md
@@ -1,0 +1,126 @@
+# Chunk optimization — post-campaign workflow
+
+## North star
+
+**Primary metric:** `median_sigma_rv_kms` — median per-exposure calibrated RV uncertainty after per-chunk debias and intrinsic-scatter IVW stacking (`validation/chunk_calibration.summarize_sigma_rv_metrics`).
+
+**Secondary:** `p90_sigma_rv_kms`, APF–APF relative gate (`relative_median_abs_delta_kms`).
+
+Do **not** use `composite_score` as the primary objective (it blends σ_RV with relative gate).
+
+---
+
+## Phase 1 — Per-order N + merge baseline (run first)
+
+From existing campaign cache (no pipeline), pick the best equal split **N ∈ {1,2,3,4}** or **merge_w{2,3,4}** per echelle order, then validate with greedy exposure-level stacks.
+
+**Normalization to n=1 (approximate):** for **sub-chunks**, σ_norm = σ_stack / √n_sub; for **merges**, σ_norm = σ_stack × √(orders merged). Combined on a stack: multiply σ_stack by `(∏√merge_width) / √(n_subchunk_meas)`. Ignores per-chunk IVW weight differences.
+
+**N=1 (one chunk per order):** candidate `split_1` uses pipelined `whole_order` measurements when present in cache; otherwise an **IVW proxy** coarsened from `subchunks_2/3/4` (see `split_1_uses_ivw_proxy` in `per_order_chunk_summary.csv`). Pipeline `whole_order` for true n=1:
+
+```bash
+PYTHONPATH=. python3 -m validation.chunk_campaign --run-pipeline --no-stage-b \
+  --out-dir "$CAMPAIGN" --only-layouts whole_order
+```
+
+```bash
+cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+CAMPAIGN=validation_output/chunk_campaign
+
+PYTHONPATH=. python3 -m validation.per_order_chunk_baseline --campaign-dir "$CAMPAIGN"
+```
+
+**Outputs** (`$CAMPAIGN/`):
+
+| File | Content |
+|------|---------|
+| `per_order_candidate_scores.csv` | Marginal median \|residual\| per (order, candidate) |
+| `per_order_chunk_map.csv` | Modal greedy winner per order across exposures |
+| `per_order_greedy_epochs.csv` | Per-exposure stacks using per-order choices |
+| `per_order_chunk_summary.csv` | Campaign median σ_RV vs reference layouts |
+| `plots/per_order_candidate_heatmap.png` | Order × candidate score heatmap |
+| `plots/per_order_choice_counts.png` | How many orders chose each candidate |
+
+**Latest run (local):** 114 exposures, `median_sigma_rv_kms ≈ 0.029` km/s (`needs_subchunks_8=True` because orders 37, 38, 49 prefer `split_4`).
+
+### Phase 1b — Gated `subchunks_8`
+
+Run **only if** `per_order_chunk_summary.csv` has `needs_subchunks_8=True`:
+
+```bash
+PYTHONPATH=. python3 -m validation.chunk_campaign --run-pipeline --no-stage-b \
+  --out-dir "$CAMPAIGN" --only-layouts subchunks_8
+
+PYTHONPATH=. python3 -m validation.per_order_chunk_baseline \
+  --campaign-dir "$CAMPAIGN" --split-ns 1,2,3,4,8
+```
+
+**After n=8:** compare N=4 vs N=8 on orders that preferred `split_4`. Pipeline N=5,6,7 only if n=8 results are ambiguous (see decision table in plan).
+
+---
+
+## Step 0 — Refresh global layout rankings
+
+```bash
+PYTHONPATH=. python3 -m validation.chunk_campaign --out-dir "$CAMPAIGN"
+
+python3 - <<'PY'
+import pandas as pd
+g = pd.read_csv("validation_output/chunk_campaign/campaign_grid_summary.csv")
+cols = ["layout","n_exposures","median_sigma_rv_kms","p90_sigma_rv_kms","relative_median_abs_delta_kms"]
+print(g[cols].sort_values("median_sigma_rv_kms").to_string(index=False))
+PY
+```
+
+**Redundant layout:** `n3_equal` ≡ `subchunks_3` (equal edges) — ignore `n3_equal`.
+
+---
+
+## Adaptive per-order mix
+
+```bash
+PYTHONPATH=. python3 -m validation.chunk_adaptive_stack --campaign-dir "$CAMPAIGN"
+```
+
+Compare `adaptive_mix` vs best fixed layout on **`adaptive_stack_common_cohort.csv`** (identical exposure set).
+
+---
+
+## Chunk weight lookup (incremental)
+
+Persist IVW weights keyed by `(layout_name, chunk_key)`. Re-running for a layout updates only that layout’s rows.
+
+```bash
+PYTHONPATH=. python3 -m validation.chunk_weight_lookup \
+  --campaign-dir "$CAMPAIGN" \
+  --layouts subchunks_4,merge_w4,n3_red_heavy \
+  --lookup-csv "$CAMPAIGN/chunk_weight_lookup.csv"
+```
+
+Weight model per chunk: `σ = hypot(stat_err, intrinsic)`; `w = 1/σ²`; exposure `σ_RV = 1/sqrt(Σw)`.
+
+---
+
+## Decision rules
+
+1. Minimize `median_sigma_rv_kms` among layouts with `n_exposures` within ~5% of cohort max.
+2. Tie-break: lower `p90_sigma_rv_kms`, then lower `relative_median_abs_delta_kms`.
+3. Use per-order baseline map for **context** (which orders want merge vs fine split); production layout may still be a single global YAML if adaptive gain is small.
+4. Adopt `adaptive_mix` only if it beats the best fixed layout on median σ_RV on the common cohort.
+
+---
+
+## Deploy (#57)
+
+1. Point production `--chunk-layout` at winner (today: `calibration/chunk_layouts/subchunks_4.yaml`).
+2. Rebuild `bias_statistics.txt` for that layout.
+3. Refit RVs: `scripts/refit_star_rvs.sh` / `scripts/refit_all_per_object_parallel.sh`.
+
+---
+
+## Future phases
+
+- **Phase 2:** Flexible YAML — per-order unequal edges + cross-order pixel spans (`validation/chunk_layout.py` v2).
+- **Phase 3:** Curated search (`validation/flexible_chunk_search.py`); discrete per-order GA on cached layouts if greedy adaptive plateaus.
+- **Edge refinement:** coordinate descent / presets — `validation_output/chunk_grid_search/EDGE_SEARCH_ADVICE.md`.
+- **ML ranking (issue #53):** BDT on chunk features to prioritize edge candidates before pipeline reruns.

--- a/validation/chunk_weight_lookup.py
+++ b/validation/chunk_weight_lookup.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Persistent chunk weight lookup: (layout_name, chunk_key) → bias, stat err, IVW weight.
+
+Incremental merge: new layouts add/update rows; other layouts are preserved.
+
+Example::
+
+  PYTHONPATH=. python3 -m validation.chunk_weight_lookup \\
+    --campaign-dir validation_output/chunk_campaign \\
+    --layouts subchunks_4,merge_w4 \\
+    --lookup-csv validation_output/chunk_campaign/chunk_weight_lookup.csv
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from validation.chunk_adaptive_stack import build_multi_layout_bias_tables, load_layouts  # noqa: E402
+from validation.chunk_measurement_cache import diagnostics_glob_for_layout  # noqa: E402
+from validation.plot_chunk_residuals import (  # noqa: E402
+    DEFAULT_CHUNK_MAX_DELTA_KMS,
+    DEFAULT_CHUNK_OUTLIER_SIGMA,
+    _load_chunk_rows,
+    apply_spectrum_chunk_outlier_clip,
+)
+
+logger = logging.getLogger(__name__)
+
+LOOKUP_COLUMNS = (
+    "layout_name",
+    "chunk_key",
+    "bias_kms",
+    "statistical_err_kms",
+    "intrinsic_scatter_kms",
+    "ivw_weight",
+    "updated_at",
+)
+
+
+def build_lookup_from_fallback(fallback: pd.DataFrame, *, layout_name: str) -> pd.DataFrame:
+    """One layout slice from multi-layout fallback bias table."""
+    sub = fallback[fallback["layout_name"].astype(str) == str(layout_name)].copy()
+    if sub.empty:
+        return pd.DataFrame(columns=LOOKUP_COLUMNS)
+    now = datetime.now(timezone.utc).isoformat()
+    rows = []
+    for _, r in sub.iterrows():
+        stat = float(r.get("statistical_err_kms", np.nan))
+        intrinsic = float(r.get("intrinsic_scatter_kms", 0.0) or 0.0)
+        sigma = float(np.hypot(stat, intrinsic)) if np.isfinite(stat) and stat > 0 else float("nan")
+        w = float(1.0 / sigma**2) if np.isfinite(sigma) and sigma > 0 else float("nan")
+        rows.append(
+            {
+                "layout_name": str(layout_name),
+                "chunk_key": str(r["chunk_key"]),
+                "bias_kms": float(r.get("bias_kms", np.nan)),
+                "statistical_err_kms": stat,
+                "intrinsic_scatter_kms": intrinsic,
+                "ivw_weight": w,
+                "updated_at": now,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def merge_lookup(existing: pd.DataFrame | None, new_rows: pd.DataFrame) -> pd.DataFrame:
+    """Upsert on (layout_name, chunk_key); preserve rows not in new_rows."""
+    if new_rows.empty and (existing is None or existing.empty):
+        return pd.DataFrame(columns=LOOKUP_COLUMNS)
+    new_rows = new_rows[list(LOOKUP_COLUMNS)].copy()
+    if existing is None or existing.empty:
+        return new_rows.sort_values(["layout_name", "chunk_key"]).reset_index(drop=True)
+    old = existing[list(LOOKUP_COLUMNS)].copy()
+    key = ["layout_name", "chunk_key"]
+    layouts_touched = set(new_rows["layout_name"].astype(str).unique())
+    keep = old[~old["layout_name"].astype(str).isin(layouts_touched)]
+    combined = pd.concat([keep, new_rows], ignore_index=True)
+    combined = combined.drop_duplicates(subset=key, keep="last")
+    return combined.sort_values(key).reset_index(drop=True)
+
+
+def load_lookup(path: Path | str) -> pd.DataFrame:
+    path = Path(path)
+    if not path.is_file():
+        return pd.DataFrame(columns=LOOKUP_COLUMNS)
+    df = pd.read_csv(path)
+    for col in LOOKUP_COLUMNS:
+        if col not in df.columns:
+            df[col] = np.nan
+    return df[list(LOOKUP_COLUMNS)]
+
+
+def save_lookup(df: pd.DataFrame, path: Path | str) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+
+
+def build_lookup_for_campaign(
+    campaign_dir: Path,
+    layout_names: list[str],
+    *,
+    lookup_path: Path | None = None,
+) -> pd.DataFrame:
+    campaign_dir = Path(campaign_dir)
+    layouts = load_layouts(campaign_dir)
+    _per_object, fallback, _intrinsic = build_multi_layout_bias_tables(campaign_dir, layouts)
+    existing = load_lookup(lookup_path) if lookup_path else pd.DataFrame(columns=LOOKUP_COLUMNS)
+    merged = existing
+    for name in layout_names:
+        if name not in layouts:
+            logger.warning("Layout %s not in campaign layouts/", name)
+            continue
+        piece = build_lookup_from_fallback(fallback, layout_name=name)
+        merged = merge_lookup(merged, piece)
+        logger.info("Lookup: %s → %d rows", name, len(piece))
+    if lookup_path:
+        save_lookup(merged, lookup_path)
+    return merged
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Build or merge chunk weight lookup CSV.")
+    p.add_argument("--campaign-dir", type=Path, required=True)
+    p.add_argument("--layouts", type=str, required=True, help="Comma-separated layout names")
+    p.add_argument("--lookup-csv", type=Path, required=True)
+    p.add_argument("--log-level", default="INFO")
+    args = p.parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    names = [x.strip() for x in args.layouts.split(",") if x.strip()]
+    build_lookup_for_campaign(args.campaign_dir, names, lookup_path=args.lookup_csv)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/per_order_chunk_baseline.py
+++ b/validation/per_order_chunk_baseline.py
@@ -1,0 +1,765 @@
+#!/usr/bin/env python3
+"""
+Per-order chunk baseline: best equal split N (1–4, optionally 8) and merge widths per echelle order.
+
+Uses campaign measurement cache (no pipeline). Emits marginal scores, greedy per-exposure
+assignment, and campaign median σ_RV vs global layouts.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  PYTHONPATH=. python3 -m validation.per_order_chunk_baseline \\
+    --campaign-dir validation_output/chunk_campaign
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from validation.chunk_adaptive_stack import (  # noqa: E402
+    MIN_CHUNKS,
+    ChunkMeas,
+    _index_by_file_layout,
+    _lookup_layout_bias,
+    _stack_result_for_meas,
+    build_multi_layout_bias_tables,
+    load_campaign_measurements,
+    load_layouts,
+)
+from validation.chunk_calibration import summarize_sigma_rv_metrics  # noqa: E402
+from validation.chunk_layout import (  # noqa: E402
+    ChunkLayout,
+    apf_valid_orders,
+    merge_order_groups,
+)
+from validation.chunk_bias_lib import load_stellar_metadata  # noqa: E402
+from darkhunter_rv.chunking import parse_chunk_key  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+SPLIT_NS = (1, 2, 3, 4, 8)
+MERGE_LAYOUTS = ("merge_w2", "merge_w3", "merge_w4")
+WHOLE_ORDER_LAYOUT = "whole_order"
+FINE_SPLIT_LAYOUT = "subchunks_4"
+
+
+def is_merge_meas(meas: ChunkMeas) -> bool:
+    return meas.layout_name in MERGE_LAYOUTS or str(meas.chunk_key).startswith("merge")
+
+
+def stack_norm_factor(chunks: list[ChunkMeas] | tuple[ChunkMeas, ...]) -> float:
+    """
+    Normalize stacked σ to n=1 (single sub-chunk / single-order equivalent).
+
+    - Sub-chunk measurements: divide by √n_sub (n_sub = count of non-merge chunks).
+    - Merge super-chunks: multiply by √(orders merged) per merge measurement.
+
+    Approximate — ignores per-chunk IVW weight differences.
+    """
+    n_sub = sum(1 for m in chunks if not is_merge_meas(m))
+    factor = 1.0 / np.sqrt(max(n_sub, 1))
+    for m in chunks:
+        if is_merge_meas(m):
+            factor *= np.sqrt(max(len(m.orders), 1))
+    return float(factor)
+
+
+def sigma_rv_normalized_kms(
+    sigma_rv_kms: float,
+    chunks: list[ChunkMeas] | tuple[ChunkMeas, ...],
+) -> float:
+    if not np.isfinite(sigma_rv_kms) or sigma_rv_kms <= 0:
+        return float("nan")
+    return float(sigma_rv_kms * stack_norm_factor(chunks))
+
+
+@dataclass(frozen=True)
+class OrderCandidate:
+    """One chunking option for a single echelle order on one exposure."""
+
+    name: str
+    layout_name: str
+    chunks: tuple[ChunkMeas, ...]
+    covered_orders: frozenset[int]
+
+    @property
+    def subchunk_n(self) -> int | None:
+        if self.name.startswith("subchunks_"):
+            return int(self.name.split("_", 1)[1])
+        return None
+
+    @property
+    def n_chunks(self) -> int:
+        """RV measurements contributed (1 for merge super-chunks)."""
+        return len(self.chunks)
+
+
+def _candidate_name_subchunks(n: int) -> str:
+    return f"subchunks_{n}"
+
+
+def _candidate_name_merge(layout_name: str) -> str:
+    return layout_name
+
+
+def _ivw_rv_err(rv: np.ndarray, err: np.ndarray) -> tuple[float, float]:
+    ok = np.isfinite(rv) & np.isfinite(err) & (err > 0)
+    if not np.any(ok):
+        return float("nan"), float("nan")
+    w = 1.0 / err[ok] ** 2
+    mu = float(np.sum(w * rv[ok]) / np.sum(w))
+    sig = float(1.0 / np.sqrt(np.sum(w)))
+    return mu, sig
+
+
+def _synthetic_whole_order_chunk(
+    file: str,
+    order: int,
+    idx: dict[tuple[str, str, str], ChunkMeas],
+) -> ChunkMeas | None:
+    """Coarsen finest available equal split to N=1 via IVW (offline proxy for whole_order)."""
+    for n_sub in (8, 4, 3, 2):
+        layout_name = f"subchunks_{n_sub}"
+        parts: list[ChunkMeas] = []
+        for si in range(n_sub):
+            m = idx.get((file, layout_name, f"{order}_{si}"))
+            if m is None:
+                parts = []
+                break
+            parts.append(m)
+        if len(parts) != n_sub:
+            continue
+        rv = np.array([p.rv_kms for p in parts], float)
+        err = np.array([p.rv_err_kms for p in parts], float)
+        mu, sig = _ivw_rv_err(rv, err)
+        if not np.isfinite(mu) or not np.isfinite(sig):
+            continue
+        ref = parts[0]
+        return ChunkMeas(
+            layout_name=layout_name,
+            chunk_key=str(order),
+            rv_kms=mu,
+            rv_err_kms=sig,
+            orders=frozenset({order}),
+            qc_pass=True,
+            file=file,
+            gaia_dr3_id=ref.gaia_dr3_id,
+            mjd=ref.mjd,
+            teff=ref.teff,
+        )
+    return None
+
+
+def _chunks_for_split(
+    file: str,
+    order: int,
+    n: int,
+    idx: dict[tuple[str, str, str], ChunkMeas],
+    layouts: dict[str, ChunkLayout],
+) -> list[ChunkMeas] | None:
+    if n == 1:
+        # Prefer pipelined whole_order (one chunk = one echelle order).
+        m = idx.get((file, WHOLE_ORDER_LAYOUT, str(order)))
+        if m is not None:
+            return [m]
+        m = _synthetic_whole_order_chunk(file, order, idx)
+        return [m] if m is not None else None
+    layout_name = f"subchunks_{n}"
+    if layout_name not in layouts:
+        return None
+    layout = layouts[layout_name]
+    n_chunks = layout.n_chunks_per_order()
+    out: list[ChunkMeas] = []
+    for si in range(n_chunks):
+        ck = f"{order}_{si}" if n_chunks > 1 else str(order)
+        m = idx.get((file, layout_name, ck))
+        if m is None:
+            return None
+        out.append(m)
+    return out
+
+
+def _orders_with_split_data(
+    file: str,
+    idx: dict[tuple[str, str, str], ChunkMeas],
+    layouts: dict[str, ChunkLayout],
+) -> list[int]:
+    """Echelle orders with at least one fine-split layout in cache for this file."""
+    orders: set[int] = set()
+    for n in (4, 2, 3, 8):
+        layout_name = f"subchunks_{n}"
+        if layout_name not in layouts:
+            continue
+        for (_f, lay, ck), _m in idx.items():
+            if _f != file or lay != layout_name:
+                continue
+            order, _, kind = parse_chunk_key(ck)
+            if order is None or kind == "merge":
+                continue
+            if _chunks_for_split(file, int(order), n, idx, layouts) is not None:
+                orders.add(int(order))
+    return sorted(orders)
+
+
+def _orders_in_merge_group(gi: int, layout: ChunkLayout) -> frozenset[int]:
+    if not layout.merge_orders or gi < 0 or gi >= len(layout.merge_orders):
+        return frozenset()
+    lo, hi = layout.merge_orders[gi]
+    valid = set(apf_valid_orders())
+    return frozenset(o for o in range(int(lo), int(hi) + 1) if o in valid)
+
+
+def _chunks_for_merge(
+    file: str,
+    order: int,
+    merge_layout_name: str,
+    layout: ChunkLayout,
+    idx: dict[tuple[str, str, str], ChunkMeas],
+) -> list[ChunkMeas] | None:
+    gi = merge_order_groups(order, layout.merge_orders)
+    if gi is None:
+        return None
+    m = idx.get((file, merge_layout_name, f"merge_{gi}"))
+    if m is None:
+        return None
+    return [m]
+
+
+def enumerate_order_candidates(
+    file: str,
+    order: int,
+    idx: dict[tuple[str, str, str], ChunkMeas],
+    layouts: dict[str, ChunkLayout],
+    *,
+    split_ns: tuple[int, ...] = SPLIT_NS,
+) -> list[OrderCandidate]:
+    cands: list[OrderCandidate] = []
+    for n in split_ns:
+        chunks = _chunks_for_split(file, order, n, idx, layouts)
+        if chunks is None:
+            continue
+        cands.append(
+            OrderCandidate(
+                name=_candidate_name_subchunks(n),
+                layout_name=chunks[0].layout_name,
+                chunks=tuple(chunks),
+                covered_orders=frozenset({order}),
+            )
+        )
+    for merge_name in MERGE_LAYOUTS:
+        layout = layouts.get(merge_name)
+        if layout is None:
+            continue
+        chunks = _chunks_for_merge(file, order, merge_name, layout, idx)
+        if chunks is None:
+            continue
+        gi = merge_order_groups(order, layout.merge_orders)
+        covered = _orders_in_merge_group(int(gi), layout) if gi is not None else frozenset({order})
+        cands.append(
+            OrderCandidate(
+                name=_candidate_name_merge(merge_name),
+                layout_name=merge_name,
+                chunks=tuple(chunks),
+                covered_orders=covered,
+            )
+        )
+    return cands
+
+
+@dataclass
+class GreedyStep:
+    order: int
+    candidate: OrderCandidate
+    sigma_rv_kms: float
+    sigma_rv_normalized_kms: float
+    norm_factor: float
+
+
+def greedy_assign_file(
+    file: str,
+    idx: dict[tuple[str, str, str], ChunkMeas],
+    layouts: dict[str, ChunkLayout],
+    *,
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    intrinsic_model,
+    star_meta: dict,
+    split_ns: tuple[int, ...] = SPLIT_NS,
+) -> tuple[list[GreedyStep], dict]:
+    """Greedy per-order assignment for one exposure; returns steps and final stack metrics."""
+    orders = _orders_with_split_data(file, idx, layouts)
+    if not orders:
+        return [], {}
+    order_set = set(orders)
+
+    covered: set[int] = set()
+    steps: list[GreedyStep] = []
+    selected_chunks: list[ChunkMeas] = []
+
+    for order in sorted(orders):
+        if order in covered:
+            continue
+        best_cand: OrderCandidate | None = None
+        best_norm = float("inf")
+        best_err = float("nan")
+        best_factor = float("nan")
+        for cand in enumerate_order_candidates(file, order, idx, layouts, split_ns=split_ns):
+            if not cand.covered_orders <= order_set:
+                continue
+            trial = selected_chunks + list(cand.chunks)
+            out = _stack_result_for_meas(
+                trial,
+                per_object=per_object,
+                fallback=fallback,
+                intrinsic_model=intrinsic_model,
+                star_meta=star_meta,
+                min_chunks=1,
+            )
+            err = float(out["rv_err_calibrated_kms"])
+            norm_factor = stack_norm_factor(trial)
+            norm = sigma_rv_normalized_kms(err, trial)
+            if np.isfinite(norm) and norm < best_norm:
+                best_norm = norm
+                best_err = err
+                best_factor = norm_factor
+                best_cand = cand
+        if best_cand is None:
+            continue
+        selected_chunks.extend(best_cand.chunks)
+        covered |= set(best_cand.covered_orders)
+        steps.append(
+            GreedyStep(
+                order=order,
+                candidate=best_cand,
+                sigma_rv_kms=best_err,
+                sigma_rv_normalized_kms=best_norm,
+                norm_factor=best_factor,
+            )
+        )
+
+    if len(selected_chunks) < MIN_CHUNKS:
+        return [], {}
+    stack = _stack_result_for_meas(
+        selected_chunks,
+        per_object=per_object,
+        fallback=fallback,
+        intrinsic_model=intrinsic_model,
+        star_meta=star_meta,
+        min_chunks=MIN_CHUNKS,
+    )
+    stack["sigma_rv_normalized_kms"] = sigma_rv_normalized_kms(
+        float(stack["rv_err_calibrated_kms"]), selected_chunks
+    )
+    stack["norm_factor"] = stack_norm_factor(selected_chunks)
+    return steps, stack
+
+
+def augment_fallback_for_coarse_keys(fallback: pd.DataFrame) -> pd.DataFrame:
+    """Add whole-order chunk_key rows (median bias/stat) for split_1 proxy lookup."""
+    if fallback.empty:
+        return fallback
+    extra: list[dict] = []
+    existing = set(
+        zip(fallback["layout_name"].astype(str), fallback["chunk_key"].astype(str))
+    )
+    for layout_name, grp in fallback.groupby("layout_name", sort=False):
+        if not str(layout_name).startswith("subchunks_"):
+            continue
+        by_order: dict[int, list[pd.Series]] = {}
+        for _, r in grp.iterrows():
+            order, _, kind = parse_chunk_key(str(r["chunk_key"]))
+            if order is None or kind == "merge":
+                continue
+            by_order.setdefault(int(order), []).append(r)
+        for order, rs in by_order.items():
+            ck = str(order)
+            if (str(layout_name), ck) in existing:
+                continue
+            biases = [float(x["bias_kms"]) for x in rs if np.isfinite(x.get("bias_kms", np.nan))]
+            stats = [float(x["statistical_err_kms"]) for x in rs if np.isfinite(x.get("statistical_err_kms", np.nan))]
+            intr = [float(x["intrinsic_scatter_kms"]) for x in rs if np.isfinite(x.get("intrinsic_scatter_kms", np.nan))]
+            if not biases:
+                continue
+            extra.append(
+                {
+                    "layout_name": str(layout_name),
+                    "chunk_key": ck,
+                    "bias_kms": float(np.median(biases)),
+                    "statistical_err_kms": float(np.median(stats)) if stats else float("nan"),
+                    "intrinsic_scatter_kms": float(np.median(intr)) if intr else 0.0,
+                }
+            )
+    if not extra:
+        return fallback
+    return pd.concat([fallback, pd.DataFrame(extra)], ignore_index=True)
+
+
+def marginal_scores(
+    meas_df: pd.DataFrame,
+    *,
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    layouts: dict[str, ChunkLayout],
+    intrinsic_model,
+    split_ns: tuple[int, ...] = SPLIT_NS,
+) -> pd.DataFrame:
+    """
+    Campaign-wide scores per (order, candidate).
+
+    Primary ``marginal_score``: median σ_norm per (order, candidate). Sub-chunks:
+    σ_norm = σ_stack / √n_sub. Merges: σ_norm = σ_stack × √(orders merged). Target n=1.
+    Approximate (ignores IVW weights). Secondary: |residual|.
+    """
+    idx = _index_by_file_layout(meas_df)
+    rows: list[dict] = []
+    idx_all = _index_by_file_layout(meas_df)
+    orders = sorted(
+        {
+            o
+            for f in meas_df["file"].astype(str).unique()
+            for o in _orders_with_split_data(f, idx_all, layouts)
+        }
+    )
+    meta_by_file: dict[str, dict] = {}
+    for file_label in meas_df["file"].astype(str).unique():
+        sub = meas_df[meas_df["file"].astype(str) == file_label]
+        meta_by_file[file_label] = {"teff": float(sub.iloc[0]["teff"])}
+
+    for order in orders:
+        abs_res: dict[str, list[float]] = {}
+        norm_sig: dict[str, list[float]] = {}
+        raw_sig: dict[str, list[float]] = {}
+        cand_norm_factor: dict[str, float] = {}
+        subchunks_1_proxy: dict[str, bool] = {}
+        for file_label in meas_df["file"].astype(str).unique():
+            for cand in enumerate_order_candidates(file_label, order, idx, layouts, split_ns=split_ns):
+                order_chunks = [m for m in cand.chunks if order in m.orders]
+                if not order_chunks:
+                    continue
+                cand_norm_factor[cand.name] = stack_norm_factor(order_chunks)
+                out = _stack_result_for_meas(
+                    order_chunks,
+                    per_object=per_object,
+                    fallback=fallback,
+                    intrinsic_model=intrinsic_model,
+                    star_meta=meta_by_file.get(file_label, {}),
+                    min_chunks=1,
+                )
+                err = float(out["rv_err_calibrated_kms"])
+                norm = sigma_rv_normalized_kms(err, order_chunks)
+                if np.isfinite(norm):
+                    norm_sig.setdefault(cand.name, []).append(norm)
+                if np.isfinite(err):
+                    raw_sig.setdefault(cand.name, []).append(err)
+                if cand.name == "subchunks_1" and cand.chunks:
+                    m0 = cand.chunks[0]
+                    subchunks_1_proxy[cand.name] = m0.layout_name != WHOLE_ORDER_LAYOUT
+                for m in order_chunks:
+                    bias = _lookup_layout_bias(
+                        m.gaia_dr3_id, m.layout_name, m.chunk_key, per_object, fallback
+                    )
+                    if not np.isfinite(bias):
+                        continue
+                    abs_res.setdefault(cand.name, []).append(abs(float(m.rv_kms) - bias))
+        for cand_name in sorted(set(norm_sig) | set(abs_res)):
+            norm_list = norm_sig.get(cand_name, [])
+            res_list = abs_res.get(cand_name, [])
+            rows.append(
+                {
+                    "order": order,
+                    "candidate": cand_name,
+                    "median_sigma_normalized_kms": float(np.median(norm_list)) if norm_list else float("nan"),
+                    "median_sigma_stack_kms": float(np.median(raw_sig.get(cand_name, [])))
+                    if raw_sig.get(cand_name)
+                    else float("nan"),
+                    "median_abs_residual_kms": float(np.median(res_list)) if res_list else float("nan"),
+                    "norm_factor": float(cand_norm_factor.get(cand_name, np.nan)),
+                    "n_exposures": len(norm_list),
+                    "marginal_score": float(np.median(norm_list)) if norm_list else float("nan"),
+                    "subchunks_1_is_proxy": bool(subchunks_1_proxy.get(cand_name, False)),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def needs_subchunks_8_from_map(chunk_map: pd.DataFrame, *, has_subchunks_8: bool) -> bool:
+    """True when any order prefers subchunks_4 and subchunks_8 is not yet available."""
+    if has_subchunks_8 or chunk_map.empty:
+        return False
+    return bool((chunk_map["choice"].astype(str) == "subchunks_4").any())
+
+
+def _plot_heatmap(scores: pd.DataFrame, out_path: Path) -> None:
+    if scores.empty:
+        return
+    pivot = scores.pivot_table(
+        index="order", columns="candidate", values="marginal_score", aggfunc="first"
+    )
+    pivot = pivot.sort_index()
+    fig, ax = plt.subplots(figsize=(10, max(4, 0.15 * len(pivot))))
+    data = pivot.astype(float).values
+    im = ax.imshow(data, aspect="auto", cmap="viridis_r")
+    ax.set_xticks(np.arange(len(pivot.columns)))
+    ax.set_xticklabels(pivot.columns.astype(str), rotation=45, ha="right", fontsize=8)
+    ax.set_yticks(np.arange(len(pivot.index)))
+    ax.set_yticklabels(pivot.index.astype(int), fontsize=7)
+    ax.set_xlabel("Candidate")
+    ax.set_ylabel("Echelle order")
+    ax.set_title("Per-order marginal score (median σ_norm, lower better)")
+    fig.colorbar(im, ax=ax, label="km/s")
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def _plot_choice_counts(chunk_map: pd.DataFrame, out_path: Path) -> None:
+    if chunk_map.empty:
+        return
+    counts = chunk_map["choice"].value_counts().sort_index()
+    fig, ax = plt.subplots(figsize=(7, 4))
+    ax.bar(counts.index.astype(str), counts.values, color="C0", alpha=0.85)
+    ax.set_ylabel("Number of orders")
+    ax.set_xlabel("Greedy winner (modal across exposures)")
+    ax.set_title("Per-order chunk choice distribution")
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=130)
+    plt.close(fig)
+
+
+def run_baseline(
+    campaign_dir: Path,
+    *,
+    split_ns: tuple[int, ...] = SPLIT_NS,
+) -> dict[str, pd.DataFrame | bool]:
+    campaign_dir = Path(campaign_dir)
+    layouts = load_layouts(campaign_dir)
+    from validation.chunk_layout import build_equal_subchunk_layout
+
+    for n in split_ns:
+        if n > 1:
+            name = f"subchunks_{n}"
+            if name not in layouts:
+                layouts[name] = build_equal_subchunk_layout(n)
+    if 1 in split_ns and WHOLE_ORDER_LAYOUT not in layouts:
+        layouts[WHOLE_ORDER_LAYOUT] = ChunkLayout(name=WHOLE_ORDER_LAYOUT, subchunks=1)
+
+    meas_df = load_campaign_measurements(campaign_dir, layouts)
+    has_whole_order = bool((meas_df["layout_name"].astype(str) == WHOLE_ORDER_LAYOUT).any())
+    if meas_df.empty:
+        raise ValueError(f"No measurements in {campaign_dir}")
+
+    per_object, fallback, intrinsic_model = build_multi_layout_bias_tables(campaign_dir, layouts)
+    fallback = augment_fallback_for_coarse_keys(fallback)
+    meta_tbl = load_stellar_metadata(REPO_ROOT / "output")
+    idx = _index_by_file_layout(meas_df)
+
+    scores = marginal_scores(
+        meas_df,
+        per_object=per_object,
+        fallback=fallback,
+        layouts=layouts,
+        intrinsic_model=intrinsic_model,
+        split_ns=split_ns,
+    )
+
+    greedy_rows: list[dict] = []
+    epoch_rows: list[dict] = []
+    per_file_choices: list[list[tuple[int, str]]] = []
+
+    for file_label in sorted(meas_df["file"].astype(str).unique()):
+        gid = str(meas_df[meas_df["file"].astype(str) == file_label].iloc[0]["gaia_dr3_id"])
+        star_meta = {"logg": np.nan, "mh": np.nan}
+        if not meta_tbl.empty:
+            sm = meta_tbl[meta_tbl["gaia_dr3_id"] == gid]
+            if len(sm):
+                star_meta["logg"] = float(sm.iloc[0].get("logg", np.nan))
+                star_meta["mh"] = float(sm.iloc[0].get("mh", np.nan))
+
+        steps, stack = greedy_assign_file(
+            file_label,
+            idx,
+            layouts,
+            per_object=per_object,
+            fallback=fallback,
+            intrinsic_model=intrinsic_model,
+            star_meta=star_meta,
+            split_ns=split_ns,
+        )
+        if not steps or not np.isfinite(stack.get("rv_err_calibrated_kms", np.nan)):
+            continue
+        file_choice_list: list[tuple[int, str]] = []
+        for step in steps:
+            pick = step.candidate
+            for o in pick.covered_orders:
+                greedy_rows.append(
+                    {
+                        "file": file_label,
+                        "order": int(o),
+                        "choice": pick.name,
+                        "layout_name": pick.layout_name,
+                        "chunk_keys": ",".join(m.chunk_key for m in pick.chunks),
+                        "greedy_step_sigma_rv_kms": step.sigma_rv_kms,
+                        "greedy_step_sigma_normalized_kms": step.sigma_rv_normalized_kms,
+                        "norm_factor_in_stack": step.norm_factor,
+                    }
+                )
+                file_choice_list.append((int(o), pick.name))
+
+        per_file_choices.append(file_choice_list)
+        ref = steps[0].candidate.chunks[0]
+        n_used = int(stack["n_chunks_used"])
+        err_final = float(stack["rv_err_calibrated_kms"])
+        epoch_rows.append(
+            {
+                "gaia_dr3_id": gid,
+                "file": file_label,
+                "mjd": ref.mjd,
+                "teff": ref.teff,
+                "rv_calibrated_kms": stack["rv_calibrated_kms"],
+                "rv_err_calibrated_kms": err_final,
+                "sigma_rv_normalized_kms": float(stack.get("sigma_rv_normalized_kms", np.nan)),
+                "n_chunks_used": n_used,
+                "norm_factor": float(stack.get("norm_factor", np.nan)),
+                "layout_mix_json": json.dumps(
+                    dict(
+                        Counter(
+                            m.layout_name
+                            for step in steps
+                            for m in step.candidate.chunks
+                        )
+                    )
+                ),
+            }
+        )
+
+    epochs = pd.DataFrame(epoch_rows)
+    summary_metrics = summarize_sigma_rv_metrics(epochs) if not epochs.empty else {}
+    if not epochs.empty and "sigma_rv_normalized_kms" in epochs.columns:
+        norm = epochs["sigma_rv_normalized_kms"].astype(float)
+        norm_ok = norm[np.isfinite(norm) & (norm > 0)]
+        if len(norm_ok):
+            summary_metrics["median_sigma_rv_normalized_kms"] = float(np.median(norm_ok))
+            summary_metrics["p90_sigma_rv_normalized_kms"] = float(np.percentile(norm_ok, 90))
+
+    # Modal choice per order across exposures
+    order_choice_counts: dict[int, Counter[str]] = {}
+    for file_choices in per_file_choices:
+        for order, choice in file_choices:
+            order_choice_counts.setdefault(order, Counter())[choice] += 1
+    map_rows = []
+    for order in sorted(order_choice_counts):
+        ctr = order_choice_counts[order]
+        choice, count = ctr.most_common(1)[0]
+        map_rows.append(
+            {
+                "order": order,
+                "choice": choice,
+                "n_files": count,
+                "frac_files": count / max(len(per_file_choices), 1),
+                "n_candidates_tried": len(ctr),
+            }
+        )
+    chunk_map = pd.DataFrame(map_rows)
+
+    grid_path = campaign_dir / "campaign_grid_summary.csv"
+    comparisons: dict[str, float] = {}
+    if grid_path.is_file():
+        grid = pd.read_csv(grid_path)
+        for layout in ("subchunks_4", "n3_red_heavy", "adaptive_mix"):
+            sub = grid[grid["layout"].astype(str) == layout]
+            if len(sub):
+                comparisons[f"ref_{layout}_median_sigma_rv_kms"] = float(
+                    sub.iloc[0]["median_sigma_rv_kms"]
+                )
+
+    has_subchunks_8 = "subchunks_8" in layouts and any(
+        meas_df["layout_name"].astype(str) == "subchunks_8"
+    )
+    needs_subchunks_8 = needs_subchunks_8_from_map(chunk_map, has_subchunks_8=has_subchunks_8)
+
+    subchunks_1_proxy = (
+        bool(scores.get("subchunks_1_is_proxy", pd.Series(dtype=bool)).any())
+        if not scores.empty
+        else True
+    )
+    summary_row = {
+        "n_exposures": len(epochs),
+        "needs_subchunks_8": bool(needs_subchunks_8),
+        "has_whole_order_in_cache": has_whole_order,
+        "subchunks_1_uses_ivw_proxy": subchunks_1_proxy and not has_whole_order,
+        **summary_metrics,
+        **comparisons,
+    }
+    summary = pd.DataFrame([summary_row])
+
+    out_scores = campaign_dir / "per_order_candidate_scores.csv"
+    out_map = campaign_dir / "per_order_chunk_map.csv"
+    out_greedy = campaign_dir / "per_order_greedy_detail.csv"
+    out_epochs = campaign_dir / "per_order_greedy_epochs.csv"
+    out_summary = campaign_dir / "per_order_chunk_summary.csv"
+    scores.to_csv(out_scores, index=False)
+    chunk_map.to_csv(out_map, index=False)
+    pd.DataFrame(greedy_rows).to_csv(out_greedy, index=False)
+    epochs.to_csv(out_epochs, index=False)
+    summary.to_csv(out_summary, index=False)
+
+    plot_dir = campaign_dir / "plots"
+    _plot_heatmap(scores, plot_dir / "per_order_candidate_heatmap.png")
+    _plot_choice_counts(chunk_map, plot_dir / "per_order_choice_counts.png")
+
+    logger.info(
+        "Per-order baseline: %d exposures, median σ_RV=%.4f km/s, needs_subchunks_8=%s",
+        len(epochs),
+        summary_metrics.get("median_sigma_rv_kms", float("nan")),
+        needs_subchunks_8,
+    )
+    return {
+        "scores": scores,
+        "chunk_map": chunk_map,
+        "epochs": epochs,
+        "summary": summary,
+        "needs_subchunks_8": needs_subchunks_8,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Per-order N + merge chunk baseline from campaign cache.")
+    p.add_argument(
+        "--campaign-dir",
+        type=Path,
+        default=REPO_ROOT / "validation_output" / "chunk_campaign",
+    )
+    p.add_argument(
+        "--split-ns",
+        type=str,
+        default="1,2,3,4",
+        help="Comma-separated equal split counts (add 8 after subchunks_8 campaign).",
+    )
+    p.add_argument("--log-level", default="INFO")
+    args = p.parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    split_ns = tuple(int(x.strip()) for x in args.split_ns.split(",") if x.strip())
+    run_baseline(args.campaign_dir, split_ns=split_ns)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/spectrum_tiling.py
+++ b/validation/spectrum_tiling.py
@@ -1,0 +1,837 @@
+"""
+Exhaustive search over valid full-spectrum chunk tilings from campaign cache.
+
+Memory model: one exposure at a time, single DFS pass, backtracking mutable state
+(no duplicate count pass, no recursive tuple chains). Uses file-scoped measurement
+indexes instead of scanning the full campaign index.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  PYTHONPATH=. python3 -m validation.spectrum_tiling_search \\
+    --campaign-dir validation_output/chunk_campaign
+"""
+from __future__ import annotations
+
+import gc
+import json
+import logging
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from typing import Protocol
+
+import numpy as np
+import pandas as pd
+
+from validation.chunk_adaptive_stack import (
+    ChunkMeas,
+    _index_by_file_layout,
+    build_multi_layout_bias_tables,
+    load_campaign_measurements,
+    load_layouts,
+)
+from validation.chunk_calibration import (
+    stack_calibrated_exposure,
+    summarize_sigma_rv_metrics,
+)
+from validation.chunk_layout import ChunkLayout, apf_valid_orders, merge_order_groups
+
+logger = logging.getLogger(__name__)
+
+MIN_CHUNKS = 3
+DEFAULT_METRIC = "rv_err_calibrated_kms"
+
+# Type alias: per-file measurement index (layout_name, chunk_key) -> ChunkMeas
+FileMeasIndex = dict[tuple[str, str], ChunkMeas]
+
+
+@dataclass(frozen=True)
+class SpectrumRegion:
+    """
+    Fraction of one echelle order covered by a tile.
+
+    Full-order tiles use the default ``pixel_lo=0``, ``pixel_hi=1``. Future layouts
+    (e.g. merge order 10 + first half of order 11) register tiles with narrower spans.
+    """
+
+    order: int
+    pixel_lo: float = 0.0
+    pixel_hi: float = 1.0
+
+    def is_full_order(self) -> bool:
+        return self.pixel_lo == 0.0 and self.pixel_hi == 1.0
+
+    def overlaps(self, other: SpectrumRegion) -> bool:
+        if self.order != other.order:
+            return False
+        return self.pixel_lo < other.pixel_hi and other.pixel_lo < self.pixel_hi
+
+
+def full_order_region(order: int) -> SpectrumRegion:
+    return SpectrumRegion(order=int(order))
+
+
+def _region_contained(inner: SpectrumRegion, outer: SpectrumRegion) -> bool:
+    return (
+        inner.order == outer.order
+        and inner.pixel_lo >= outer.pixel_lo
+        and inner.pixel_hi <= outer.pixel_hi
+    )
+
+
+def _tile_fits_uncovered(tile: TileCandidate, uncovered: list[SpectrumRegion]) -> bool:
+    return all(
+        any(_region_contained(tr, ur) for ur in uncovered) for tr in tile.regions
+    )
+
+
+def _subtract_regions_list(
+    uncovered: list[SpectrumRegion],
+    removed: frozenset[SpectrumRegion],
+) -> list[SpectrumRegion]:
+    """Return a new uncovered list with ``removed`` spans subtracted."""
+    out: list[SpectrumRegion] = []
+    for u in uncovered:
+        remaining: list[SpectrumRegion] = [u]
+        for r in removed:
+            if u.order != r.order:
+                continue
+            new_remaining: list[SpectrumRegion] = []
+            for part in remaining:
+                if not part.overlaps(r):
+                    new_remaining.append(part)
+                    continue
+                if r.pixel_lo <= part.pixel_lo and r.pixel_hi >= part.pixel_hi:
+                    continue
+                if r.pixel_lo > part.pixel_lo:
+                    new_remaining.append(
+                        SpectrumRegion(part.order, part.pixel_lo, r.pixel_lo)
+                    )
+                if r.pixel_hi < part.pixel_hi:
+                    new_remaining.append(
+                        SpectrumRegion(part.order, r.pixel_hi, part.pixel_hi)
+                    )
+            remaining = new_remaining
+        out.extend(remaining)
+    return out
+
+
+def _anchor_index(uncovered: list[SpectrumRegion]) -> int:
+    return min(range(len(uncovered)), key=lambda i: (uncovered[i].order, uncovered[i].pixel_lo))
+
+
+def _sig_key(meas_keys: set[tuple[str, str]]) -> tuple[tuple[str, str], ...]:
+    return tuple(sorted(meas_keys))
+
+
+@dataclass(frozen=True)
+class TileCandidate:
+    """One installable tile: cached measurements covering a set of spectrum regions."""
+
+    name: str
+    layout_name: str
+    measurements: tuple[ChunkMeas, ...]
+    regions: frozenset[SpectrumRegion]
+
+    @property
+    def meas_keys(self) -> frozenset[tuple[str, str]]:
+        return frozenset((m.layout_name, m.chunk_key) for m in self.measurements)
+
+
+class CustomTileProvider(Protocol):
+    """Hook for layouts that do not map to per-order or merge-group tiles."""
+
+    def tiles_for_anchor(
+        self,
+        anchor: SpectrumRegion,
+        *,
+        uncovered: tuple[SpectrumRegion, ...],
+    ) -> list[TileCandidate]:
+        ...
+
+
+CustomTileProviderFactory = Callable[[ChunkLayout, dict], CustomTileProvider]
+
+_CUSTOM_TILE_FACTORIES: dict[str, CustomTileProviderFactory] = {}
+
+
+def register_custom_tile_layout(
+    layout_name: str,
+    factory: CustomTileProviderFactory,
+) -> None:
+    """Register a provider for exotic layouts (partial-order merges, etc.)."""
+    _CUSTOM_TILE_FACTORIES[str(layout_name)] = factory
+
+
+def file_meas_index(
+    global_idx: dict[tuple[str, str, str], ChunkMeas],
+    file: str,
+) -> FileMeasIndex:
+    """Slice campaign index to one exposure (no file key in stored tuples)."""
+    return {
+        (lay, ck): m
+        for (f, lay, ck), m in global_idx.items()
+        if f == file
+    }
+
+
+def _layout_has_cache_data(layout_name: str, file_idx: FileMeasIndex) -> bool:
+    return any(lay == layout_name for (lay, _ck) in file_idx)
+
+
+def _layout_kind(layout: ChunkLayout) -> str:
+    if layout.name in _CUSTOM_TILE_FACTORIES:
+        return "custom"
+    if layout.merge_orders:
+        return "merge_groups"
+    return "per_order_partition"
+
+
+def _orders_in_merge_group(gi: int, layout: ChunkLayout) -> frozenset[int]:
+    if not layout.merge_orders or gi < 0 or gi >= len(layout.merge_orders):
+        return frozenset()
+    lo, hi = layout.merge_orders[gi]
+    valid = set(apf_valid_orders())
+    return frozenset(o for o in range(int(lo), int(hi) + 1) if o in valid)
+
+
+def _order_partition_chunks(
+    order: int,
+    layout_name: str,
+    layout: ChunkLayout,
+    file_idx: FileMeasIndex,
+) -> list[ChunkMeas] | None:
+    n = layout.n_chunks_per_order()
+    chunks: list[ChunkMeas] = []
+    for si in range(n):
+        ck = f"{order}_{si}" if n > 1 else str(order)
+        m = file_idx.get((layout_name, ck))
+        if m is None:
+            return None
+        chunks.append(m)
+    return chunks
+
+
+def _merge_group_tile(
+    order: int,
+    layout_name: str,
+    layout: ChunkLayout,
+    file_idx: FileMeasIndex,
+) -> TileCandidate | None:
+    gi = merge_order_groups(order, layout.merge_orders)
+    if gi is None:
+        return None
+    m = file_idx.get((layout_name, f"merge_{gi}"))
+    if m is None:
+        return None
+    covered_orders = _orders_in_merge_group(int(gi), layout)
+    regions = frozenset(full_order_region(o) for o in covered_orders)
+    return TileCandidate(
+        name=f"{layout_name}:merge_{gi}",
+        layout_name=layout_name,
+        measurements=(m,),
+        regions=regions,
+    )
+
+
+def _per_order_partition_tile(
+    order: int,
+    layout_name: str,
+    layout: ChunkLayout,
+    file_idx: FileMeasIndex,
+) -> TileCandidate | None:
+    chunks = _order_partition_chunks(order, layout_name, layout, file_idx)
+    if chunks is None:
+        return None
+    return TileCandidate(
+        name=f"{layout_name}:order_{order}",
+        layout_name=layout_name,
+        measurements=tuple(chunks),
+        regions=frozenset({full_order_region(order)}),
+    )
+
+
+@dataclass
+class TileRegistry:
+    """
+    Tile discovery for one exposure.
+
+    Uses a file-scoped ``file_idx`` so searches never scan the full campaign cache.
+    """
+
+    file: str
+    layouts: dict[str, ChunkLayout]
+    file_idx: FileMeasIndex
+    mix_layout_names: tuple[str, ...] = field(default_factory=tuple)
+    whole_layout_names: tuple[str, ...] = field(default_factory=tuple)
+    custom_providers: dict[str, CustomTileProvider] = field(default_factory=dict)
+    _order_tile_cache: dict[int, tuple[TileCandidate, ...]] = field(
+        default_factory=dict, repr=False
+    )
+
+    @classmethod
+    def for_file(
+        cls,
+        file: str,
+        layouts: dict[str, ChunkLayout],
+        file_idx: FileMeasIndex,
+        *,
+        mix_layout_names: list[str] | None = None,
+        whole_layout_names: list[str] | None = None,
+    ) -> TileRegistry:
+        if mix_layout_names is None:
+            mix_layout_names = sorted(
+                name
+                for name, lay in layouts.items()
+                if _layout_kind(lay) in ("per_order_partition", "merge_groups", "custom")
+                and _layout_has_cache_data(name, file_idx)
+            )
+        if whole_layout_names is None:
+            whole_layout_names = sorted(
+                name for name in layouts if _layout_has_cache_data(name, file_idx)
+            )
+
+        custom: dict[str, CustomTileProvider] = {}
+        for name in mix_layout_names:
+            if name in _CUSTOM_TILE_FACTORIES and name in layouts:
+                custom[name] = _CUSTOM_TILE_FACTORIES[name](layouts[name], {"file_idx": file_idx})
+
+        return cls(
+            file=file,
+            layouts=layouts,
+            file_idx=file_idx,
+            mix_layout_names=tuple(mix_layout_names),
+            whole_layout_names=tuple(whole_layout_names),
+            custom_providers=custom,
+        )
+
+    def spectrum_regions(self) -> list[SpectrumRegion]:
+        from validation.per_order_chunk_baseline import _orders_with_split_data
+
+        global_idx = {
+            (self.file, lay, ck): m for (lay, ck), m in self.file_idx.items()
+        }
+        orders = _orders_with_split_data(self.file, global_idx, self.layouts)
+        if not orders and self.custom_providers:
+            extra: set[int] = set()
+            for (_lay, _ck), m in self.file_idx.items():
+                if m.layout_name in self.custom_providers:
+                    extra |= {int(o) for o in m.orders}
+            orders = sorted(extra)
+        return [full_order_region(o) for o in orders]
+
+    def _tiles_for_anchor_uncovered(
+        self,
+        anchor: SpectrumRegion,
+        uncovered: list[SpectrumRegion],
+    ) -> list[TileCandidate]:
+        uncovered_t = tuple(uncovered)
+        out: list[TileCandidate] = []
+        seen: set[frozenset[tuple[str, str]]] = set()
+        order = anchor.order
+
+        for layout_name in self.mix_layout_names:
+            layout = self.layouts.get(layout_name)
+            if layout is None:
+                continue
+            kind = _layout_kind(layout)
+            if kind == "custom" and layout_name in self.custom_providers:
+                for tile in self.custom_providers[layout_name].tiles_for_anchor(
+                    anchor, uncovered=uncovered_t
+                ):
+                    if not _tile_fits_uncovered(tile, uncovered):
+                        continue
+                    if tile.meas_keys in seen:
+                        continue
+                    seen.add(tile.meas_keys)
+                    out.append(tile)
+                continue
+            cand = (
+                _merge_group_tile(order, layout_name, layout, self.file_idx)
+                if kind == "merge_groups"
+                else _per_order_partition_tile(order, layout_name, layout, self.file_idx)
+            )
+            if cand is None or not _tile_fits_uncovered(cand, uncovered):
+                continue
+            if cand.meas_keys in seen:
+                continue
+            seen.add(cand.meas_keys)
+            out.append(cand)
+        return out
+
+    def candidate_tiles_at_anchor(self, anchor: SpectrumRegion) -> tuple[TileCandidate, ...]:
+        """Tiles for ``anchor`` when all splittable orders are still uncovered (cached)."""
+        order = anchor.order
+        cached = self._order_tile_cache.get(order)
+        if cached is not None:
+            return cached
+        regions = self.spectrum_regions()
+        if not regions:
+            cached = ()
+        else:
+            cached = tuple(
+                self._tiles_for_anchor_uncovered(anchor, regions)
+            )
+        self._order_tile_cache[order] = cached
+        return cached
+
+    def whole_layout_tile(self, layout_name: str) -> TileCandidate | None:
+        chunks = [m for (lay, _ck), m in self.file_idx.items() if lay == layout_name]
+        if len(chunks) < MIN_CHUNKS:
+            return None
+        regions: set[SpectrumRegion] = set()
+        for m in chunks:
+            for o in m.orders:
+                regions.add(full_order_region(int(o)))
+        return TileCandidate(
+            name=f"whole:{layout_name}",
+            layout_name=layout_name,
+            measurements=tuple(sorted(chunks, key=lambda m: m.chunk_key)),
+            regions=frozenset(regions),
+        )
+
+
+def count_complete_tilings(registry: TileRegistry, *, max_count: int | None = None) -> int:
+    """Count distinct complete mixed tilings (single DFS pass, compact dedup keys)."""
+    mixed_count, _evaluated, _best, _trunc = _search_mixed_tilings(
+        registry,
+        per_object=pd.DataFrame(),
+        fallback=pd.DataFrame(),
+        intrinsic_model=None,
+        star_meta={},
+        metric=DEFAULT_METRIC,
+        max_tilings=max_count,
+        include_whole_layouts=False,
+        min_chunks=MIN_CHUNKS,
+        count_only=True,
+    )
+    return mixed_count
+
+
+def iterate_complete_tilings(
+    registry: TileRegistry,
+) -> Iterator[tuple[tuple[tuple[str, str], ...], tuple[TileCandidate, ...]]]:
+    """Yield complete tilings (testing helper — prefer ``find_best_tiling_for_file``)."""
+    regions = registry.spectrum_regions()
+    if not regions:
+        return
+    seen: set[tuple[tuple[str, str], ...]] = set()
+    tiles_acc: list[TileCandidate] = []
+    keys_acc: set[tuple[str, str]] = set()
+
+    def _dfs(uncovered: list[SpectrumRegion]) -> Iterator[tuple[tuple[tuple[str, str], ...], tuple[TileCandidate, ...]]]:
+        if not uncovered:
+            key = _sig_key(keys_acc)
+            if key not in seen:
+                seen.add(key)
+                yield key, tuple(tiles_acc)
+            return
+        anchor = uncovered[_anchor_index(uncovered)]
+        for tile in registry.candidate_tiles_at_anchor(anchor):
+            if not _tile_fits_uncovered(tile, uncovered):
+                continue
+            if tile.meas_keys & keys_acc:
+                continue
+            tiles_acc.append(tile)
+            keys_acc.update(tile.meas_keys)
+            yield from _dfs(_subtract_regions_list(uncovered, tile.regions))
+            keys_acc.difference_update(tile.meas_keys)
+            tiles_acc.pop()
+
+    yield from _dfs(list(regions))
+
+
+def measurements_from_tiles(tiles: tuple[TileCandidate, ...]) -> list[ChunkMeas]:
+    out: list[ChunkMeas] = []
+    seen: set[tuple[str, str]] = set()
+    for tile in tiles:
+        for m in tile.measurements:
+            key = (m.layout_name, m.chunk_key)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(m)
+    return out
+
+
+def tiling_name(tiles: tuple[TileCandidate, ...]) -> str:
+    if len(tiles) == 1 and tiles[0].name.startswith("whole:"):
+        return tiles[0].name
+    parts = sorted(tile.name for tile in tiles)
+    return "mix:" + "+".join(parts)
+
+
+def stack_tiling_pipeline(
+    measurements: list[ChunkMeas],
+    *,
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    intrinsic_model,
+    star_meta: dict,
+    min_chunks: int = MIN_CHUNKS,
+) -> dict:
+    """Pipeline metric: debias + IVW + CDF core90 via stack_calibrated_exposure."""
+    if len(measurements) < min_chunks:
+        return {
+            "rv_calibrated_kms": np.nan,
+            "rv_err_calibrated_kms": np.nan,
+            "sigma_rv_core90_kms": np.nan,
+            "n_chunks_used": len(measurements),
+            "n_chunks_core90": 0,
+            "bias_source_mix": "",
+        }
+    gid = str(measurements[0].gaia_dr3_id)
+    per_obj = per_object
+    if len(per_object) and "layout_name" in per_object.columns:
+        per_obj = per_object[per_object["gaia_dr3_id"] == gid]
+
+    rv = np.array([m.rv_kms for m in measurements], dtype=float)
+    err = np.array([m.rv_err_kms for m in measurements], dtype=float)
+    chunk_df = pd.DataFrame(
+        {
+            "gaia_dr3_id": gid,
+            "layout_name": [m.layout_name for m in measurements],
+            "chunk_key": [m.chunk_key for m in measurements],
+            "rv_kms": rv,
+            "rv_err_kms": err,
+            "chunk_kept": True,
+            "teff": measurements[0].teff,
+            "logg": star_meta.get("logg", np.nan),
+            "mh": star_meta.get("mh", np.nan),
+        }
+    )
+    return stack_calibrated_exposure(
+        chunk_df,
+        per_object=per_obj,
+        fallback=fallback,
+        intrinsic_model=intrinsic_model,
+        min_chunks=min_chunks,
+    )
+
+
+@dataclass
+class TilingSearchResult:
+    file: str
+    tiling_name: str
+    tiles: tuple[TileCandidate, ...]
+    stack: dict
+    n_tilings_evaluated: int
+    n_mixed_tilings: int
+    n_whole_layouts: int
+    search_truncated: bool
+
+    @property
+    def metric_value(self) -> float:
+        return float(self.stack.get(DEFAULT_METRIC, np.nan))
+
+    @property
+    def n_tilings_available(self) -> int:
+        return self.n_mixed_tilings + self.n_whole_layouts
+
+
+def _search_mixed_tilings(
+    registry: TileRegistry,
+    *,
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    intrinsic_model,
+    star_meta: dict,
+    metric: str,
+    max_tilings: int | None,
+    include_whole_layouts: bool,
+    min_chunks: int,
+    count_only: bool = False,
+) -> tuple[int, int, TilingSearchResult | None, bool]:
+    """
+    Single backtracking DFS.
+
+    Returns ``(n_mixed_tilings, n_evaluated, best_result_or_none, truncated)``.
+    When ``count_only=True``, skips stack evaluation (bias/intrinsic may be None).
+    """
+    regions = registry.spectrum_regions()
+    n_whole = 0
+    if include_whole_layouts:
+        n_whole = sum(
+            1 for lay in registry.whole_layout_names if registry.whole_layout_tile(lay) is not None
+        )
+
+    best: TilingSearchResult | None = None
+    best_val = float("inf")
+    evaluated = 0
+    mixed_count = 0
+    seen: set[tuple[tuple[str, str], ...]] = set()
+    truncated = False
+
+    tiles_acc: list[TileCandidate] = []
+    keys_acc: set[tuple[str, str]] = set()
+
+    def _at_limit() -> bool:
+        return max_tilings is not None and evaluated >= max_tilings
+
+    def _evaluate_leaf() -> None:
+        nonlocal best, best_val, evaluated, mixed_count
+        key = _sig_key(keys_acc)
+        if key in seen:
+            return
+        seen.add(key)
+        mixed_count += 1
+        if count_only:
+            if _at_limit():
+                return
+            evaluated += 1
+            return
+        if _at_limit():
+            return
+        meas = measurements_from_tiles(tuple(tiles_acc))
+        stack = stack_tiling_pipeline(
+            meas,
+            per_object=per_object,
+            fallback=fallback,
+            intrinsic_model=intrinsic_model,
+            star_meta=star_meta,
+            min_chunks=min_chunks,
+        )
+        evaluated += 1
+        val = float(stack.get(metric, np.nan))
+        if not np.isfinite(val):
+            return
+        if val < best_val - 1e-12:
+            best_val = val
+            best = TilingSearchResult(
+                file=registry.file,
+                tiling_name=tiling_name(tuple(tiles_acc)),
+                tiles=tuple(tiles_acc),
+                stack=stack,
+                n_tilings_evaluated=evaluated,
+                n_mixed_tilings=mixed_count,
+                n_whole_layouts=n_whole,
+                search_truncated=False,
+            )
+
+    def _dfs(uncovered: list[SpectrumRegion]) -> None:
+        nonlocal truncated
+        if _at_limit():
+            truncated = max_tilings is not None
+            return
+        if not uncovered:
+            _evaluate_leaf()
+            return
+        anchor = uncovered[_anchor_index(uncovered)]
+        for tile in registry.candidate_tiles_at_anchor(anchor):
+            if _at_limit():
+                truncated = max_tilings is not None
+                return
+            if not _tile_fits_uncovered(tile, uncovered):
+                continue
+            if tile.meas_keys & keys_acc:
+                continue
+            tiles_acc.append(tile)
+            keys_acc.update(tile.meas_keys)
+            _dfs(_subtract_regions_list(uncovered, tile.regions))
+            keys_acc.difference_update(tile.meas_keys)
+            tiles_acc.pop()
+
+    if regions:
+        _dfs(list(regions))
+
+    if include_whole_layouts and not count_only:
+        for layout_name in registry.whole_layout_names:
+            if _at_limit():
+                truncated = True
+                break
+            tile = registry.whole_layout_tile(layout_name)
+            if tile is None:
+                continue
+            key = _sig_key(set(tile.meas_keys))
+            if key in seen:
+                continue
+            seen.add(key)
+            stack = stack_tiling_pipeline(
+                list(tile.measurements),
+                per_object=per_object,
+                fallback=fallback,
+                intrinsic_model=intrinsic_model,
+                star_meta=star_meta,
+                min_chunks=min_chunks,
+            )
+            evaluated += 1
+            val = float(stack.get(metric, np.nan))
+            if not np.isfinite(val):
+                continue
+            if val < best_val - 1e-12:
+                best_val = val
+                best = TilingSearchResult(
+                    file=registry.file,
+                    tiling_name=tiling_name((tile,)),
+                    tiles=(tile,),
+                    stack=stack,
+                    n_tilings_evaluated=evaluated,
+                    n_mixed_tilings=mixed_count,
+                    n_whole_layouts=n_whole,
+                    search_truncated=truncated,
+                )
+
+    if best is not None:
+        best.n_tilings_evaluated = evaluated
+        best.search_truncated = truncated
+    return mixed_count, evaluated, best, truncated
+
+
+def find_best_tiling_for_file(
+    registry: TileRegistry,
+    *,
+    per_object: pd.DataFrame,
+    fallback: pd.DataFrame,
+    intrinsic_model,
+    star_meta: dict,
+    metric: str = DEFAULT_METRIC,
+    max_tilings: int | None = None,
+    include_whole_layouts: bool = True,
+    min_chunks: int = MIN_CHUNKS,
+) -> TilingSearchResult | None:
+    """One DFS pass: dedupe, count mixed tilings, and track best pipeline σ."""
+    if max_tilings is not None:
+        logger.info(
+            "%s: capping evaluations at %d tilings",
+            registry.file,
+            max_tilings,
+        )
+    mixed_count, _evaluated, best, truncated = _search_mixed_tilings(
+        registry,
+        per_object=per_object,
+        fallback=fallback,
+        intrinsic_model=intrinsic_model,
+        star_meta=star_meta,
+        metric=metric,
+        max_tilings=max_tilings,
+        include_whole_layouts=include_whole_layouts,
+        min_chunks=min_chunks,
+        count_only=False,
+    )
+    if truncated and best is not None:
+        logger.warning(
+            "%s: search truncated at %d evaluations (%d mixed tilings seen)",
+            registry.file,
+            best.n_tilings_evaluated,
+            _mixed_count,
+        )
+    return best
+
+
+def run_campaign_tiling_search(
+    campaign_dir,
+    *,
+    max_tilings_per_file: int | None = None,
+    metric: str = DEFAULT_METRIC,
+    mix_layout_names: list[str] | None = None,
+    whole_layout_names: list[str] | None = None,
+    count_tilings: bool = False,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Search best tiling per exposure; one file in memory at a time."""
+    from pathlib import Path
+
+    from validation.chunk_bias_lib import load_stellar_metadata
+    from validation.chunk_adaptive_stack import REPO_ROOT
+
+    campaign_dir = Path(campaign_dir)
+    layouts = load_layouts(campaign_dir)
+    meas_df = load_campaign_measurements(campaign_dir, layouts)
+    if meas_df.empty:
+        raise ValueError(f"No measurements in {campaign_dir}")
+
+    per_object, fallback, intrinsic_model = build_multi_layout_bias_tables(campaign_dir, layouts)
+    meta_tbl = load_stellar_metadata(REPO_ROOT / "output")
+    global_idx = _index_by_file_layout(meas_df)
+
+    file_labels = sorted(meas_df["file"].astype(str).unique())
+    meta_by_gid: dict[str, dict] = {}
+    if not meta_tbl.empty:
+        for gid, row in meta_tbl.set_index("gaia_dr3_id").iterrows():
+            meta_by_gid[str(gid)] = {
+                "logg": float(row.get("logg", np.nan)),
+                "mh": float(row.get("mh", np.nan)),
+            }
+
+    epoch_rows: list[dict] = []
+    count_rows: list[dict] = []
+
+    for fi, file_label in enumerate(file_labels):
+        if fi % 10 == 0:
+            logger.info("Tiling search %d/%d at %s", fi + 1, len(file_labels), file_label)
+
+        gid = str(meas_df.loc[meas_df["file"].astype(str) == file_label, "gaia_dr3_id"].iloc[0])
+        star_meta = meta_by_gid.get(gid, {"logg": np.nan, "mh": np.nan})
+
+        fidx = file_meas_index(global_idx, file_label)
+        registry = TileRegistry.for_file(
+            file_label,
+            layouts,
+            fidx,
+            mix_layout_names=mix_layout_names,
+            whole_layout_names=whole_layout_names,
+        )
+
+        if count_tilings:
+            n_mixed = count_complete_tilings(registry)
+            count_rows.append({"file": file_label, "n_mixed_tilings": n_mixed})
+            registry._order_tile_cache.clear()
+            del registry, fidx
+            gc.collect()
+            continue
+
+        result = find_best_tiling_for_file(
+            registry,
+            per_object=per_object,
+            fallback=fallback,
+            intrinsic_model=intrinsic_model,
+            star_meta=star_meta,
+            metric=metric,
+            max_tilings=max_tilings_per_file,
+        )
+
+        if result is not None:
+            count_rows.append({"file": file_label, "n_mixed_tilings": result.n_mixed_tilings})
+
+        if result is not None:
+            teff = float(meas_df.loc[meas_df["file"].astype(str) == file_label, "teff"].iloc[0])
+            mjd = float(meas_df.loc[meas_df["file"].astype(str) == file_label, "mjd"].iloc[0])
+            epoch_rows.append(
+                {
+                    "gaia_dr3_id": gid,
+                    "file": file_label,
+                    "mjd": mjd,
+                    "teff": teff,
+                    "tiling_name": result.tiling_name,
+                    "rv_calibrated_kms": result.stack["rv_calibrated_kms"],
+                    "rv_err_calibrated_kms": result.stack["rv_err_calibrated_kms"],
+                    "sigma_rv_core90_kms": result.stack.get("sigma_rv_core90_kms", np.nan),
+                    "n_chunks_used": result.stack.get("n_chunks_used", np.nan),
+                    "n_chunks_core90": result.stack.get("n_chunks_core90", np.nan),
+                    "n_mixed_tilings": result.n_mixed_tilings,
+                    "n_tilings_evaluated": result.n_tilings_evaluated,
+                    "search_truncated": result.search_truncated,
+                    "tile_plan_json": json.dumps([t.name for t in result.tiles]),
+                }
+            )
+
+        registry._order_tile_cache.clear()
+        del registry, fidx, result
+        gc.collect()
+
+    epochs = pd.DataFrame(epoch_rows)
+    counts = pd.DataFrame(count_rows)
+    summary_metrics = summarize_sigma_rv_metrics(epochs) if not epochs.empty else {}
+    summary = pd.DataFrame(
+        [
+            {
+                "n_exposures": len(epochs),
+                "metric": metric,
+                **summary_metrics,
+                "n_files_truncated": int(epochs["search_truncated"].sum()) if not epochs.empty else 0,
+                "median_n_mixed_tilings": float(counts["n_mixed_tilings"].median())
+                if not counts.empty
+                else np.nan,
+            }
+        ]
+    )
+    return epochs, summary, counts

--- a/validation/spectrum_tiling_search.py
+++ b/validation/spectrum_tiling_search.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+CLI: exhaustive mixed-layout tiling search with pipeline σ_RV.
+
+Example::
+
+  cd /Users/rfoley/darkhunter/rvs/dark-hunter_rv
+  PYTHONPATH=. python3 -m validation.spectrum_tiling_search \\
+    --campaign-dir validation_output/chunk_campaign
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from validation.spectrum_tiling import (  # noqa: E402
+    DEFAULT_METRIC,
+    TileRegistry,
+    count_complete_tilings,
+    file_meas_index,
+    find_best_tiling_for_file,
+    run_campaign_tiling_search,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Find best full-spectrum mixed chunk tiling (pipeline σ_RV) from campaign cache.",
+    )
+    parser.add_argument(
+        "--campaign-dir",
+        type=Path,
+        default=REPO_ROOT / "validation_output" / "chunk_campaign",
+        help="Campaign directory with measurement_cache.csv and layouts/",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Output directory (default: <campaign-dir>/spectrum_tiling_search)",
+    )
+    parser.add_argument(
+        "--metric",
+        type=str,
+        default=DEFAULT_METRIC,
+        choices=("rv_err_calibrated_kms", "sigma_rv_core90_kms"),
+        help="Objective for best tiling (pipeline stack outputs).",
+    )
+    parser.add_argument(
+        "--max-tilings",
+        type=int,
+        default=None,
+        help="Cap stack evaluations per exposure (default: no cap).",
+    )
+    parser.add_argument(
+        "--count-only",
+        action="store_true",
+        help="Only count mixed tilings per file (no stack evaluation).",
+    )
+    parser.add_argument(
+        "--mix-layouts",
+        type=str,
+        default="",
+        help="Comma-separated layouts for mixed tiles (default: all cached layouts).",
+    )
+    parser.add_argument(
+        "--whole-layouts",
+        type=str,
+        default="",
+        help="Comma-separated whole-spectrum layouts (default: all cached layouts).",
+    )
+    parser.add_argument(
+        "--only-file",
+        type=str,
+        default="",
+        help="Run a single exposure basename/path for debugging.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    campaign_dir = Path(args.campaign_dir)
+    out_dir = Path(args.out_dir) if args.out_dir else campaign_dir / "spectrum_tiling_search"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    mix_layouts = [s.strip() for s in args.mix_layouts.split(",") if s.strip()] or None
+    whole_layouts = [s.strip() for s in args.whole_layouts.split(",") if s.strip()] or None
+
+    if args.only_file:
+        from validation.chunk_adaptive_stack import (
+            _index_by_file_layout,
+            build_multi_layout_bias_tables,
+            load_campaign_measurements,
+            load_layouts,
+        )
+        from validation.chunk_bias_lib import load_stellar_metadata
+
+        layouts = load_layouts(campaign_dir)
+        meas_df = load_campaign_measurements(campaign_dir, layouts)
+        needle = str(args.only_file)
+        hits = meas_df[meas_df["file"].astype(str).str.endswith(needle)]
+        if hits.empty:
+            hits = meas_df[meas_df["file"].astype(str) == needle]
+        if hits.empty:
+            raise SystemExit(f"No exposures match --only-file={args.only_file!r}")
+        file_label = str(hits.iloc[0]["file"])
+        global_idx = _index_by_file_layout(meas_df)
+        fidx = file_meas_index(global_idx, file_label)
+        registry = TileRegistry.for_file(
+            file_label,
+            layouts,
+            fidx,
+            mix_layout_names=mix_layouts,
+            whole_layout_names=whole_layouts,
+        )
+        if args.count_only:
+            n_mixed = count_complete_tilings(registry)
+            payload = {"file": file_label, "n_mixed_tilings": n_mixed}
+            out_path = out_dir / "single_file_tiling_count.json"
+            out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            print(json.dumps(payload, indent=2))
+            return 0
+
+        per_object, fallback, intrinsic_model = build_multi_layout_bias_tables(campaign_dir, layouts)
+        meta_tbl = load_stellar_metadata(REPO_ROOT / "output")
+        gid = str(hits.iloc[0]["gaia_dr3_id"])
+        star_meta = {"logg": np.nan, "mh": np.nan}
+        if not meta_tbl.empty:
+            sm = meta_tbl[meta_tbl["gaia_dr3_id"] == gid]
+            if len(sm):
+                star_meta["logg"] = float(sm.iloc[0].get("logg", np.nan))
+                star_meta["mh"] = float(sm.iloc[0].get("mh", np.nan))
+
+        result = find_best_tiling_for_file(
+            registry,
+            per_object=per_object,
+            fallback=fallback,
+            intrinsic_model=intrinsic_model,
+            star_meta=star_meta,
+            metric=args.metric,
+            max_tilings=args.max_tilings,
+        )
+        if result is None:
+            raise SystemExit("No valid tiling found")
+        logger.info(
+            "%s: %d mixed tilings, %d evaluated",
+            file_label,
+            result.n_mixed_tilings,
+            result.n_tilings_evaluated,
+        )
+        payload = {
+            "file": file_label,
+            "tiling_name": result.tiling_name,
+            "metric": args.metric,
+            "metric_value": result.metric_value,
+            "stack": {k: (float(v) if hasattr(v, "__float__") else v) for k, v in result.stack.items()},
+            "tiles": [t.name for t in result.tiles],
+            "n_mixed_tilings": result.n_mixed_tilings,
+            "n_tilings_evaluated": result.n_tilings_evaluated,
+            "search_truncated": result.search_truncated,
+        }
+        out_path = out_dir / "single_file_best_tiling.json"
+        out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(json.dumps(payload, indent=2))
+        print(f"Wrote {out_path}")
+        return 0
+
+    epochs, summary, counts = run_campaign_tiling_search(
+        campaign_dir,
+        max_tilings_per_file=args.max_tilings,
+        metric=args.metric,
+        mix_layout_names=mix_layouts,
+        whole_layout_names=whole_layouts,
+        count_tilings=args.count_only,
+    )
+
+    if args.count_only:
+        counts_path = out_dir / "tiling_search_counts.csv"
+        counts.to_csv(counts_path, index=False)
+        print(f"Wrote {counts_path}")
+        return 0
+
+    epochs_path = out_dir / "best_mixed_tiling_epochs.csv"
+    summary_path = out_dir / "best_mixed_tiling_summary.csv"
+    counts_path = out_dir / "tiling_search_counts.csv"
+    epochs.to_csv(epochs_path, index=False)
+    summary.to_csv(summary_path, index=False)
+    counts.to_csv(counts_path, index=False)
+
+    if not summary.empty and "median_sigma_rv_kms" in summary.columns:
+        med = float(summary.iloc[0]["median_sigma_rv_kms"])
+        logger.info(
+            "Best mixed tiling: %d exposures, median %s=%.4f km/s",
+            len(epochs),
+            args.metric,
+            med,
+        )
+    print(f"Wrote {epochs_path}")
+    print(f"Wrote {summary_path}")
+    print(f"Wrote {counts_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- **Chunk optimization (campaign conclusion):** add `subchunks_8` layout YAML and campaign support (`--only-layouts subchunks_8`), layout-aware chunk debiasing, per-order greedy baseline (`per_order_chunk_baseline`), chunk weight lookup, and offline mixed-layout search (`spectrum_tiling_search`). Campaign on 114 exposures shows uniform `subchunks_8` beats `subchunks_4` (~15% lower median σ_RV); adaptive mix collapses to pure s8 on 110/114 exposures.
- **Workflow docs:** `validation/chunk_optimization_advice.md` documents north-star metric (median σ_RV), Phase 1 baseline, adaptive stack, and deploy steps.
- **External RV catalogs:** DESI, GALAH, APOGEE, and GES query modules with VizieR TAP helpers, barycentric frame normalization (`rv_frame`), and integration into `gaia_utils`; summary update scripts and docs.
- **CCF estimator validation (step 09 groundwork):** benchmark/bias/precision-gate modules, baseline reference JSON, plan doc, and tests.

## Test plan

- [x] `pytest tests/validation/test_per_order_chunk_baseline.py tests/validation/test_chunk_weight_lookup.py tests/validation/test_spectrum_tiling_search.py tests/validation/test_chunk_grid_search.py tests/validation/test_chunk_adaptive_stack.py` (20 passed)
- [x] `pytest tests/test_apogee_rv_query.py tests/test_desi_rv_query.py tests/test_galah_rv_query.py tests/test_rv_frame.py tests/test_vizier_tap.py tests/test_ccf_rv_estimators.py tests/test_external_rv_unified_rows.py tests/validation/test_ccf_estimator_bias.py tests/validation/test_ccf_rv_post_debias.py tests/validation/test_ccf_rv_precision_gates.py` (32 passed)
- [ ] Post-merge: rebuild `bias_statistics.txt` for `subchunks_8` and run `scripts/refit_star_rvs.sh` on production cohort (#57)

## Notes for reviewers

- Campaign diagnostics and `validation_output/` artifacts are **not** in this PR (local only).
- Recommended production layout from campaign: uniform **`subchunks_8`** (not per-order n=2/3/4 greedy mix).
- Excluded from commit: `bias_statistics.txt.bak_*`, `rv_fit_reports/` (local generated output).


Made with [Cursor](https://cursor.com)