### PR TITLE
Fix APF observability seasons (nautical twilight, planning-table regression)

### DIFF
--- a/darkhunter_rv/apf_observability.py
+++ b/darkhunter_rv/apf_observability.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -18,12 +19,13 @@ from darkhunter_rv.summary_paths import parse_object_id_from_summary
 LICK_LOCATION = EarthLocation(lat=37.3413 * u.deg, lon=-121.6438 * u.deg, height=1280 * u.m)
 
 TWILIGHT_SUN_ALT_DEG = -12.0
-TWILIGHT_BUFFER_MINUTES = 30
 MAX_AIRMASS = 1.7
 MIN_OBS_MINUTES = 30
 STEP_MINUTES = 5
-HORIZON_DAYS = 183  # ~6 months
-PLOT_HORIZON_DAYS = HORIZON_DAYS
+SCAN_HORIZON_DAYS = 365
+PLOT_HORIZON_DAYS = 90
+HORIZON_DAYS = SCAN_HORIZON_DAYS
+MERGE_RUN_GAP_DAYS = 45
 
 
 def _altitude_deg_for_airmass(airmass: float) -> float:
@@ -44,6 +46,34 @@ def _airmass_from_altitude_deg(alt_deg: float) -> float:
     if cos_z <= 0:
         return float("inf")
     return 1.0 / cos_z
+
+
+def _target_observable(alt_deg: float, airmass: float) -> bool:
+    return (
+        np.isfinite(alt_deg)
+        and alt_deg > 0.0
+        and np.isfinite(airmass)
+        and airmass <= MAX_AIRMASS
+    )
+
+
+def _geometric_min_altitude_deg(coord: SkyCoord) -> float:
+    """Minimum altitude (deg) at lower culmination for a northern target at Lick."""
+    lat = float(LICK_LOCATION.lat.deg)
+    dec = float(coord.dec.deg)
+    lat_r = math.radians(lat)
+    dec_r = math.radians(dec)
+    return float(
+        math.degrees(
+            math.asin(
+                np.clip(
+                    math.sin(dec_r) * math.sin(lat_r) - math.cos(dec_r) * math.cos(lat_r),
+                    -1.0,
+                    1.0,
+                )
+            )
+        )
+    )
 
 
 def _target_coord_from_summary(summary_path: Path) -> Optional[SkyCoord]:
@@ -89,13 +119,12 @@ def _sun_alt_deg(time: Time, location: EarthLocation) -> float:
 
 @dataclass
 class NightRecord:
-    """One local night at Lick between 12° twilights."""
+    """One local night at Lick between nautical (-12°) twilights."""
 
     evening_twilight_mjd: float
     morning_twilight_mjd: float
     calendar_date: str
-    strict_ok: bool
-    up_during_night: bool
+    observable_night: bool
 
 
 def _mjd_to_iso_date(mjd: float) -> str:
@@ -103,9 +132,6 @@ def _mjd_to_iso_date(mjd: float) -> str:
 
 
 def _sun_alts_deg(mjds: np.ndarray) -> np.ndarray:
-    """Vectorized sun altitude (deg) at Lick via ERFA."""
-    import erfa
-
     out = np.empty(len(mjds), dtype=float)
     for i, mjd in enumerate(mjds):
         out[i] = _sun_alt_deg(Time(float(mjd), format="mjd", scale="utc"), LICK_LOCATION)
@@ -123,10 +149,12 @@ def _sample_nights(
     start_mjd: float,
     end_mjd: float,
 ) -> List[NightRecord]:
-    """Walk 5-min steps, segment into nautical-twilight nights, evaluate each."""
+    """
+    Observable night: airmass ≤ 1.7 for ≥30 min while sun ≤ nautical twilight (-12°)
+    and target is above the horizon.
+    """
     step_days = STEP_MINUTES / (24.0 * 60.0)
     min_steps = max(1, int(round(MIN_OBS_MINUTES / STEP_MINUTES)))
-    buffer_days = TWILIGHT_BUFFER_MINUTES / (24.0 * 60.0)
 
     mjds = np.arange(start_mjd, end_mjd + step_days, step_days, dtype=float)
     if mjds.size == 0:
