### PR TITLE
Fix APF observability windows relative to today

### DIFF
--- a/darkhunter_rv/apf_observability.py
+++ b/darkhunter_rv/apf_observability.py
@@ -14,6 +14,7 @@ from astropy.time import Time
 
 from darkhunter_rv.gaia_utils import parse_gaia_metadata_from_star_summary
 from darkhunter_rv.lick_twilight_cache import (
+    LICK_TZ,
     default_cache_path as default_lick_twilight_cache_path,
     interpolate_lst_deg,
     nights_in_mjd_range,
@@ -32,6 +33,24 @@ SCAN_HORIZON_DAYS = 365
 PLOT_HORIZON_DAYS = 90
 HORIZON_DAYS = SCAN_HORIZON_DAYS
 MERGE_RUN_GAP_DAYS = 45
+
+
+def reference_now(reference_mjd: Optional[float] = None) -> Tuple[float, str]:
+    """Return (today_mjd, Lick-local calendar date) for the reference instant (now by default)."""
+    mjd = float(Time.now().mjd) if reference_mjd is None else float(reference_mjd)
+    today_iso = Time(mjd, format="mjd").to_datetime(timezone=LICK_TZ).date().isoformat()
+    return mjd, today_iso
+
+
+def lick_twilight_cache_for_observability(
+    observability_cache_path: Optional[Path] = None,
+) -> Path:
+    """Resolve Lick twilight JSON beside observability cache, else repo default."""
+    if observability_cache_path is not None:
+        sibling = observability_cache_path.parent / "lick_twilight_cache.json"
+        if sibling.is_file():
+            return sibling
+    return default_lick_twilight_cache_path()
 
 
 def _altitude_deg_for_airmass(airmass: float) -> float:
@@ -238,24 +257,27 @@ def _run_span(run: List[NightRecord]) -> Tuple[str, str, float, float]:
     )
 
 
