### PR TITLE
Backfill missing pipeline summaries for website cron

### DIFF
--- a/darkhunter_rv/summary_paths.py
+++ b/darkhunter_rv/summary_paths.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Set
 
 from darkhunter_rv.gaia_utils import parse_gaia_metadata_from_star_summary
+from darkhunter_rv.rv_point_filters import rv_epoch_is_valid
+
+_PRIMARY_EPOCH_NAME = re.compile(r"^Gaia_DR3_(\d+)_epoch_\d+\.txt$")
+_GAIA_DIR_NAME = re.compile(r"^Gaia_DR3_(\d+)$")
 
 
 def parse_object_id_from_summary(path: Path) -> Optional[str]:
@@ -28,6 +32,67 @@ def parse_object_id_from_summary(path: Path) -> Optional[str]:
                 return m.group(1)
     m = re.match(r"([0-9]+)_summary$", path.stem)
     return m.group(1) if m else None
+
+
+def discover_spec_gaia_ids(spec_root: Path) -> Set[str]:
+    """Unique Gaia source ids under a reduction tree (any subdirectory depth)."""
+    ids: Set[str] = set()
+    if not spec_root.is_dir():
+        return ids
+    for path in spec_root.rglob("Gaia_DR3_*_epoch_*.txt"):
+        if not path.is_file() or "_order_" in path.name:
+            continue
+        match = _PRIMARY_EPOCH_NAME.match(path.name)
+        if match:
+            ids.add(match.group(1))
+    for path in spec_root.rglob("Gaia_DR3_*"):
+        if not path.is_dir():
+            continue
+        match = _GAIA_DIR_NAME.match(path.name)
+        if match:
+            ids.add(match.group(1))
+    return ids
+
+
+def discover_primary_epoch_files(spec_root: Path, gaia_source_id: str) -> list[Path]:
+    """Primary per-epoch reduced spectra (exclude per-order splits)."""
+    sid = str(gaia_source_id).strip()
+    if not sid or not spec_root.is_dir():
+        return []
+    out: list[Path] = []
+    for path in spec_root.rglob(f"Gaia_DR3_{sid}_epoch_*.txt"):
+        if not path.is_file() or "_order_" in path.name:
+            continue
+        if _PRIMARY_EPOCH_NAME.match(path.name):
+            out.append(path)
+    return sorted(out, key=lambda p: p.name)
+
+
+def count_valid_pipeline_rv_epochs(path: Path) -> int:
+    """Finite pipeline RV epochs in [PIPELINE RESULTS] (no matplotlib / fit deps)."""
+    if not path.is_file():
+        return 0
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if "[PIPELINE RESULTS]" in text:
+        lines = text.split("[PIPELINE RESULTS]", 1)[-1].splitlines()
+    else:
+        lines = text.splitlines()
+    n = 0
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#") or (line.startswith("[") and line.endswith("]")):
+            continue
+        parts = line.split()
+        if len(parts) < 5:
+            continue
+        try:
+            mjd = float(parts[1])
+            rv = float(parts[2])
+        except ValueError:
+            continue
+        if rv_epoch_is_valid(mjd, rv):
+            n += 1
+    return n
 
 
 def count_pipeline_rows(path: Path) -> int:

--- a/docs/website.md
+++ b/docs/website.md
@@ -214,6 +214,16 @@ PYTHONPATH=. python3 scripts/build_hbeta_website_plots.py \
 
 **Missing epochs in summaries:** Cron used to match only `*_ap1.*` / `*.fits`, not `Gaia_DR3_*_epoch_*.txt`. Stars with only epoch `.txt` reductions (e.g. nine epochs on disk but four in `[PIPELINE RESULTS]`) need a one-time **`bash scripts/full_website_refresh.sh`** (`RUN_PIPELINE=1`, default), which runs the pipeline on all epoch files then refits. Incremental cron picks up new epoch `.txt` files after that.
 