@@ -143,12 +171,11 @@ def _sample_nights(
     nights: List[NightRecord] = []
     in_night = False
     evening_mjd: Optional[float] = None
-    strict_streak = 0
-    strict_ok = False
-    up_during_night = False
+    obs_streak = 0
+    observable_night = False
 
     def _close_night(morn_mjd: float) -> None:
-        nonlocal strict_ok, up_during_night, strict_streak
+        nonlocal observable_night, obs_streak
         if evening_mjd is None:
             return
         nights.append(
@@ -156,16 +183,13 @@ def _sample_nights(
                 evening_twilight_mjd=evening_mjd,
                 morning_twilight_mjd=morn_mjd,
                 calendar_date=_mjd_to_iso_date(evening_mjd),
-                strict_ok=strict_ok,
-                up_during_night=up_during_night,
+                observable_night=observable_night,
             )
         )
-        strict_ok = False
-        up_during_night = False
-        strict_streak = 0
+        observable_night = False
+        obs_streak = 0
 
     for i in range(len(mjds)):
-        t = float(mjds[i])
         sun_alt = float(sun_alts[i])
         target_alt = float(target_alts[i])
         prev_sun = float(sun_alts[i - 1]) if i > 0 else sun_alt + 1.0
@@ -173,25 +197,20 @@ def _sample_nights(
 
         if not in_night and prev_sun > TWILIGHT_SUN_ALT_DEG >= sun_alt:
             in_night = True
-            evening_mjd = t
-            strict_ok = False
-            up_during_night = False
-            strict_streak = 0
+            evening_mjd = float(mjds[i])
+            observable_night = False
+            obs_streak = 0
 
         if in_night:
-            if sun_alt < 0.0 and target_alt > 0.0:
-                up_during_night = True
-
-            in_extended = evening_mjd is not None and t >= evening_mjd - buffer_days
-            if in_extended and np.isfinite(am) and am <= MAX_AIRMASS:
-                strict_streak += 1
-                if strict_streak >= min_steps:
-                    strict_ok = True
-            else:
-                strict_streak = 0
+            if sun_alt <= TWILIGHT_SUN_ALT_DEG and _target_observable(target_alt, am):
+                obs_streak += 1
+                if obs_streak >= min_steps:
+                    observable_night = True
+            elif sun_alt > TWILIGHT_SUN_ALT_DEG:
+                obs_streak = 0
 
             if prev_sun <= TWILIGHT_SUN_ALT_DEG < sun_alt:
-                _close_night(t)
+                _close_night(float(mjds[i]))
                 in_night = False
                 evening_mjd = None
 
@@ -203,69 +222,64 @@ def _is_circumpolar_for_apf(
     start_mjd: float,
     end_mjd: float,
 ) -> bool:
-    """
-    True only when the target stays above the airmass-1.7 limit whenever the
-    sun is below 12° twilight (observable every night at APF elevations).
-    """
-    step_days = 15.0 / (24.0 * 60.0)  # coarser grid for classification only
-    mjds = np.arange(start_mjd, end_mjd + step_days, step_days, dtype=float)
-    if mjds.size == 0:
+    if _geometric_min_altitude_deg(coord) < ALTITUDE_MIN_DEG - 0.5:
         return False
-    sun_alts = _sun_alts_deg(mjds)
-    night_mask = sun_alts <= TWILIGHT_SUN_ALT_DEG
-    if not np.any(night_mask):
+    nights = _sample_nights(coord, start_mjd, end_mjd)
+    if not nights:
         return False
-    target_alts = _target_alts_deg(coord, mjds[night_mask])
-    min_alt = float(np.nanmin(target_alts))
-    return min_alt >= ALTITUDE_MIN_DEG - 0.5
+    return all(n.observable_night for n in nights)
+
+
+def _build_season_runs(nights: List[NightRecord]) -> List[List[NightRecord]]:
+    runs: List[List[NightRecord]] = []
+    current: List[NightRecord] = []
+    for night in nights:
+        if night.observable_night:
+            current.append(night)
+        elif current:
+            runs.append(current)
+            current = []
+    if current:
+        runs.append(current)
+    return runs
+
+
+def _merge_close_runs(
+    runs: List[List[NightRecord]],
+    *,
+    gap_days: float = MERGE_RUN_GAP_DAYS,
+) -> List[List[NightRecord]]:
+    if not runs:
+        return []
+    merged: List[List[NightRecord]] = [list(runs[0])]
+    for run in runs[1:]:
+        gap = run[0].evening_twilight_mjd - merged[-1][-1].morning_twilight_mjd
+        if gap <= gap_days:
+            merged[-1].extend(run)
+        else:
+            merged.append(list(run))
+    return merged
+
+
+def _run_span(run: List[NightRecord]) -> Tuple[str, str, float, float]:
+    start = run[0]
+    end = run[-1]
+    return (
+        start.calendar_date,
+        end.calendar_date,
+        start.evening_twilight_mjd,
+        end.morning_twilight_mjd,
+    )
 
 
 def _find_season_window(
     nights: List[NightRecord],
     today_mjd: float,
 ) -> Optional[Tuple[str, str, float, float]]:
-    """
-    Return (start_date, end_date, start_mjd, end_mjd) for the current or next season.
-
-    A season is a contiguous block of nights when the target is up during the night.
-    The first night of a block must pass the strict twilight/airmass test; interior
-    nights only need to be above the horizon at some point during nautical night.
-    """
-    if not nights:
-        return None
-
-    runs: List[List[NightRecord]] = []
-    current: List[NightRecord] = []
-
-    for night in nights:
-        if not current:
-            if night.strict_ok:
-                current = [night]
-        elif night.up_during_night:
-            current.append(night)
-        else:
-            runs.append(current)
-            current = []
-            if night.strict_ok:
-                current = [night]
-
-    if current:
-        runs.append(current)
-
+    runs = _merge_close_runs(_build_season_runs(nights))
     if not runs:
         return None
 
-    def _run_span(run: List[NightRecord]) -> Tuple[str, str, float, float]:
-        start = run[0]
-        end = run[-1]
-        return (
-            start.calendar_date,
-            end.calendar_date,
-            start.evening_twilight_mjd,
-            end.morning_twilight_mjd,
-        )
-
-    # Prefer season containing today; else next season; else last season.
     for run in runs:
         start_mjd, end_mjd = run[0].evening_twilight_mjd, run[-1].morning_twilight_mjd
         if start_mjd <= today_mjd <= end_mjd + 1.0:
@@ -298,20 +312,19 @@ def compute_apf_observability(
     coord: SkyCoord,
     *,
     start_mjd: Optional[float] = None,
-    horizon_days: int = HORIZON_DAYS,
+    scan_horizon_days: int = SCAN_HORIZON_DAYS,
+    plot_horizon_days: int = PLOT_HORIZON_DAYS,
 ) -> Dict[str, Any]:
     """
-    APF visibility season at Lick.
+  APF visibility season at Lick.
 
-    - Nautical twilight (-12°); target airmass ≤ 1.7 for ≥30 min within ±30 min of twilight
-      defines season entry (rising near sunrise) and quality on boundary nights.
-    - Between season start and end, any night the target is above the horizon counts.
-    - One window: next/current season start → when the target sets out of the window.
-    - Circumpolar: target stays above airmass 1.7 all nautical nights (very high dec).
+    - Nautical twilight (-12°).
+    - Observable night: target above horizon, airmass ≤ 1.7, for ≥30 min while sun ≤ -12°.
+    - Season: contiguous observable nights (short gaps merged).
     """
     now_mjd = float(Time.now().mjd) if start_mjd is None else float(start_mjd)
-    plot_end_mjd = now_mjd + float(min(horizon_days, PLOT_HORIZON_DAYS))
-    scan_end_mjd = plot_end_mjd + 1.0
+    plot_end_mjd = now_mjd + float(plot_horizon_days)
+    scan_end_mjd = now_mjd + float(scan_horizon_days)
 
     if _is_circumpolar_for_apf(coord, now_mjd, scan_end_mjd):
         win = ObsWindow(now_mjd, plot_end_mjd, "", "")

--- a/darkhunter_rv/observability_table_compare.py
+++ b/darkhunter_rv/observability_table_compare.py
@@ -1,0 +1,209 @@
+"""Compare our Lick visibility math against a planning-table reference (Gaia 4491)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from astropy.coordinates import AltAz, SkyCoord
+from astropy.time import Time
+
+from .apf_observability import LICK_LOCATION, TWILIGHT_SUN_ALT_DEG, _airmass_from_altitude_deg, _sun_alt_deg
+
+# User table for Gaia DR3 449121951305471360 (correct ICRS RA/Dec from Gaia DR3).
+GAIA_4491 = SkyCoord(ra=55.52045150805677, dec=57.90254409416177, unit="deg", frame="icrs")
+
+# Reference rows transcribed from the corrected planning-table screenshot (2026).
+REFERENCE_TABLE: Dict[str, Dict[str, float]] = {
+    "2026-03-18": {"airm_eve": 1.32, "airm_ctr": 3.45, "airm_morn": 9.06, "hrs3": 4.0, "hrs2": 2.5, "hrs15": 0.9},
+    "2026-04-01": {"airm_eve": 1.56, "airm_ctr": 4.57, "airm_morn": 8.07, "hrs3": 2.9, "hrs2": 1.3, "hrs15": 0.0},
+    "2026-04-16": {"airm_eve": 1.98, "airm_ctr": 6.28, "airm_morn": 6.83, "hrs3": 1.6, "hrs2": 0.0, "hrs15": 0.0},
+    "2026-04-30": {"airm_eve": 2.67, "airm_ctr": 8.20, "airm_morn": 5.68, "hrs3": 0.4, "hrs2": 0.0, "hrs15": 0.0},
+    "2026-05-16": {"airm_eve": 4.10, "airm_ctr": 9.60, "airm_morn": 4.48, "hrs3": 0.0, "hrs2": 0.0, "hrs15": 0.0},
+    "2026-05-30": {"airm_eve": 6.19, "airm_ctr": 8.88, "airm_morn": 3.56, "hrs3": 0.0, "hrs2": 0.0, "hrs15": 0.0},
+    "2026-06-14": {"airm_eve": 8.70, "airm_ctr": 6.72, "airm_morn": 2.73, "hrs3": 0.3, "hrs2": 0.0, "hrs15": 0.0},
+    "2026-06-29": {"airm_eve": 9.61, "airm_ctr": 4.70, "airm_morn": 2.09, "hrs3": 1.4, "hrs2": 0.0, "hrs15": 0.0},
+    "2026-07-13": {"airm_eve": 8.70, "airm_ctr": 3.42, "airm_morn": 1.66, "hrs3": 2.5, "hrs2": 0.9, "hrs15": 0.0},
+    "2026-07-28": {"airm_eve": 7.19, "airm_ctr": 2.56, "airm_morn": 1.37, "hrs3": 3.8, "hrs2": 2.2, "hrs15": 0.6},
+    "2026-08-11": {"airm_eve": 5.94, "airm_ctr": 2.05, "airm_morn": 1.20, "hrs3": 5.0, "hrs2": 3.4, "hrs15": 1.9},
+    "2026-08-27": {"airm_eve": 4.80, "airm_ctr": 1.68, "airm_morn": 1.10, "hrs3": 6.3, "hrs2": 4.8, "hrs15": 3.2},
+    "2026-09-10": {"airm_eve": 4.02, "airm_ctr": 1.46, "airm_morn": 1.07, "hrs3": 7.5, "hrs2": 5.9, "hrs15": 4.4},
+    "2026-09-25": {"airm_eve": 3.35, "airm_ctr": 1.30, "airm_morn": 1.09, "hrs3": 8.7, "hrs2": 7.2, "hrs15": 5.6},
+    "2026-10-09": {"airm_eve": 2.83, "airm_ctr": 1.20, "airm_morn": 1.15, "hrs3": 9.7, "hrs2": 8.3, "hrs15": 6.7},
+    "2026-10-25": {"airm_eve": 2.34, "airm_ctr": 1.12, "airm_morn": 1.29, "hrs3": 10.2, "hrs2": 9.6, "hrs15": 8.0},
+}
+
+
+def _hour_angle_deg(time: Time, coord: SkyCoord) -> float:
+    lst = time.sidereal_time("apparent", LICK_LOCATION).deg
+    return float((lst - coord.ra.deg + 180.0) % 360.0 - 180.0)
+
+
+def _hour_angle_midpoint_deg(ha_eve_deg: float, ha_morn_deg: float) -> float:
+    h_eve = ha_eve_deg / 15.0
+    h_morn = ha_morn_deg / 15.0
+    delta_h = (h_morn - h_eve + 12.0) % 24.0 - 12.0
+    return float((h_eve + delta_h / 2.0) * 15.0)
+
+
+def _refine_twilight_mjd(
+    mjd_guess: float,
+    *,
+    evening: bool,
+    span_days: float = 0.02,
+) -> float:
+    lo = mjd_guess - span_days
+    hi = mjd_guess + span_days
+    for _ in range(40):
+        mid = 0.5 * (lo + hi)
+        sun_alt = _sun_alt_deg(Time(mid, format="mjd", scale="utc"), LICK_LOCATION)
+        if evening:
+            if sun_alt > TWILIGHT_SUN_ALT_DEG:
+                lo = mid
+            else:
+                hi = mid
+        elif sun_alt < TWILIGHT_SUN_ALT_DEG:
+            lo = mid
+        else:
+            hi = mid
+    return 0.5 * (lo + hi)
+
+
+def _find_evening_twilight_mjd(evening_date: str) -> Optional[float]:
+    """Evening nautical twilight on the UTC calendar date *evening_date*."""
+    t0 = Time(evening_date, scale="utc").mjd
+    prev_sun: Optional[float] = None
+    crossing: Optional[float] = None
+    for mjd in np.linspace(t0 - 0.5, t0 + 0.5, 2000):
+        sun_alt = _sun_alt_deg(Time(float(mjd), format="mjd", scale="utc"), LICK_LOCATION)
+        if prev_sun is not None and prev_sun > TWILIGHT_SUN_ALT_DEG >= sun_alt:
+            crossing = float(mjd)
+        prev_sun = sun_alt
+    if crossing is None:
+        return None
+    return _refine_twilight_mjd(crossing, evening=True)
+
+
+def _find_morning_twilight_mjd(evening_mjd: float) -> Optional[float]:
+    prev_sun: Optional[float] = None
+    crossing: Optional[float] = None
+    for mjd in np.linspace(evening_mjd + 0.1, evening_mjd + 1.2, 2000):
+        sun_alt = _sun_alt_deg(Time(float(mjd), format="mjd", scale="utc"), LICK_LOCATION)
+        if prev_sun is not None and prev_sun < TWILIGHT_SUN_ALT_DEG <= sun_alt:
+            crossing = float(mjd)
+            break
+        prev_sun = sun_alt
+    if crossing is None:
+        return None
+    return _refine_twilight_mjd(crossing, evening=False)
+
+
+@dataclass
+class NightSnapshot:
+    evening_date: str
+    airm_eve: float
+    airm_morn: float
+    airm_ctr: float
+    hrs_below: Dict[float, float]
+
+
+def night_snapshot_for_evening_date(
+    coord: SkyCoord,
+    evening_date: str,
+    *,
+    step_minutes: int = 5,
+) -> Optional[NightSnapshot]:
+    """
+    Nautical-night model aligned with the Lick planning table:
+
+    - Evening / morning anchors: sun at TWILIGHT_SUN_ALT_DEG (-12°).
+    - Evening date: UTC calendar date of evening twilight.
+    - Center airmass: target at the hour-angle midpoint between eve and morn.
+    - Hours: integrate while sun <= -12°, target above horizon, airmass below limit.
+    """
+    eve_mjd = _find_evening_twilight_mjd(evening_date)
+    if eve_mjd is None:
+        return None
+    morn_mjd = _find_morning_twilight_mjd(eve_mjd)
+    if morn_mjd is None or morn_mjd <= eve_mjd:
+        return None
+
+    eve_t = Time(eve_mjd, format="mjd", scale="utc")
+    morn_t = Time(morn_mjd, format="mjd", scale="utc")
+    eve_star = coord.transform_to(AltAz(obstime=eve_t, location=LICK_LOCATION))
+    morn_star = coord.transform_to(AltAz(obstime=morn_t, location=LICK_LOCATION))
+    airm_eve = _airmass_from_altitude_deg(float(eve_star.alt.deg))
+    airm_morn = _airmass_from_altitude_deg(float(morn_star.alt.deg))
+
+    ha_mid = _hour_angle_midpoint_deg(_hour_angle_deg(eve_t, coord), _hour_angle_deg(morn_t, coord))
+    ctr_mjd = eve_mjd
+    best_err = 1e9
+    for mjd in np.linspace(eve_mjd, morn_mjd, 3000):
+        t = Time(float(mjd), format="mjd", scale="utc")
+        err = abs((_hour_angle_deg(t, coord) - ha_mid + 180.0) % 360.0 - 180.0)
+        if err < best_err:
+            best_err = err
+            ctr_mjd = float(mjd)
+    ctr_star = coord.transform_to(AltAz(obstime=Time(ctr_mjd, format="mjd"), location=LICK_LOCATION))
+    airm_ctr = _airmass_from_altitude_deg(float(ctr_star.alt.deg))
+
+    step_days = step_minutes / (24.0 * 60.0)
+    hrs_below = {3.0: 0.0, 2.0: 0.0, 1.5: 0.0}
+    for mjd in np.arange(eve_mjd, morn_mjd, step_days):
+        t = Time(float(mjd), format="mjd", scale="utc")
+        if _sun_alt_deg(t, LICK_LOCATION) > TWILIGHT_SUN_ALT_DEG:
+            continue
+        star = coord.transform_to(AltAz(obstime=t, location=LICK_LOCATION))
+        alt = float(star.alt.deg)
+        if alt <= 0:
+            continue
+        am = _airmass_from_altitude_deg(alt)
+        for lim in hrs_below:
+            if am <= lim:
+                hrs_below[lim] += step_minutes / 60.0
+
+    return NightSnapshot(
+        evening_date=evening_date,
+        airm_eve=airm_eve,
+        airm_morn=airm_morn,
+        airm_ctr=airm_ctr,
+        hrs_below=hrs_below,
+    )
+
+
+def compare_reference_table(
+    coord: SkyCoord = GAIA_4491,
+    *,
+    airm_tol: float = 0.5,
+    hrs_tol: float = 1.2,
+) -> List[str]:
+    """Return human-readable diff lines vs REFERENCE_TABLE."""
+    lines: List[str] = []
+    for date in REFERENCE_TABLE:
+        ref = REFERENCE_TABLE[date]
+        snap = night_snapshot_for_evening_date(coord, date)
+        if snap is None:
+            lines.append(f"{date}: could not pair twilights")
+            continue
+        parts = [f"{date}:"]
+        for key, ref_val in ref.items():
+            if key == "airm_eve":
+                got = snap.airm_eve
+            elif key == "airm_morn":
+                got = snap.airm_morn
+            elif key == "airm_ctr":
+                got = snap.airm_ctr
+            elif key == "hrs3":
+                got = snap.hrs_below[3.0]
+            elif key == "hrs2":
+                got = snap.hrs_below[2.0]
+            elif key == "hrs15":
+                got = snap.hrs_below[1.5]
+            else:
+                continue
+            tol = hrs_tol if key.startswith("hrs") else airm_tol
+            flag = "OK" if abs(got - ref_val) <= tol else "DIFF"
+            parts.append(f"{key} ref={ref_val} got={got:.2f} [{flag}]")
+        lines.append("  ".join(parts))
+    return lines

--- a/darkhunter_rv/rv_keplerian_plots.py
+++ b/darkhunter_rv/rv_keplerian_plots.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from fit_apf_rv_keplerian import RVPoint
 
+from darkhunter_rv.apf_observability import PLOT_HORIZON_DAYS
 from darkhunter_rv.rv_point_filters import rv_value_is_valid
 
 
@@ -93,10 +94,12 @@ def _xlim_from_data(t: np.ndarray, report: dict) -> Tuple[float, float]:
     t_hi = float(np.max(t) + pad)
     t_lo = min(t_lo, now_mjd - 0.01 * t_span)
     t_hi = max(t_hi, now_mjd + 0.01 * t_span)
+    plot_cap_mjd = now_mjd + float(PLOT_HORIZON_DAYS)
     obs_start, obs_end, _ = _observability_span(report)
     if obs_start is not None and obs_end is not None:
         t_lo = min(t_lo, obs_start - 0.01 * t_span)
-        t_hi = max(t_hi, obs_end + 0.01 * t_span)
+        t_hi = max(t_hi, min(obs_end + 0.01 * t_span, plot_cap_mjd))
+    t_hi = min(t_hi, plot_cap_mjd)
     return t_lo, t_hi
 
 
@@ -164,7 +167,7 @@ def _shade_apf_window(
     if not windows:
         return
     now_mjd = float(report.get("now_mjd", Time.now().mjd))
-    plot_cap_mjd = now_mjd + 183.0
+    plot_cap_mjd = now_mjd + float(PLOT_HORIZON_DAYS)
     label_parts: List[str] = []
     for w in windows:
         try:

--- a/docs/website.md
+++ b/docs/website.md
@@ -82,7 +82,7 @@ Ensure Apache serves `/var/www/html/darkhunter/rv/` (existing `Alias` or symlink
 | **(M2sin i)/(sin i) (Msun)** | Same f(M) and M1 with Gaia astrometric inclination |
 | **INCLINATION (deg)** | Astrometric i used for M2 at i (from Gaia NSS or derived from Thiele-Innes A,B,F,G when the database field is empty; empty if unknown or edge-on) |
 
-**RV fit plots:** blue shaded regions mark the current APF visibility season at Lick (nautical twilight −12°; airmass ≤ 1.7 for ≥30 min within ±30 min of twilight at season boundaries; interior nights when the target is up at all). One window per target, plotted out to 6 months. Built via `scripts/build_apf_observability_cache.py` and stored in `rv_fit_reports/observability_windows_cache.json`. Very high-declination circumpolar targets are annotated without date labels.
+**RV fit plots:** blue shaded regions mark the current APF visibility season at Lick (nautical twilight −12°; airmass ≤ 1.7 for ≥30 min/night while the sun is at/below twilight; short gaps merged). One window per target; season search scans up to one year ahead, plot shading capped at 90 days past today. Built via `scripts/build_apf_observability_cache.py` and stored in `rv_fit_reports/observability_windows_cache.json`. Only targets observable on every nautical night in the scan are labeled circumpolar (no dates).
 
 ## Three commands (ziggy)
 

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -34,6 +34,7 @@ import numpy as np
 from astropy.timeseries import LombScargle
 from astropy.time import Time
 
+from darkhunter_rv.apf_observability import PLOT_HORIZON_DAYS
 from darkhunter_rv.summary_paths import (
     count_pipeline_rows,
     discover_summary_files,
@@ -1533,12 +1534,13 @@ def build_plot(
             obs_start = None
             obs_end = None
 
+    plot_cap_mjd = now_mjd + float(PLOT_HORIZON_DAYS)
     t_start = float(np.min(t) - 0.02 * (np.ptp(t) + 1))
     # Extend through nearest upcoming extrema and observability window if available.
     t_end_candidates = [np.max(t) + 0.02 * (np.ptp(t) + 1), now_mjd, next_event]
     if obs_end is not None:
-        t_end_candidates.append(obs_end)
-    t_end = float(max(t_end_candidates))
+        t_end_candidates.append(min(obs_end, plot_cap_mjd))
+    t_end = float(min(max(t_end_candidates), plot_cap_mjd))
     t_dense = np.linspace(t_start, t_end, 2000)
     y_dense = rv_model(params, t_dense, t_ref)
     # Lock y-limits from RV data + fitted curve only (ignore large error bars).
@@ -1558,7 +1560,7 @@ def build_plot(
     if obs_start is not None and obs_end is not None and isinstance(obs_win, dict):
         try:
             left = max(t_start, obs_start)
-            right = min(t_end, obs_end)
+            right = min(t_end, obs_end, plot_cap_mjd)
             if right > left:
                 ax.axvspan(left, right, color="tab:blue", alpha=0.12, zorder=0)
                 ax.text(

--- a/scripts/compare_observability_table.py
+++ b/scripts/compare_observability_table.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Print our Lick visibility numbers vs the Gaia-4491 planning-table reference."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+from darkhunter_rv.observability_table_compare import compare_reference_table
+
+
+def main() -> int:
+    for line in compare_reference_table():
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_apf_observability.py
+++ b/tests/test_apf_observability.py
@@ -6,6 +6,9 @@ from astropy import units as u
 from darkhunter_rv.apf_observability import (
     ALTITUDE_MIN_DEG,
     HORIZON_DAYS,
+    PLOT_HORIZON_DAYS,
+    SCAN_HORIZON_DAYS,
+    _geometric_min_altitude_deg,
     _is_circumpolar_for_apf,
     compute_apf_observability,
 )
@@ -20,9 +23,18 @@ def test_circumpolar_requires_very_high_dec() -> None:
     assert _is_circumpolar_for_apf(coord89, 60000.0, 60000.0 + 30)
 
 
+def test_dec_58_not_circumpolar() -> None:
+    coord = SkyCoord(ra=55.52045 * u.deg, dec=57.90254 * u.deg, frame="icrs")
+    assert _geometric_min_altitude_deg(coord) < ALTITUDE_MIN_DEG
+    out = compute_apf_observability(coord, start_mjd=61000.0, scan_horizon_days=120)
+    assert out["circumpolar"] is False
+
+
 def test_circumpolar_output_has_no_dates() -> None:
     coord = SkyCoord(ra=180.0 * u.deg, dec=89.0 * u.deg, frame="icrs")
-    out = compute_apf_observability(coord, start_mjd=60000.0, horizon_days=30)
+    out = compute_apf_observability(
+        coord, start_mjd=60000.0, scan_horizon_days=30, plot_horizon_days=30
+    )
     assert out["circumpolar"] is True
     assert out["windows"]
     assert out["next_window_start_date"] == ""
@@ -31,7 +43,7 @@ def test_circumpolar_output_has_no_dates() -> None:
 
 def test_mid_latitude_single_season_window() -> None:
     coord = SkyCoord(ra=120.0 * u.deg, dec=20.0 * u.deg, frame="icrs")
-    out = compute_apf_observability(coord, start_mjd=60000.0, horizon_days=90)
+    out = compute_apf_observability(coord, start_mjd=60000.0, scan_horizon_days=90)
     assert out["circumpolar"] is False
     if out["windows"]:
         assert len(out["windows"]) == 1
@@ -45,3 +57,8 @@ def test_airmass_limit_is_17() -> None:
 
     assert MAX_AIRMASS == pytest.approx(1.7)
     assert ALTITUDE_MIN_DEG == pytest.approx(36.3, abs=0.5)
+
+
+def test_plot_horizon_is_three_months() -> None:
+    assert PLOT_HORIZON_DAYS == 90
+    assert SCAN_HORIZON_DAYS >= 180

--- a/tests/test_observability_table_compare.py
+++ b/tests/test_observability_table_compare.py
@@ -1,0 +1,22 @@
+import pytest
+
+from darkhunter_rv.observability_table_compare import (
+    GAIA_4491,
+    REFERENCE_TABLE,
+    night_snapshot_for_evening_date,
+)
+
+
+@pytest.mark.parametrize(
+    "evening_date",
+    ["2026-03-18", "2026-07-13", "2026-08-27", "2026-10-25"],
+)
+def test_night_snapshot_matches_planning_table(evening_date: str) -> None:
+    ref = REFERENCE_TABLE[evening_date]
+    snap = night_snapshot_for_evening_date(GAIA_4491, evening_date)
+    assert snap is not None
+    assert snap.airm_ctr == pytest.approx(ref["airm_ctr"], abs=0.15)
+    assert snap.airm_morn == pytest.approx(ref["airm_morn"], abs=0.35)
+    assert snap.hrs_below[3.0] == pytest.approx(ref["hrs3"], abs=1.2)
+    if "hrs2" in ref:
+        assert snap.hrs_below[2.0] == pytest.approx(ref["hrs2"], abs=1.2)


### PR DESCRIPTION
## Summary

- Align APF visibility seasons with Lick planning-table semantics: nautical twilight (−12°), airmass ≤ 1.7 for ≥30 min/night, consecutive eve/morn pairing.
- Add `observability_table_compare.py` regression harness against the corrected Gaia DR3 449121951305471360 table (Mar–Oct 2026); center airmass uses the HA midpoint between evening and morning twilight.
- Fix false circumpolar labels for high-Dec targets (e.g. 4491): require geometric min-altitude check plus observable nights, not merely “up during twilight.”
- Cap Keplerian plot observability shading at 90 days ahead; extend season scan to 365 days.
- Add `scripts/compare_observability_table.py` CLI for on-server validation.

## Test plan

- [x] `pytest tests/test_apf_observability.py tests/test_observability_table_compare.py`
- [ ] On ziggy: rebuild observability cache, refit 4491 and 2060, confirm blue shading and non-circumpolar label
- [ ] `python3 scripts/compare_observability_table.py` — `airm_ctr` within ~0.15, `hrs<3` within ~1.2 h of reference


Made with [Cursor](https://cursor.com)