### PR TITLE
Skip *_order_* spectrum extracts; dedupe CI (workflow edit needed)

### DIFF
--- a/darkhunter_rv/pipeline.py
+++ b/darkhunter_rv/pipeline.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from . import config, instruments, io_utils, continuum, rv_core, templates, chunking, plotting, qc
+from darkhunter_rv.summary_paths import is_primary_epoch_spectrum_name
 
 logger = logging.getLogger(__name__)
 
@@ -1706,6 +1707,14 @@ def main(argv: list[str] | None = None) -> None:
             return False
 
     for fn in args.input_file:
+        fn_path = Path(str(fn))
+        if (
+            fn_path.suffix.lower() == ".txt"
+            and "_epoch_" in fn_path.name
+            and not is_primary_epoch_spectrum_name(fn_path.name)
+        ):
+            logger.info("Skipping per-order spectrum extract: %s", fn)
+            continue
         if _skip_update(str(fn)):
             logger.info("Skipping (up to date): %s", fn)
             continue

--- a/darkhunter_rv/summary_paths.py
+++ b/darkhunter_rv/summary_paths.py
@@ -13,6 +13,11 @@ _PRIMARY_EPOCH_NAME = re.compile(r"^Gaia_DR3_(\d+)_epoch_\d+\.txt$")
 _GAIA_DIR_NAME = re.compile(r"^Gaia_DR3_(\d+)$")
 
 
+def is_primary_epoch_spectrum_name(filename: str) -> bool:
+    """True for full-epoch Gaia_DR3_*_epoch_<N>.txt files (not *_order_* extracts)."""
+    return bool(_PRIMARY_EPOCH_NAME.match(Path(filename).name))
+
+
 def parse_object_id_from_summary(path: Path) -> Optional[str]:
     m = re.search(r"Gaia_DR3_(\d{18,19})", f"{path.parent.name}/{path.stem}")
     if m:
@@ -40,7 +45,7 @@ def discover_spec_gaia_ids(spec_root: Path) -> Set[str]:
     if not spec_root.is_dir():
         return ids
     for path in spec_root.rglob("Gaia_DR3_*_epoch_*.txt"):
-        if not path.is_file() or "_order_" in path.name:
+        if not path.is_file() or not is_primary_epoch_spectrum_name(path.name):
             continue
         match = _PRIMARY_EPOCH_NAME.match(path.name)
         if match:
@@ -61,9 +66,7 @@ def discover_primary_epoch_files(spec_root: Path, gaia_source_id: str) -> list[P
         return []
     out: list[Path] = []
     for path in spec_root.rglob(f"Gaia_DR3_{sid}_epoch_*.txt"):
-        if not path.is_file() or "_order_" in path.name:
-            continue
-        if _PRIMARY_EPOCH_NAME.match(path.name):
+        if path.is_file() and is_primary_epoch_spectrum_name(path.name):
             out.append(path)
     return sorted(out, key=lambda p: p.name)
 

--- a/docs/website.md
+++ b/docs/website.md
@@ -209,7 +209,7 @@ PYTHONPATH=. python3 scripts/build_hbeta_website_plots.py \
 
 `scripts/cron_update_rv_website.sh` runs:
 
-1. **Pipeline** `--update` on `SPEC_ROOT` for `Gaia_DR3_*_epoch_*.txt`, `*_ap1.{flm,txt}`, and `*.fits` (skips spectra whose `*_diagnostics.csv` is newer than the input).
+1. **Pipeline** `--update` on `SPEC_ROOT` for full-epoch `Gaia_DR3_*_epoch_<N>.txt` (not `*_order_*` Hβ extracts), `*_ap1.{flm,txt}`, and `*.fits` (skips spectra whose `*_diagnostics.csv` is newer than the input).
 2. **Populate**: Keplerian fits (≥`MIN_POINTS`, literature included, bad RVs filtered), RV/Hβ plots, `data.csv` mass columns, staging to `WEB_ROOT`. Skips refit when the JSON is newer than the summary (`FIT_FORCE=0`).
 
 **Missing epochs in summaries:** Cron used to match only `*_ap1.*` / `*.fits`, not `Gaia_DR3_*_epoch_*.txt`. Stars with only epoch `.txt` reductions (e.g. nine epochs on disk but four in `[PIPELINE RESULTS]`) need a one-time **`bash scripts/full_website_refresh.sh`** (`RUN_PIPELINE=1`, default), which runs the pipeline on all epoch files then refits. Incremental cron picks up new epoch `.txt` files after that.

--- a/scripts/lib/refit_one_object.sh
+++ b/scripts/lib/refit_one_object.sh
@@ -61,7 +61,7 @@ while IFS= read -r f; do
   [[ -n "$f" ]] && SPEC_FILES+=("$f")
 done < <(
   find "$SPEC_ROOT" -type f \( \
-    -name "Gaia_DR3_${gid}_epoch_*.txt" -o \
+    \( -name "Gaia_DR3_${gid}_epoch_*.txt" ! -name '*_order_*' \) -o \
     -name "Gaia_DR3_${gid}_*_ap1.flm" -o \
     -name "Gaia_DR3_${gid}_*_ap1.txt" \
   \) 2>/dev/null | sort

--- a/scripts/lib/spec_find_patterns.sh
+++ b/scripts/lib/spec_find_patterns.sh
@@ -1,10 +1,11 @@
 # Shared find(1) for APF spectrum files under a reduction tree.
-# Gaia_DR3_*_epoch_*.txt are reduced spectra in star summaries; *_ap1.* / *.fits are APF products.
+# Gaia_DR3_*_epoch_<N>.txt are full-epoch reduced spectra; exclude *_order_* extracts
+# (e.g. epoch_1_order_28.txt is Hβ-only). *_ap1.* / *.fits are APF products.
 
 find_apf_spectra_print0() {
   local root="${1:?root directory required}"
   find "$root" -type f \( \
-    -name 'Gaia_DR3_*_epoch_*.txt' -o \
+    \( -name 'Gaia_DR3_*_epoch_*.txt' ! -name '*_order_*' \) -o \
     -name '*_ap1.flm' -o \
     -name '*_ap1.txt' -o \
     -name '*.fits' \

--- a/scripts/refit_star_rvs.sh
+++ b/scripts/refit_star_rvs.sh
@@ -77,7 +77,7 @@ while IFS= read -r f; do
   [[ -n "$f" ]] && SPEC_FILES+=("$f")
 done < <(
   find "$SPEC_ROOT" -type f \( \
-    -name "Gaia_DR3_${STAR_ID}_epoch_*.txt" -o \
+    \( -name "Gaia_DR3_${STAR_ID}_epoch_*.txt" ! -name '*_order_*' \) -o \
     -name "Gaia_DR3_${STAR_ID}_*_ap1.flm" -o \
     -name "Gaia_DR3_${STAR_ID}_*_ap1.txt" \
   \) 2>/dev/null | sort

--- a/tests/test_summary_paths_spec_discovery.py
+++ b/tests/test_summary_paths_spec_discovery.py
@@ -4,6 +4,7 @@ from darkhunter_rv.summary_paths import (
     count_valid_pipeline_rv_epochs,
     discover_primary_epoch_files,
     discover_spec_gaia_ids,
+    is_primary_epoch_spectrum_name,
 )
 
 
@@ -20,6 +21,12 @@ def test_discover_spec_gaia_ids_primary_epochs_only(tmp_path: Path) -> None:
     ids = discover_spec_gaia_ids(root)
     assert ids == {"111111111111111111", "222222222222222222"}
     assert len(discover_primary_epoch_files(root, "111111111111111111")) == 1
+
+
+def test_is_primary_epoch_spectrum_name() -> None:
+    assert is_primary_epoch_spectrum_name("Gaia_DR3_77413727493690112_epoch_1.txt")
+    assert not is_primary_epoch_spectrum_name("Gaia_DR3_77413727493690112_epoch_1_order_28.txt")
+    assert not is_primary_epoch_spectrum_name("Gaia_DR3_77413727493690112_epoch_10_order_28.txt")
 
 
 def test_count_valid_pipeline_rv_epochs(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

### Per-order spectrum extracts (in this PR)

Stars like `Gaia_DR3_77413727493690112` have sidecar files such as `*_epoch_1_order_28.txt` (single-order Hβ extracts). These are **not** full-epoch spectra and should not be measured or fit as separate epochs.

- **`scripts/lib/spec_find_patterns.sh`** — cron `find_apf_spectra_print0` excludes `*_order_*`
- **`refit_one_object.sh` / `refit_star_rvs.sh`** — same exclusion on per-star `find`
- **`darkhunter_rv/pipeline.py`** — skips per-order extracts if passed on the CLI
- **`is_primary_epoch_spectrum_name()`** in `summary_paths.py` — shared rule (already used by audit/ensure)

### CI deduplication (apply manually — see below)

The workflow file could not be pushed from this environment (GitHub PAT lacks `workflow` scope). Please add this one line on merge:

```yaml
# .github/workflows/tests.yml
on:
  push:
    branches: [main]   # <-- add this line
  pull_request:
```

That stops duplicate pytest runs on every PR push (today both `push` and `pull_request` fire).

## Test plan

- [x] `pytest tests/test_summary_paths_spec_discovery.py`
- [ ] After merge: confirm cron log no longer lists `*_order_28.txt` for pipeline
- [ ] Apply CI workflow edit (above) via GitHub web editor or local push with `workflow` scope


Made with [Cursor](https://cursor.com)