-def _find_season_window(
+def _distance_to_run_mjd(today_mjd: float, run: List[NightRecord]) -> float:
+    """Days from today to the nearest point in an observable run (0 if today is inside)."""
+    start_mjd = run[0].evening_twilight_mjd
+    end_mjd = run[-1].morning_twilight_mjd
+    if start_mjd <= today_mjd <= end_mjd + 1.0:
+        return 0.0
+    if today_mjd < start_mjd:
+        return start_mjd - today_mjd
+    return today_mjd - end_mjd
+
+
+def _find_closest_window(
     nights: List[NightRecord],
     today_mjd: float,
 ) -> Optional[Tuple[str, str, float, float]]:
+    """Among merged observable runs, return the one closest to today."""
     runs = _merge_close_runs(_build_season_runs(nights))
     if not runs:
         return None
-
-    for run in runs:
-        start_mjd, end_mjd = run[0].evening_twilight_mjd, run[-1].morning_twilight_mjd
-        if start_mjd <= today_mjd <= end_mjd + 1.0:
-            return _run_span(run)
-
-    for run in runs:
-        if run[0].evening_twilight_mjd >= today_mjd - 1.0:
-            return _run_span(run)
-
-    return _run_span(runs[-1])
+    best = min(runs, key=lambda run: (_distance_to_run_mjd(today_mjd, run), run[0].evening_twilight_mjd))
+    return _run_span(best)
 
 
 @dataclass
@@ -283,12 +305,13 @@ def compute_apf_observability(
     lick_cache_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """
-    APF visibility season at Lick.
+    APF visibility at Lick from reference-now through +scan_horizon_days.
 
-    Nautical (-12°) twilight times and LST come from the UCO/Lick calendar cache
-    (see scripts/build_lick_twilight_cache.py). Target airmass uses HA = LST − RA.
+    Always anchored to Time.now() (Pacific calendar date at Lick) unless start_mjd
+    is passed for tests. Returns the observable run closest to reference-now.
+    Plot shading still caps at plot_horizon_days in rv_keplerian_plots.
     """
-    now_mjd = float(Time.now().mjd) if start_mjd is None else float(start_mjd)
+    now_mjd, today_iso = reference_now(start_mjd)
     plot_end_mjd = now_mjd + float(plot_horizon_days)
     scan_end_mjd = now_mjd + float(scan_horizon_days)
 
@@ -301,8 +324,9 @@ def compute_apf_observability(
             "next_window_end_date": "",
         }
 
-    nights = _sample_nights(coord, now_mjd - 2.0, scan_end_mjd, lick_cache_path=lick_cache_path)
-    season = _find_season_window(nights, now_mjd)
+    nights = _sample_nights(coord, now_mjd, scan_end_mjd, lick_cache_path=lick_cache_path)
+    nights = [n for n in nights if n.calendar_date >= today_iso]
+    season = _find_closest_window(nights, now_mjd)
 
     if season is None:
         return {"circumpolar": False, "windows": []}
@@ -321,13 +345,18 @@ def observability_for_summary(
     summary_path: Path,
     *,
     lick_cache_path: Optional[Path] = None,
+    reference_mjd: Optional[float] = None,
 ) -> Optional[Dict[str, Any]]:
     sid = parse_object_id_from_summary(summary_path)
     coord = _target_coord_from_summary(summary_path)
     if sid is None or coord is None:
         return None
     try:
-        result = compute_apf_observability(coord, lick_cache_path=lick_cache_path)
+        result = compute_apf_observability(
+            coord,
+            start_mjd=reference_mjd,
+            lick_cache_path=lick_cache_path,
+        )
     except FileNotFoundError:
         return None
     if not result.get("windows") and not result.get("circumpolar"):

--- a/fit_apf_rv_keplerian.py
+++ b/fit_apf_rv_keplerian.py
@@ -200,19 +200,20 @@ def resolve_observability_window(
     source_id: Optional[str],
     cache_path: Optional[Path],
 ) -> Optional[Dict[str, Any]]:
-    """APF shading window: cache first, then compute from summary coordinates."""
-    obs = load_observability_window(source_id, cache_path)
-    if obs is not None:
-        return obs
+    """APF shading window: always recomputed from summary coords relative to now."""
     try:
-        from darkhunter_rv.apf_observability import observability_for_summary
+        from darkhunter_rv.apf_observability import (
+            lick_twilight_cache_for_observability,
+            observability_for_summary,
+        )
 
-        row = observability_for_summary(summary_path)
-        if row is None:
-            return None
-        return {k: v for k, v in row.items() if k != "gaia_source_id"}
+        lick_cache = lick_twilight_cache_for_observability(cache_path)
+        row = observability_for_summary(summary_path, lick_cache_path=lick_cache)
+        if row is not None:
+            return {k: v for k, v in row.items() if k != "gaia_source_id"}
     except Exception:
-        return None
+        pass
+    return load_observability_window(source_id, cache_path)
 
 
 def load_observability_window(source_id: Optional[str], cache_path: Optional[Path]) -> Optional[Dict[str, Any]]:

--- a/scripts/build_apf_observability_cache.py
+++ b/scripts/build_apf_observability_cache.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Build rv_fit_reports/observability_windows_cache.json for APF visibility shading."""
+"""Build rv_fit_reports/observability_windows_cache.json for APF visibility shading.
+
+Entries are a snapshot at build time (logging / offline review). Plots and fits
+call resolve_observability_window(), which recomputes windows relative to today.
+"""
 
 from __future__ import annotations
 

--- a/tests/test_apf_observability.py
+++ b/tests/test_apf_observability.py
@@ -88,3 +88,54 @@ def test_full_year_scan_is_fast(tmp_path: Path) -> None:
         lick_cache_path=lick_cache,
     )
     assert time.perf_counter() - t0 < 2.0
+
+
+def test_forward_scan_does_not_start_before_reference_today(tmp_path: Path) -> None:
+    """Window search is [reference-today, reference-today+1y) in Lick local calendar."""
+    from astropy.time import Time
+
+    from darkhunter_rv.apf_observability import reference_now
+    from darkhunter_rv.lick_twilight_cache import build_cache_years
+
+    lick_cache = tmp_path / "lick_twilight_cache.json"
+    build_cache_years([2026], cache_path=lick_cache)
+    ref_mjd, ref_iso = reference_now(float(Time("2026-06-12").mjd))
+
+    for ra in (55.5, 120.0, 180.0, 270.0):
+        for dec in (-10.0, 20.0, 45.0, 58.0):
+            out = compute_apf_observability(
+                SkyCoord(ra=ra * u.deg, dec=dec * u.deg),
+                start_mjd=ref_mjd,
+                scan_horizon_days=365,
+                lick_cache_path=lick_cache,
+            )
+            start = out.get("next_window_start_date", "")
+            if start:
+                assert start >= ref_iso
+
+
+def test_resolve_observability_prefers_live_over_stale_cache(tmp_path: Path) -> None:
+    from astropy.time import Time
+
+    from darkhunter_rv.apf_observability import reference_now
+    from darkhunter_rv.lick_twilight_cache import build_cache_years
+    from fit_apf_rv_keplerian import resolve_observability_window
+
+    lick_cache = tmp_path / "lick_twilight_cache.json"
+    build_cache_years([2026], cache_path=lick_cache)
+    obs_cache = tmp_path / "observability_windows_cache.json"
+    obs_cache.write_text(
+        '{"999": {"circumpolar": false, "next_window_start_date": "2020-01-01", '
+        '"next_window_end_date": "2020-01-31", "windows": [{"start_date": "2020-01-01", "end_date": "2020-01-31"}]}}'
+    )
+    summ = tmp_path / "Gaia_DR3_999_summary.txt"
+    summ.write_text(
+        "[GAIA METADATA]\nSource_ID: 999\nRA: 120.0\nDec: 20.0\n\n[PIPELINE RESULTS]\n"
+    )
+    ref_mjd, ref_iso = reference_now(float(Time("2026-06-12").mjd))
+    obs = resolve_observability_window(summ, "999", obs_cache)
+    assert obs is not None
+    start = obs.get("next_window_start_date") or obs.get("windows", [{}])[0].get("start_date", "")
+    if start:
+        assert start >= ref_iso
+        assert not start.startswith("2020-")


### PR DESCRIPTION
## Summary

- Scan APF visibility **forward only** from Lick-local **today** through +1 year (fixes June 10 start-date artifact from `now − 2d` lookback).
- Pick the **closest** observable run to today (active run if today falls inside it; otherwise the nearest upcoming season).
- **`resolve_observability_window()`** recomputes from summary coordinates on every fit/replot; JSON cache is fallback only (no frozen build-time dates on plots).
- `observability_windows_cache.json` remains a build-time snapshot for logging; shading uses live `Time.now()`.

Plot axis logic in `rv_keplerian_plots.py` is unchanged (blue shading still capped at now + 90 days).

## Test plan

- [x] `PYTHONPATH=. python -m pytest tests/test_apf_observability.py tests/test_observability_table_compare.py`
- [ ] On ziggy after merge: replot RV figures (`resolve_observability_window` in replot script); confirm windows no longer cluster on 2026-06-10


Made with [Cursor](https://cursor.com)