### PR TITLE
Fix website Hβ plots and Keplerian four-fit/APF window regression

### DIFF
--- a/darkhunter_rv/summary_paths.py
+++ b/darkhunter_rv/summary_paths.py
@@ -13,6 +13,11 @@ _PRIMARY_EPOCH_NAME = re.compile(r"^Gaia_DR3_(\d+)_epoch_\d+\.txt$")
 _GAIA_DIR_NAME = re.compile(r"^Gaia_DR3_(\d+)$")
 
 
+def is_primary_epoch_spectrum_name(filename: str) -> bool:
+    """True for full-epoch Gaia_DR3_*_epoch_<N>.txt files (not *_order_* extracts)."""
+    return bool(_PRIMARY_EPOCH_NAME.match(Path(filename).name))
+
+
 def parse_object_id_from_summary(path: Path) -> Optional[str]:
     m = re.search(r"Gaia_DR3_(\d{18,19})", f"{path.parent.name}/{path.stem}")
     if m:

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -172,6 +172,49 @@ def _load_json_cache(path: Path) -> Dict[str, Any]:
         return {}
 
 
+def load_gaia_nss_from_cache(source_id: Optional[str], cache_path: Optional[Path]) -> Optional[Dict[str, float]]:
+    """Offline NSS period/eccentricity from gaia_nss_cache.json (no network)."""
+    if source_id is None or cache_path is None or not cache_path.exists():
+        return None
+    val = _load_json_cache(cache_path).get(str(source_id))
+    if not isinstance(val, dict) or val.get("_none"):
+        return None
+    p = val.get("period_days")
+    e = val.get("eccentricity")
+    if p is None or e is None:
+        return None
+    try:
+        p_f = float(p)
+        e_f = float(e)
+    except (TypeError, ValueError):
+        return None
+    if not np.isfinite(p_f) or not np.isfinite(e_f):
+        return None
+    if p_f <= 0 or e_f < 0 or e_f >= 1:
+        return None
+    return val
+
+
+def resolve_observability_window(
+    summary_path: Path,
+    source_id: Optional[str],
+    cache_path: Optional[Path],
+) -> Optional[Dict[str, Any]]:
+    """APF shading window: cache first, then compute from summary coordinates."""
+    obs = load_observability_window(source_id, cache_path)
+    if obs is not None:
+        return obs
+    try:
+        from darkhunter_rv.apf_observability import observability_for_summary
+
+        row = observability_for_summary(summary_path)
+        if row is None:
+            return None
+        return {k: v for k, v in row.items() if k != "gaia_source_id"}
+    except Exception:
+        return None
+
+
 def load_observability_window(source_id: Optional[str], cache_path: Optional[Path]) -> Optional[Dict[str, Any]]:
     if source_id is None or cache_path is None or (not cache_path.exists()):
         return None
@@ -302,10 +345,10 @@ def fetch_gaia_nss_orbit(source_id: str, cache_path: Optional[Path] = None) -> O
             val = cache[source_id]
             if isinstance(val, dict) and val.get("_none"):
                 return None
-            # If cache already has M1, trust it. Otherwise re-query to enrich/update.
-            if isinstance(val, dict) and val.get("m1_msun") is not None:
-                return val
-            # For cached None or dict without masses, continue and re-query.
+            cached = load_gaia_nss_from_cache(source_id, cache_path)
+            if cached is not None:
+                return cached
+            # Cached entry without usable orbit priors — re-query when allowed.
 
     try:
         from astroquery.gaia import Gaia  # type: ignore