+**Spectra on disk but empty GAIA DATA folder:** The catalog table (`data.csv`) was copied from legacy `rv_website_v1`; star assets are built separately from `$REPO/output/Gaia_DR3_*_summary.txt`. Cron runs `pipeline --update`, which **skips** spectra whose diagnostics CSV is newer than the input and does **not** create a summary when every epoch is skipped. After the daily pipeline pass, cron runs `scripts/ensure_pipeline_summaries.py` to backfill missing/incomplete summaries for any `Gaia_DR3_*` tree under `SPEC_ROOT` (all subdirectories). Audit gaps (no matplotlib required):
+
+```bash
+cd /data2/darkhunter/dark-hunter_rv
+PY=/home/marley/anaconda2/envs/gaia-env/bin/python PYTHONPATH=. \
+  python3 scripts/audit_pipeline_coverage.py --only-issues
+```
+
+Use the gaia-env Python on ziggy (base conda lacks matplotlib). One-star backfill: `PY=... python3 scripts/ensure_pipeline_summaries.py --gaia-id <id>`.
+
 Install crontab: run **`crontab -e`** alone (do not put the schedule on the same shell line), then add:
 
 ```cron

--- a/scripts/audit_pipeline_coverage.py
+++ b/scripts/audit_pipeline_coverage.py
@@ -7,40 +7,25 @@ import argparse
 import csv
 from pathlib import Path
 
-from darkhunter_rv.rv_keplerian_plots import our_telescope_points
 from darkhunter_rv.summary_paths import (
     count_pipeline_rows,
+    count_valid_pipeline_rv_epochs,
+    discover_primary_epoch_files,
+    discover_spec_gaia_ids,
     discover_summary_files,
     discover_summary_path,
     parse_object_id_from_summary,
 )
 from darkhunter_rv.website_table_csv import gaia_id_from_row
-from fit_apf_rv_keplerian import parse_summary
 
 MIN_RV_PLOT_POINTS = 2
 
 
 def _discover_spectra(spec_root: Path) -> dict[str, int]:
-    """Gaia id -> spectrum file count under SPEC_ROOT."""
+    """Gaia id -> primary epoch spectrum count under SPEC_ROOT (any depth)."""
     counts: dict[str, int] = {}
-    if not spec_root.is_dir():
-        return counts
-    patterns = (
-        "Gaia_DR3_*_epoch_*.txt",
-        "Gaia_DR3_*_*_ap1.flm",
-        "Gaia_DR3_*_*_ap1.txt",
-    )
-    for pat in patterns:
-        for p in spec_root.rglob(pat):
-            if not p.is_file():
-                continue
-            stem = p.name
-            if stem.startswith("Gaia_DR3_"):
-                parts = stem.split("_")
-                if len(parts) >= 3 and parts[1] == "DR3":
-                    gid = parts[2]
-                    if gid.isdigit():
-                        counts[gid] = counts.get(gid, 0) + 1
+    for gid in discover_spec_gaia_ids(spec_root):
+        counts[gid] = len(discover_primary_epoch_files(spec_root, gid))
     return counts
 
 
@@ -76,16 +61,8 @@ def _audit_one(
     summ_flat = out_dir / f"Gaia_DR3_{gid}_summary.txt"
     has_summary = summ is not None and summ.is_file()
     n_rows = count_pipeline_rows(summ) if has_summary and summ else 0
-    n_finite = 0
-    n_plot_points = 0
-    if has_summary and summ:
-        try:
-            parsed = parse_summary(summ)
-            n_finite = len(parsed)
-            n_plot_points = len(our_telescope_points(parsed))
-        except Exception:
-            n_finite = 0
-            n_plot_points = 0
+    n_finite = count_valid_pipeline_rv_epochs(summ) if has_summary and summ else 0
+    n_plot_points = n_finite
 
     fit_json = reports_dir / f"{gid}_keplerian_fit.json"
     fit_png = reports_dir / f"{gid}_keplerian_fit.png"
@@ -103,6 +80,8 @@ def _audit_one(
         issues.append("no_summary")
     elif summ and summ.resolve() != summ_flat.resolve() and not summ_flat.is_file():
         issues.append("summary_nested_only")
+    if has_summary and n_rows < n_spec and n_spec > 0:
+        issues.append(f"summary_incomplete({n_rows}<{n_spec})")
     if has_summary and n_finite < min_points:
         issues.append(f"few_rv_points({n_finite}<{min_points})")
     if has_summary and n_finite >= min_points and not fit_json.is_file():
@@ -115,6 +94,8 @@ def _audit_one(
         issues.append("website_summary_no_rv_plot")
     if web_summ.is_file() and not web_fit.is_file():
         issues.append("website_summary_no_rv_fit")
+    if n_spec > 0 and not web_summ.is_file():
+        issues.append("spectra_not_staged")
 
     return {
         "gaia_id": gid,
@@ -186,14 +167,16 @@ def main() -> int:
 
     n_issue = sum(1 for r in rows if r["issues"])
     n_no_summ = sum(1 for r in rows if "no_summary" in r["issues"])
+    n_not_staged = sum(1 for r in rows if "spectra_not_staged" in r["issues"])
     n_no_rv_plot = sum(
         1
         for r in rows
         if "no_rv_data_plot" in r["issues"] or "website_summary_no_rv_plot" in r["issues"]
     )
     print(
-        f"audit: {len(rows)} stars, {n_issue} with issues, "
-        f"{n_no_summ} missing summary, {n_no_rv_plot} missing RV data plot assets"
+        f"audit: {len(rows)} stars ({len(spec_counts)} with spectra under spec-root), "
+        f"{n_issue} with issues, {n_no_summ} missing summary, "
+        f"{n_not_staged} with spectra not staged, {n_no_rv_plot} missing RV data plot assets"
     )
     print(f"wrote {out_csv}")
     return 0

--- a/scripts/cron_update_rv_website.sh
+++ b/scripts/cron_update_rv_website.sh
@@ -18,6 +18,9 @@ OUT="${OUT:-$REPO/output}"
 WEB_ROOT="${WEB_ROOT:-/var/www/html/darkhunter/rv}"
 SPEC_ROOT="${SPEC_ROOT:-/data2/gaia_stars/apf_reductions}"
 PY="${PY:-/home/marley/anaconda2/envs/gaia-env/bin/python}"
+if [[ ! -x "$PY" ]]; then
+  PY="${PY_FALLBACK:-python3}"
+fi
 MIN_POINTS="${MIN_POINTS:-5}"
 LOG="${LOG:-$REPO/logs/cron_rv_website.log}"
 RUN_PIPELINE="${RUN_PIPELINE:-1}"
@@ -39,8 +42,14 @@ echo "=== $(date -Is) cron_update_rv_website start (pid $$) ==="
 if [[ "$RUN_PIPELINE" == "1" && -d "$SPEC_ROOT" ]]; then
   echo "=== Pipeline --update on $SPEC_ROOT ==="
   find_apf_spectra_print0 "$SPEC_ROOT" \
-    | xargs -0 -r "$PY" -m darkhunter_rv.pipeline --instrument APF --update --plots --plots-focus 2>/dev/null \
+    | xargs -0 -r "$PY" -m darkhunter_rv.pipeline --instrument APF --update --plots --plots-focus \
     || echo "[WARN] pipeline pass had errors (continuing)"
+
+  echo "=== Ensure summaries for stars with spectra but missing output summaries ==="
+  "$PY" scripts/ensure_pipeline_summaries.py \
+    --spec-root "$SPEC_ROOT" \
+    --output-dir "$OUT" \
+    || echo "[WARN] ensure_pipeline_summaries had errors (continuing)"
 elif [[ "$RUN_PIPELINE" == "1" ]]; then
   echo "[WARN] SPEC_ROOT missing: $SPEC_ROOT"
 fi

--- a/scripts/ensure_pipeline_summaries.py
+++ b/scripts/ensure_pipeline_summaries.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Backfill output/Gaia_DR3_*_summary.txt for stars with spectra but missing summaries.
+
+Cron runs ``pipeline --update``, which skips spectra whose diagnostics CSV is newer than
+the input. When every epoch for a star is skipped and no summary ever existed in
+``output/``, populate/website staging never sees that star.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from darkhunter_rv.summary_paths import (
+    count_pipeline_rows,
+    discover_primary_epoch_files,
+    discover_spec_gaia_ids,
+)
+
+
+def _needs_summary(
+    gaia_id: str,
+    *,
+    spec_root: Path,
+    out_dir: Path,
+) -> tuple[bool, Path, list[Path]]:
+    epoch_files = discover_primary_epoch_files(spec_root, gaia_id)
+    if not epoch_files:
+        return False, out_dir / f"Gaia_DR3_{gaia_id}_summary.txt", epoch_files
+    summary_path = out_dir / f"Gaia_DR3_{gaia_id}_summary.txt"
+    n_epochs = len(epoch_files)
+    n_rows = count_pipeline_rows(summary_path) if summary_path.is_file() else 0
+    return n_rows < n_epochs, summary_path, epoch_files
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Run pipeline on stars whose summaries are missing or incomplete."
+    )
+    ap.add_argument("--spec-root", default="/data2/gaia_stars/apf_reductions")
+    ap.add_argument("--output-dir", default=None, help="Pipeline output (default: REPO/output)")
+    ap.add_argument("--gaia-id", default=None, help="Single Gaia DR3 source id")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument(
+        "--with-plots",
+        action="store_true",
+        help="Pass --plots --plots-focus to pipeline (default: measure only, faster).",
+    )
+    args = ap.parse_args()
+
+    repo = Path(__file__).resolve().parents[1]
+    out_dir = Path(args.output_dir) if args.output_dir else repo / "output"
+    spec_root = Path(args.spec_root)
+    py = os.environ.get("PY", sys.executable)
+
+    if args.gaia_id:
+        gaia_ids = [str(args.gaia_id).strip()]
+    else:
+        gaia_ids = sorted(discover_spec_gaia_ids(spec_root))
+
+    pending: list[tuple[str, list[Path]]] = []
+    for gid in gaia_ids:
+        need, _summary, epoch_files = _needs_summary(gid, spec_root=spec_root, out_dir=out_dir)
+        if need:
+            pending.append((gid, epoch_files))
+
+    if not pending:
+        print("ensure_pipeline_summaries: all spectra have complete summaries")
+        return 0
+
+    print(f"ensure_pipeline_summaries: {len(pending)} star(s) need summary backfill")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo)
+    env["DARKHUNTER_OUTPUT_DIR"] = str(out_dir)
+
+    rc = 0
+    for gid, epoch_files in pending:
+        cmd = [
+            py,
+            "-m",
+            "darkhunter_rv.pipeline",
+            "--instrument",
+            "APF",
+            "--update",
+            "--no-run-all-methods",
+        ]
+        if args.with_plots:
+            cmd.extend(["--plots", "--plots-focus"])
+        cmd.extend(str(p) for p in epoch_files)
+        print(f"  Gaia_DR3_{gid}: {len(epoch_files)} epoch file(s)")
+        if args.dry_run:
+            continue
+        proc = subprocess.run(cmd, cwd=repo, env=env)
+        if proc.returncode != 0:
+            print(f"[WARN] pipeline exit {proc.returncode} for Gaia_DR3_{gid}", file=sys.stderr)
+            rc = proc.returncode
+
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/discover_gaia_star_ids.sh
+++ b/scripts/lib/discover_gaia_star_ids.sh
@@ -1,5 +1,4 @@
-# List unique Gaia DR3 source ids under a reduction tree (sorted).
-# Uses top-level Gaia_DR3_* directories and Gaia_DR3_*_epoch_*.txt basenames.
+# List unique Gaia DR3 source ids under a reduction tree (sorted, any depth).
 
 discover_gaia_star_ids() {
   local root="${1:?SPEC_ROOT required}"
@@ -13,14 +12,14 @@ discover_gaia_star_ids() {
   while IFS= read -r d; do
     base=$(basename "$d")
     ids+=("${base#Gaia_DR3_}")
-  done < <(find "$root" -maxdepth 1 -type d -name 'Gaia_DR3_*' 2>/dev/null | sort)
+  done < <(find "$root" -type d -name 'Gaia_DR3_*' 2>/dev/null | sort)
 
   while IFS= read -r base; do
     base=$(basename "$base")
-    if [[ "$base" =~ ^Gaia_DR3_([0-9]+)_epoch_ ]]; then
+    if [[ "$base" =~ ^Gaia_DR3_([0-9]+)_epoch_[0-9]+\.txt$ ]]; then
       ids+=("${BASH_REMATCH[1]}")
     fi
-  done < <(find "$root" -type f -name 'Gaia_DR3_*_epoch_*.txt' 2>/dev/null | sort -u)
+  done < <(find "$root" -type f -name 'Gaia_DR3_*_epoch_*.txt' ! -name '*_order_*' 2>/dev/null | sort -u)
 
   if [[ "${#ids[@]}" -eq 0 ]]; then
     return 0

--- a/tests/test_ensure_pipeline_summaries.py
+++ b/tests/test_ensure_pipeline_summaries.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from scripts.ensure_pipeline_summaries import _needs_summary
+
+
+def test_needs_summary_when_missing(tmp_path: Path) -> None:
+    spec = tmp_path / "spec"
+    out = tmp_path / "out"
+    gid = "77413727493690112"
+    star = spec / f"Gaia_DR3_{gid}"
+    star.mkdir(parents=True)
+    (star / f"Gaia_DR3_{gid}_epoch_1.txt").write_text("spectrum")
+    need, _path, files = _needs_summary(gid, spec_root=spec, out_dir=out)
+    assert need is True
+    assert len(files) == 1

--- a/tests/test_summary_paths_spec_discovery.py
+++ b/tests/test_summary_paths_spec_discovery.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from darkhunter_rv.summary_paths import (
+    count_valid_pipeline_rv_epochs,
+    discover_primary_epoch_files,
+    discover_spec_gaia_ids,
+)
+
+
+def test_discover_spec_gaia_ids_primary_epochs_only(tmp_path: Path) -> None:
+    root = tmp_path / "apf_reductions"
+    star = root / "Gaia_DR3_111111111111111111"
+    star.mkdir(parents=True)
+    (star / "Gaia_DR3_111111111111111111_epoch_1.txt").write_text("x")
+    (star / "Gaia_DR3_111111111111111111_epoch_1_order_28.txt").write_text("x")
+    nested = root / "batch" / "Gaia_DR3_222222222222222222"
+    nested.mkdir(parents=True)
+    (nested / "Gaia_DR3_222222222222222222_epoch_2.txt").write_text("x")
+
+    ids = discover_spec_gaia_ids(root)
+    assert ids == {"111111111111111111", "222222222222222222"}
+    assert len(discover_primary_epoch_files(root, "111111111111111111")) == 1
+
+
+def test_count_valid_pipeline_rv_epochs(tmp_path: Path) -> None:
+    summ = tmp_path / "Gaia_DR3_1_summary.txt"
+    summ.write_text(
+        "### STAR SUMMARY ###\n\n[PIPELINE RESULTS]\n"
+        "Gaia_DR3_1_epoch_1.txt 60532.5 -1.6 0.01 0.01 False\n"
+        "Gaia_DR3_1_epoch_2.txt 60555.4 -9999.0 0.01 0.01 False\n"
+    )
+    assert count_valid_pipeline_rv_epochs(summ) == 1


### PR DESCRIPTION
## Summary

- Add `scripts/ensure_pipeline_summaries.py` to backfill `output/Gaia_DR3_*_summary.txt` when spectra exist under `SPEC_ROOT` but cron’s `pipeline --update` skipped every epoch (diagnostics newer than input, no summary ever written).
- Wire ensure into `scripts/cron_update_rv_website.sh` after the daily pipeline pass; stop hiding pipeline stderr (`2>/dev/null` removed); fall back to `python3` if gaia-env is missing.
- Fix `scripts/audit_pipeline_coverage.py` to run without matplotlib; discover spectra recursively under all `apf_reductions` subdirectories (primary epoch files only, not `*_order_*` sidecars).
- Extend `discover_gaia_star_ids.sh` and `summary_paths.py` for any-depth spec-tree discovery; flag `spectra_not_staged` / `summary_incomplete` in audit output.

## Ziggy after merge

```bash
cd /data2/darkhunter/dark-hunter_rv
git checkout main && git pull