@@ -1856,10 +1899,14 @@ def run_one(
         gaia_nss = load_nss_priors_from_summary(summary_path)
         if gaia_nss is not None:
             nss_source = "summary"
-        elif query_gaia_online and gaia_source_id is not None:
-            gaia_nss = fetch_gaia_nss_orbit(gaia_source_id, cache_path=gaia_cache_path)
+        elif gaia_source_id is not None:
+            gaia_nss = load_gaia_nss_from_cache(gaia_source_id, gaia_cache_path)
             if gaia_nss is not None:
-                nss_source = "online"
+                nss_source = "cache"
+            elif query_gaia_online:
+                gaia_nss = fetch_gaia_nss_orbit(gaia_source_id, cache_path=gaia_cache_path)
+                if gaia_nss is not None:
+                    nss_source = "online"
 
     fit_m1_msun = _finite_mass_value(table_m1_msun)
     if fit_m1_msun is None:
@@ -1910,7 +1957,9 @@ def run_one(
     report["gaia_source_id"] = gaia_source_id
     report["gaia_nss"] = gaia_nss
     report["nss_priors_source"] = nss_source
-    report["observability_window"] = load_observability_window(gaia_source_id, observability_cache_path)
+    report["observability_window"] = resolve_observability_window(
+        summary_path, gaia_source_id, observability_cache_path
+    )
     report["fit_variants"] = {k: copy.deepcopy(v[1]) for k, v in fit_variants.items()}
     report["params_by_variant"] = {k: np.asarray(v[0], dtype=float).tolist() for k, v in fit_variants.items()}
 

--- a/scripts/build_hbeta_website_plots.py
+++ b/scripts/build_hbeta_website_plots.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import re
 from pathlib import Path
 
 import matplotlib
@@ -15,7 +14,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from darkhunter_rv import continuum, io_utils, rv_core
-from fit_apf_rv_keplerian import discover_summary_files, parse_object_id_from_summary
+from darkhunter_rv.summary_paths import (
+    discover_summary_files,
+    discover_summary_path,
+    is_primary_epoch_spectrum_name,
+    parse_object_id_from_summary,
+)
 
 
 def _epoch_rows(summary_path: Path) -> list[tuple[float, str]]:
@@ -52,17 +56,36 @@ def _parse_teff_from_summary(summary_path: Path) -> float:
     return 5500.0
 
 
-def _find_spectrum(basename: str, roots: list[Path]) -> Path | None:
-    name = Path(basename).name
+def _find_spectrum(file_ref: str, roots: list[Path], *, gaia_id: str | None = None) -> Path | None:
+    ref = Path(file_ref)
+    try:
+        if ref.is_file():
+            return ref.resolve()
+    except OSError:
+        pass
+
+    name = ref.name
+    if not is_primary_epoch_spectrum_name(name):
+        return None
+
     for root in roots:
         if not root.is_dir():
             continue
+        if gaia_id:
+            preferred = root / f"Gaia_DR3_{gaia_id}" / name
+            if preferred.is_file():
+                return preferred
         direct = root / name
         if direct.is_file():
             return direct
         hits = sorted(root.rglob(name))
-        if hits:
-            return hits[0]
+        if not hits:
+            continue
+        if gaia_id:
+            for hit in hits:
+                if f"Gaia_DR3_{gaia_id}" in hit.as_posix():
+                    return hit
+        return hits[0]
     return None
 
 
@@ -113,11 +136,14 @@ def build_overlay(
     summary_path: Path,
     spec_roots: list[Path],
     out_png: Path,
+    *,
+    gaia_id: str | None = None,
 ) -> bool:
     teff = _parse_teff_from_summary(summary_path)
+    sid = gaia_id or parse_object_id_from_summary(summary_path)
     curves: list[tuple[float, np.ndarray, np.ndarray]] = []
     for mjd, bn in epochs:
-        spec = _find_spectrum(bn, spec_roots)
+        spec = _find_spectrum(bn, spec_roots, gaia_id=sid)
         if spec is None:
             continue
         prof = _hbeta_profile_from_spectrum(spec, teff)
@@ -189,7 +215,9 @@ def main() -> int:
         spec_roots = [Path(env_root), summary_dir, summary_dir.parent]
 
     if args.star_id:
-        summaries = [summary_dir / f"Gaia_DR3_{args.star_id}_summary.txt"]
+        sid = str(args.star_id).strip()
+        summ = discover_summary_path(summary_dir, sid)
+        summaries = [summ] if summ is not None else []
     else:
         summaries = discover_summary_files(summary_dir)
 
@@ -206,10 +234,12 @@ def main() -> int:
         plot_dir = plots_root / f"Gaia_DR3_{sid}"
         out_png = plot_dir / f"Gaia_DR3_{sid}_28_hbeta.png"
         epochs = _epoch_rows(summ)
-        if build_overlay(epochs, summ, spec_roots, out_png):
+        if build_overlay(epochs, summ, spec_roots, out_png, gaia_id=sid):
             built += 1
+            print(f"Built Hβ overlay for Gaia_DR3_{sid} -> {out_png}")
         else:
             skipped += 1
+            print(f"[WARN] Hβ overlay skipped for Gaia_DR3_{sid} (epochs={len(epochs)}, spec_roots={spec_roots})")
     print(f"Built {built} Hβ overlay plots (skipped {skipped}).")
     return 0
 

--- a/scripts/lib/refit_one_object.sh
+++ b/scripts/lib/refit_one_object.sh
@@ -95,6 +95,14 @@ if [[ ! -f "$summ" ]]; then
   exit 1
 fi
 
+echo "=== APF observability window (single star) ==="
+"$PY" scripts/build_apf_observability_cache.py \
+  --data-csv "$DATA_CSV" \
+  --output-dir "$OUT" \
+  --cache "$REPORTS_DIR/observability_windows_cache.json" \
+  --gaia-id "$gid" \
+  || echo "[WARN] observability cache build failed for Gaia_DR3_${gid} (fit will compute inline)"
+
 fit_args=(
   fit_apf_rv_keplerian.py
   --summary "$summ"

--- a/scripts/lib/website_plot_sync.sh
+++ b/scripts/lib/website_plot_sync.sh
@@ -9,13 +9,18 @@ website_stage_gaia_plots() {
 
   run_cmd mkdir -p "$dest_dir"
   local name
+  local reports_dir="${REPORTS_DIR:-}"
   for name in \
     "Gaia_DR3_${gid}_28_hbeta.png" \
     "Gaia_DR3_${gid}_rv_plot.png" \
     "Gaia_DR3_${gid}_keplerian_residuals.png"
   do
-    if [[ -f "$src_dir/$name" ]]; then
-      run_cmd cp "$src_dir/$name" "$dest_dir/$name"
+    local src="$src_dir/$name"
+    if [[ ! -f "$src" && "$name" == "Gaia_DR3_${gid}_keplerian_residuals.png" && -n "$reports_dir" ]]; then
+      src="$reports_dir/${gid}_keplerian_residuals.png"
+    fi
+    if [[ -f "$src" ]]; then
+      run_cmd cp "$src" "$dest_dir/$name"
       n=$((n + 1))
     fi
   done

--- a/tests/test_build_hbeta_website_plots.py
+++ b/tests/test_build_hbeta_website_plots.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from scripts.build_hbeta_website_plots import _find_spectrum
+
+
+def test_find_spectrum_prefers_gaia_subdir(tmp_path: Path) -> None:
+    spec_root = tmp_path / "apf_reductions"
+    star_a = spec_root / "Gaia_DR3_111111111111111111"
+    star_b = spec_root / "Gaia_DR3_222222222222222222"
+    star_a.mkdir(parents=True)
+    star_b.mkdir(parents=True)
+    name = "Gaia_DR3_111111111111111111_epoch_1.txt"
+    (star_a / name).write_text("x")
+    (star_b / "Gaia_DR3_222222222222222222_epoch_1.txt").write_text("y")
+
+    hit = _find_spectrum(name, [spec_root], gaia_id="111111111111111111")
+    assert hit == star_a / name
+
+
+def test_find_spectrum_absolute_path(tmp_path: Path) -> None:
+    spec = tmp_path / "Gaia_DR3_1_epoch_2.txt"
+    spec.write_text("x")
+    hit = _find_spectrum(str(spec), [tmp_path], gaia_id="1")
+    assert hit == spec.resolve()
+
+
+def test_find_spectrum_skips_order_extract(tmp_path: Path) -> None:
+    spec_root = tmp_path / "apf_reductions"
+    star = spec_root / "Gaia_DR3_1"
+    star.mkdir(parents=True)
+    order_only = star / "Gaia_DR3_1_epoch_1_order_28.txt"
+    order_only.write_text("x")
+    assert _find_spectrum(order_only.name, [spec_root], gaia_id="1") is None

--- a/tests/test_fit_apf_rv_keplerian.py
+++ b/tests/test_fit_apf_rv_keplerian.py
@@ -1,5 +1,6 @@
 """Tests for fit_apf_rv_keplerian summary parsing (no network)."""
 
+import json
 from pathlib import Path
 
 import numpy as np
@@ -531,6 +532,86 @@ def test_table_m1_overrides_default_and_nss() -> None:
     assert cols_default["m2sin_i_msun"] is not None
     assert cols_table["m2sin_i_msun"] is not None
     assert cols_table["m2sin_i_msun"] != cols_default["m2sin_i_msun"]
+
+
+def test_load_gaia_nss_from_cache_returns_orbit_without_m1(tmp_path: Path) -> None:
+    sid = "77413727493690112"
+    cache = tmp_path / "gaia_nss_cache.json"
+    cache.write_text(
+        json.dumps(
+            {
+                sid: {
+                    "period_days": 1327.5,
+                    "eccentricity": 0.0,
+                }
+            }
+        )
+    )
+    out = fitmod.load_gaia_nss_from_cache(sid, cache)
+    assert out is not None
+    assert out["period_days"] == pytest.approx(1327.5)
+    assert out["eccentricity"] == pytest.approx(0.0)
+
+
+def test_run_one_uses_nss_cache_when_summary_lacks_period(tmp_path: Path) -> None:
+    sid = "77413727493690112"
+    summ = tmp_path / f"Gaia_DR3_{sid}_summary.txt"
+    summ.write_text(
+        "[GAIA METADATA]\nSource_ID: 77413727493690112\nRA: 180.0\nDec: 45.0\n"
+        "NSS_Solution_Type: None\nPeriod: NaN\nEccentricity: NaN\n"
+        "\n[PIPELINE RESULTS]\n# hdr\n"
+        + "\n".join(
+            f"Gaia_DR3_{sid}_epoch_{i}.txt {60500 + i * 30} {-10.0 + 0.5 * i} 0.5 0.4 False"
+            for i in range(12)
+        )
+        + "\n"
+    )
+    reports = tmp_path / "reports"
+    cache = tmp_path / "gaia_nss_cache.json"
+    cache.write_text(json.dumps({sid: {"period_days": 1200.0, "eccentricity": 0.0}}))
+    obs_cache = tmp_path / "observability_windows_cache.json"
+    obs_cache.write_text(
+        json.dumps(
+            {
+                sid: {
+                    "circumpolar": False,
+                    "next_window_start_date": "2026-06-01",
+                    "next_window_end_date": "2026-09-30",
+                    "windows": [
+                        {
+                            "start_date": "2026-06-01",
+                            "end_date": "2026-09-30",
+                            "start_mjd": 61000.0,
+                            "end_mjd": 61120.0,
+                        }
+                    ],
+                }
+            }
+        )
+    )
+    report = fitmod.run_one(
+        summ,
+        reports,
+        min_points=7,
+        max_points=None,
+        m1_msun=1.0,
+        period_min=None,
+        period_max=None,
+        period_prior=None,
+        period_prior_sigma=0.15,
+        fix_period=None,
+        fix_e=None,
+        use_gaia_nss=True,
+        gaia_cache_path=cache,
+        observability_cache_path=obs_cache,
+        query_gaia_online=False,
+        plots_root=tmp_path / "plots",
+        table_m1_msun=None,
+    )
+    assert report is not None
+    assert report.get("nss_priors_source") == "cache"
+    assert len(report.get("fit_variants", {})) == 4
+    assert report.get("observability_window") is not None
 
 
 def test_fix_period_seeded_from_free_fit() -> None:


### PR DESCRIPTION
## Summary

- Fix `build_hbeta_website_plots.py` spectrum lookup: prefer `Gaia_DR3_<id>/` under `SPEC_ROOT` instead of first global `rglob` match (wrong star).
- Accept absolute spectrum paths from summary rows; skip `*_order_*` extracts.
- Use `discover_summary_path` for `--star-id` (works with nested summaries).
- Restore four-fit Keplerian plots and APF observability shading on per-star refit: read NSS priors from `gaia_nss_cache.json` offline, build observability cache in `refit_one_object.sh`, compute APF window inline when cache is missing, and stage `keplerian_residuals.png` from `rv_fit_reports/` when needed.

## Ziggy (77413727493690112)

Hβ only:

```bash
cd /data2/darkhunter/dark-hunter_rv && git pull
STAR_ID=77413727493690112 bash scripts/update_hbeta_website.sh
```

Full refit + website (Hβ, four-fit curves, APF window):

```bash
cd /data2/darkhunter/dark-hunter_rv && git pull
STAR_ID=77413727493690112 FIT_FORCE=1 MIN_POINTS=5 PIPELINE_FORCE=0 \
  bash scripts/lib/refit_one_object.sh 77413727493690112
```

If NSS priors are missing from summary and cache:

```bash
PYTHONPATH=. /home/marley/anaconda2/envs/gaia-env/bin/python scripts/prefetch_gaia_nss_for_table.py \
  --reports-dir rv_fit_reports --gaia-id 77413727493690112
```

## Test plan

- [x] `pytest tests/test_build_hbeta_website_plots.py`
- [x] `pytest tests/test_fit_apf_rv_keplerian.py::test_load_gaia_nss_from_cache_returns_orbit_without_m1 tests/test_fit_apf_rv_keplerian.py::test_run_one_uses_nss_cache_when_summary_lacks_period`