PY=/home/marley/anaconda2/envs/gaia-env/bin/python
export PYTHONPATH=$PWD DARKHUNTER_OUTPUT_DIR=$PWD/output

# 1) Audit gaps (works on base python3 too after this PR)
python3 scripts/audit_pipeline_coverage.py \
  --spec-root /data2/gaia_stars/apf_reductions \
  --output-dir /data2/darkhunter/dark-hunter_rv/output \
  --reports-dir /data2/darkhunter/dark-hunter_rv/rv_fit_reports \
  --web-root /var/www/html/darkhunter/rv \
  --data-csv /var/www/html/darkhunter/rv/tables/data.csv \
  --min-points 5 \
  --only-issues

# 2) Backfill missing summaries, then stage fits/plots
$PY scripts/ensure_pipeline_summaries.py \
  --spec-root /data2/gaia_stars/apf_reductions \
  --output-dir /data2/darkhunter/dark-hunter_rv/output

MIN_POINTS=5 FIT_FORCE=1 bash scripts/populate_website.sh
```

Single-star example: `$PY scripts/ensure_pipeline_summaries.py --gaia-id 77413727493690112 ...` then `STAR_ID=77413727493690112 MIN_POINTS=5 FIT_FORCE=1 bash scripts/refit_all_per_object.sh`.

## Test plan

- [x] `pytest tests/test_summary_paths_spec_discovery.py tests/test_ensure_pipeline_summaries.py`
- [ ] On ziggy: audit `--only-issues` runs without matplotlib import error
- [ ] `ensure_pipeline_summaries.py` creates summary for a star with spectra but no `output/` summary
- [ ] `populate_website.sh` stages GAIA DATA assets for backfilled stars


Made with [Cursor](https://cursor.com)